### PR TITLE
Fix for functions with variadic arguments

### DIFF
--- a/src/Method.php
+++ b/src/Method.php
@@ -261,7 +261,7 @@ class Method
             $paramStr = '$' . $param->getName();
             $params[] = $paramStr;
             if ($param->isOptional()) {
-                $default = $param->getDefaultValue();
+                $default = $param->isDefaultValueAvailable() ? $param->getDefaultValue() : null;
                 if (is_bool($default)) {
                     $default = $default ? 'true' : 'false';
                 } elseif (is_array($default)) {


### PR DESCRIPTION
The `php artisan ide-helper:generate` command fails with the following error for functions with variadic arguments:

```
[ReflectionException]                                 
Internal error: Failed to retrieve the default value
```
