### PR TITLE
Use camel case for model scope generation

### DIFF
--- a/src/Barryvdh/LaravelIdeHelper/ModelsCommand.php
+++ b/src/Barryvdh/LaravelIdeHelper/ModelsCommand.php
@@ -232,7 +232,7 @@ class ModelsCommand extends Command {
                    }
                }elseif(\Str::startsWith($method, 'scope') && $method !== 'scopeQuery'){
                    //Magic set<name>Attribute
-                   $name =  \Str::snake(substr($method, 5));
+                   $name =  \Str::camel(substr($method, 5));
                    if(!empty($name)){
                        $reflection = new \ReflectionMethod($model, $method);
                        $args = $this->getParameters($reflection);


### PR DESCRIPTION
In L4, scope functions only work with camel case (http://four.laravel.com/docs/eloquent#query-scopes)
