### PR TITLE
Allow excluding directories from the model search with sensible defaults

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -47,6 +47,7 @@ class ModelsCommand extends Command
     protected $methods = array();
     protected $write = false;
     protected $dirs = array();
+    protected $ignoredDirectories = array();
     protected $reset;
 
 
@@ -63,6 +64,8 @@ class ModelsCommand extends Command
             $this->laravel['config']->get('laravel-ide-helper::model_locations'),
             $this->option('dir')
         );
+
+        $this->ignoredDirectories = $this->laravel['config']->get('laravel-ide-helper::ignored_directories');
         $model = $this->argument('model');
         $ignore = $this->option('ignore');
         $this->reset = $this->option('reset');
@@ -201,7 +204,16 @@ class ModelsCommand extends Command
             $dir = base_path() . '/' . $dir;
             if (file_exists($dir)) {
                 foreach (ClassMapGenerator::createMap($dir) as $model => $path) {
-                    $models[] = $model;
+                    $addModel = true;
+                    $relativePath = str_replace(base_path() . '/', '', $path);
+                    foreach($this->ignoredDirectories as $toIgnore){
+                        if (0 === strpos($relativePath, $toIgnore)) {
+                            $addModel = false;
+                        }
+                    }
+                    if($addModel){
+                        $models[] = $model;
+                    }
                 }
             }
         }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -44,6 +44,22 @@ return array(
         'app/models',
     ),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Model locations to exclude
+    |--------------------------------------------------------------------------
+    |
+    | Define in which directories the ide-helper:models command should exclude
+    | when looking for models - recursive.
+    |
+    */
+
+    'ignored_directories' => array(
+        'app/Console',
+        'app/Exceptions',
+        'app/Http',
+        'app/Providers'
+    ),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
In L5 (this is also backwards compatible/non-breaking with L4) your models now live in the base app directory - 
You also have a bunch of other directories at the same level that do not contain models Console, Exception, Http etc - 

These generate a lot of "xxx is not a model" message, this requests allows you to set paths relative to the base url (the same as model_locations) that classes found will not be added to the models array.

This is recursive so excluding app/Console will exclude app/Console/Commands etc.
