### PR TITLE
"An Eloquent Model:" is not necessary, removed it.

### DIFF
--- a/src/Barryvdh/LaravelIdeHelper/ModelsCommand.php
+++ b/src/Barryvdh/LaravelIdeHelper/ModelsCommand.php
@@ -359,7 +359,7 @@ class ModelsCommand extends Command {
         }
 
         if(!$phpdoc->getText()){
-            $phpdoc->setText("An Eloquent Model: '$class'");
+            $phpdoc->setText($class);
         }
 
         $properties = array();


### PR DESCRIPTION
Not needind it since that information is gathered by IDE\* with class definition.

`class MyClass extends Eloquent {`

*:(almost all ide will, I guess)
