### PR TITLE
Include return value when generating scope methods

### DIFF
--- a/src/Barryvdh/LaravelIdeHelper/ModelsCommand.php
+++ b/src/Barryvdh/LaravelIdeHelper/ModelsCommand.php
@@ -238,7 +238,7 @@ class ModelsCommand extends Command {
                        $args = $this->getParameters($reflection);
                        //Remove the first ($query) argument
                        array_shift($args);
-                       $this->setMethod($name, 'static', $args);
+                       $this->setMethod($name, "static " . $reflection->class, $args);
                    }
                }elseif(!method_exists('Eloquent', $method) && !\Str::startsWith($method, 'get')){
 


### PR DESCRIPTION
It's handy to specify return values in phpDoc comments. This patch sets the return value to the containing class.
