### PR TITLE
Fixed class name resolution via get_class() and static::class.

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -331,9 +331,9 @@ class ModelsCommand extends Command
                         $search = '$this->' . $relation . '(';
                         if ($pos = stripos($code, $search)) {
                             $code = substr($code, $pos + strlen($search));
-                            $arguments = explode(',', substr($code, 0, stripos($code, ')')));
+                            $arguments = explode(',', substr($code, 0, strpos($code, ');')));
                             //Remove quotes, ensure 1 \ in front of the model
-                            $returnModel = $this->getClassName($arguments[0]);
+                            $returnModel = $this->getClassName($arguments[0], $model);
                             if ($relation === "belongsToMany" or $relation === 'hasMany' or $relation === 'morphMany' or $relation === 'morphToMany') {
                                 //Collection or array of models (because Collection is Arrayable)
                                 $this->setProperty(
@@ -507,9 +507,19 @@ class ModelsCommand extends Command
         return $paramsWithDefault;
     }
 
-    private function getClassName($className)
+    /**
+     * @param string $className
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @return string
+     */
+    private function getClassName($className, $model)
     {
-        // If the class name was resovled via ::class (PHP 5.5+)
+        // If the class name was resolved via get_class($this) or static::class
+        if(strpos($className, 'get_class($this)') !== false || strpos($className, 'static::class') !== false) {
+            return get_class($model);
+        }
+
+        // If the class name was resolved via ::class (PHP 5.5+)
         if(strpos($className, '::class') !== false) {
             $end = -1 * strlen('::class');
             return substr($className, 0, $end);


### PR DESCRIPTION
Hi Barry.

My Base Model has some of relations:
```php
	/**
     * Relation to the parent.
     *
     * @return BelongsTo
     */
    public function parent()
    {
        return $this->belongsTo(static::class, static::PARENT_ID);
    }

    /**
     * Relation to children.
     *
     * @return HasMany
     */
    public function children()
    {
        return $this->hasMany(get_class($this), static::PARENT_ID);
    }
```

It is incorrect result of `./artisan ide-helper:models -W` command
```php
/**
 * ModelName
 *
 * @property-read static $parent
 * @property-read \Illuminate\Database\Eloquent\Collection|\get_class($this)[] $children
 */
```
And it is expected result
```php
/**
 * ModelName
 *
 * @property-read ModelName $parent
 * @property-read \Illuminate\Database\Eloquent\Collection|ModelName[] $children
 */
```

The attached patch fix this.