### PR TITLE
Removed space after "@method static ..."

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -444,7 +444,7 @@ class ModelsCommand extends Command
                 continue;
             }
             $arguments = implode(', ', $method['arguments']);
-            $tag = Tag::createInstance("@method static {$method['type']} {$name}({$arguments}) ", $phpdoc);
+            $tag = Tag::createInstance("@method static {$method['type']} {$name}({$arguments})", $phpdoc);
             $phpdoc->appendTag($tag);
         }
 


### PR DESCRIPTION
According to PSR-2, "there MUST NOT be trailing whitespace at the end of non-blank lines" (http://www.php-fig.org/psr/psr-2/). My IDE is checking for this, and I always have to remove the spaces manually...  ;-)
