### PR TITLE
Class with same name already defined in this file

### DIFF
--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -100,7 +100,9 @@ class GeneratorCommand extends Command
             if ($this->option('helpers') || ($this->config->get('laravel-ide-helper::include_helpers'))) {
                 foreach ($this->config->get('laravel-ide-helper::helper_files', array()) as $helper) {
                     if (file_exists($helper)) {
-                        $helpers .= str_replace(array('<?php', '?>'), '', $this->files->get($helper));
+                        $helper_contents = str_replace(array('<?php', '?>'), '', $this->files->get($helper));
+                        $helper_contents = preg_replace("/use ([\w\\\\])+;/", '', $helper_contents);
+                        $helpers .= $helper_contents;
                     }
                 }
             } else {


### PR DESCRIPTION
I'd got this error when I included helper files to my _ide_helper due to PHP imports in these files.
In particular I'd got the error with Str class, which is being imported in Laravel's helpers and then also being declared later by IDE Helper's generator.
I suggest trying to remove those imports with preg_replace. Maybe there is a better solution for this or the issue is not worth it.