### PR TITLE
Check for driver method on Auth facade

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -114,7 +114,7 @@ class Generator
     protected function detectDrivers()
     {
         try{
-            if (class_exists('Auth')) {
+            if (class_exists('Auth') && method_exists('Auth', 'driver')) {
                 $class = get_class(\Auth::driver());
                 $this->extra['Auth'] = array($class);
                 $this->interfaces['\Illuminate\Auth\UserProviderInterface'] = $class;


### PR DESCRIPTION
[October CMS](http://octobercms.com/) built on laravel includes an Auth facade in its [RainLab.User](https://github.com/rainlab/user-plugin) plugin but the resolved class doesn't contain a *driver()* method - so `php artisan ide-helper:generate` gives a nasty error during execution. This PR checks for the existance of the method before attempting to use it.

Ideally I'd like to see your other if statements in this method include the same check, but for the moment this is the only one erroring so I only updated that line.