### PR TITLE
Removing \r from generator in order to prevent ^M from being inserted in...

### DIFF
--- a/src/Barryvdh/LaravelIdeHelper/GeneratorCommand.php
+++ b/src/Barryvdh/LaravelIdeHelper/GeneratorCommand.php
@@ -361,7 +361,7 @@ exit('Only to be used as an helper for your IDE');\n\n";
         $output .= $serializer->getDocComment($phpdoc) ."\n\t public static function ".$methodName."(";
 
         $output .= implode($paramsWithDefault, ", ");
-        $output .= "){\r\n";
+        $output .= "){\n";
 
         //Only return when not a constructor and not void.
         $return = ($returnValue && $returnValue !== "void" && $method->name !== "__construct") ? 'return' : '';
@@ -371,13 +371,13 @@ exit('Only to be used as an helper for your IDE');\n\n";
         $root = $class->getName();
 
         if($declaringClass->name != $root){
-            $output .= "\t\t//Method inherited from $declaringClass->name\r\n";
+            $output .= "\t\t//Method inherited from $declaringClass->name\n";
         }
 
         $output .=  "\t\t$return $root::";
 
         //Write the default parameters in the function call
-        $output .=  $method->name."(".implode($params, ", ").");\r\n";
+        $output .=  $method->name."(".implode($params, ", ").");\n";
         $output .= "\t }\n\n";
 
         return $output;


### PR DESCRIPTION
Each time I run php artisan ide-helper:generate ^M is inserted to the ending of several lines.  

Each function in _ide_helper.php looks like this:

```
public static function __construct($request = null){^M
                 Illuminate\Foundation\Application::__construct($request);^M
         }

        /**
         * Set the application request for the console environment.
         *
         * @return void
         * @static
         */
         public static function setRequestForConsoleEnvironment(){^M
                 Illuminate\Foundation\Application::setRequestForConsoleEnvironment();^M
         }
```

I've verified the same thing happens with several other people.  Each person I verified is running the command on an Ubuntu machine and for each person this pull request resolves the issue.
