### PR TITLE
Fix typo in ModelsCommand.php . Fixes #141

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -165,7 +165,7 @@ class ModelsCommand extends Command
                     $this->comment("Loading model '$name'");
 
                     if (!$reflectionClass->IsInstantiable()) {
-                        throw new \Exception($name . ' is not instanciable.');
+                        throw new \Exception($name . ' is not instantiable.');
                     }
 
                     $model = new $name();


### PR DESCRIPTION
Changed the exception message text on line 168 in ModelsCommand.php from ' is not instanciable.' to ' is not instantiable.'
