### PR TITLE
Authenticatable Contract for User model

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -83,7 +83,7 @@ return array(
     */
     
     'interfaces' => array(
-        '\Illuminate\Auth\UserInterface' => config('auth.model', 'User'),
+        '\Illuminate\Contracts\Auth\Authenticatable' => config('auth.model', 'App\User'),
     )
 
 );


### PR DESCRIPTION
Hi Barry,

I have updated config so that it will map `Authenticatable` contract rather than `UserInterface` for the `App\User` model by default.

Thanks,
Matt