### PR TITLE
Add support for October CMS config

### DIFF
--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -59,7 +59,7 @@ class GeneratorCommand extends Command
      * @param \Illuminate\View\Factory $view
      */
     public function __construct(
-        ConfigRepository $config,
+        /*ConfigRepository */ $config,
         Filesystem $files, /* Illuminate\View\Factory */
         $view
     ) {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -36,7 +36,7 @@ class Generator
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @param string $helpers
      */
-    public function __construct(ConfigRepository $config,
+    public function __construct(/*ConfigRepository */ $config,
         /* Illuminate\View\Factory */ $view,
         OutputInterface $output = null,
         $helpers = ''


### PR DESCRIPTION
Super frustratingly, October CMS RC uses `October\Rain\Config\Repository` instead of `Illuminate\Config\Repository` so your package is incompatible with it. Removing the typehints in the same way you've already done with your `$view` constructor argument fixes this problem and generators work fine again.