### PR TITLE
Model doc : create model using App::make($name)

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -168,7 +168,7 @@ class ModelsCommand extends Command
                         throw new \Exception($name . ' is not instanciable.');
                     }
 
-                    $model = new $name();
+                    $model = \App::make($name);
                     if ($hasDoctrine) {
                         $this->getPropertiesFromTable($model);
                     }


### PR DESCRIPTION
trying to generate doc for a model with dependencies in constructor will fail with `new $name` .
Now it works using `\App:make($name)` laravel IOC resolves the dependencies.