### PR TITLE
fixed a bug causing the model command to fail on methods that are not re...

### DIFF
--- a/src/Barryvdh/LaravelIdeHelper/ModelsCommand.php
+++ b/src/Barryvdh/LaravelIdeHelper/ModelsCommand.php
@@ -199,15 +199,19 @@ class ModelsCommand extends Command {
                    $code = substr($code, $begin, strrpos($code, '}') - $begin + 1);
 
                    $begin = stripos($code, 'return $this->');
-                   list($relation, $returnModel, $rest) = explode("'", substr($code, $begin+14),3);  //"return $this->" is 14 chars
-                   $relation = trim($relation, ' (');
-
-                   if($relation === "belongsTo" or $relation === 'hasOne'){
-                       //Single model is returned
-                       $this->setProperty($method, $returnModel, true, null);
-                   }elseif($relation === "belongsToMany" or $relation === 'hasMany'){
-                       //Collection or array of models (because Collection is Arrayable)
-                       $this->setProperty($method,  '\Illuminate\Database\Eloquent\Collection|'.$returnModel.'[]', true, null);
+                   $parts = explode("'", substr($code, $begin+14),3);  //"return $this->" is 14 chars
+                   if (isset($parts[2]))
+                   {
+                       list($relation, $returnModel, $rest) = $parts;
+                       $relation = trim($relation, ' (');
+    
+                       if($relation === "belongsTo" or $relation === 'hasOne'){
+                           //Single model is returned
+                           $this->setProperty($method, $returnModel, true, null);
+                       }elseif($relation === "belongsToMany" or $relation === 'hasMany'){
+                           //Collection or array of models (because Collection is Arrayable)
+                           $this->setProperty($method,  '\Illuminate\Database\Eloquent\Collection|'.$returnModel.'[]', true, null);
+                       }
                    }else{
                        //Not a relation
                    }


### PR DESCRIPTION
I have the following method in one of my models:

```
    /**
     * Returns the display name for this BID.
     *
     * @return string
     */
    public function displayName()
    {
        return $this->name.$this->band->tag;
    }
```

This was causing the following error when running the `:models` command:

```
{"error":{"type":"ErrorException","message":"Undefined offset: 2","file":"\/home\/andrew\/Developer\/LiquidCompass\/BuildTools\/development\/Sites\/apinew\/vendor\/barryvdh\/laravel-ide-helper\/src\/Barryvdh\/LaravelIdeHelper\/ModelsCommand.php","line":203}}
```

This code change fixes this bug and I have a successful model helper built.
