### PR TITLE
Added cache repository to extra classes

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -53,7 +53,7 @@ return array(
 
     'extra' => array(
         'Auth'      => array('Illuminate\Auth\Guard'),
-        'Cache'     => array('Illuminate\Cache\StoreInterface'),
+        'Cache'     => array('Illuminate\Cache\StoreInterface', 'Illuminate\Cache\Repository'),
         'DB'        => array('Illuminate\Database\Connection'),
         'Eloquent'  => array('Illuminate\Database\Query\Builder'),
         'Queue'     => array('Illuminate\Queue\QueueInterface'),


### PR DESCRIPTION
This will add the following function to autocomplete:

``` php
Cache::add
Cache::remember
Cache::sear
Cache::rememberForever
```

and a few others, but these are the important ones :)

This requires #13 to work.

Signed-off-by: Daniel Bondergaard danielboendergaard@gmail.com
