### PR TITLE
Fixed bug with several extra roots in extra classes

### DIFF
--- a/src/Barryvdh/LaravelIdeHelper/GeneratorCommand.php
+++ b/src/Barryvdh/LaravelIdeHelper/GeneratorCommand.php
@@ -184,8 +184,8 @@ namespace {\n\tdie('Only to be used as an helper for your IDE');\n}\n\n";
                     }
 
                     if(array_key_exists($alias, $extra)){
+                        $i = 2;
                         foreach($extra[$alias] as $extraClass){
-                            $i =2;
                             if(!class_exists($extraClass) && !interface_exists($extraClass)){
                                 continue;
                             }


### PR DESCRIPTION
The variable is assigned the value of "2" on each iteration in the foreach loop. This results in all roots being root2.

Signed-off-by: Daniel Bondergaard danielboendergaard@gmail.com
