### PR TITLE
remove static keyword from magic methods' docs

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -444,7 +444,7 @@ class ModelsCommand extends Command
                 continue;
             }
             $arguments = implode(', ', $method['arguments']);
-            $tag = Tag::createInstance("@method static {$method['type']} {$name}({$arguments}) ", $phpdoc);
+            $tag = Tag::createInstance("@method {$method['type']} {$name}({$arguments}) ", $phpdoc);
             $phpdoc->appendTag($tag);
         }
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -444,7 +444,8 @@ class ModelsCommand extends Command
                 continue;
             }
             $arguments = implode(', ', $method['arguments']);
-            $tag = Tag::createInstance("@method {$method['type']} {$name}({$arguments}) ", $phpdoc);
+            $static = (\Config::get('laravel-ide-helper::models-magic-static')) ? " static" : "";
+            $tag = Tag::createInstance("@method{$static} {$method['type']} {$name}({$arguments}) ", $phpdoc);
             $phpdoc->appendTag($tag);
         }
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -43,7 +43,16 @@ return array(
     'model_locations' => array(
         'app/models',
     ),
-
+    
+    /*
+      |--------------------------------------------------------------------------
+      | Static keyword for dynamic methods
+      |--------------------------------------------------------------------------
+      |
+      | Define whether the magically documented methods of the model classes should contain the static keyword.
+      |
+     */
+    'models-magic-static' => true,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
I am not sure whether my problem is actually related to #105, but the static keyword in ModelsCommand::createPhpDocs in line 422 is wrong in my opinion. The generated models file is only working without this keyword.