### PR TITLE
Custom database types support for L4 branch

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -217,7 +217,14 @@ class ModelsCommand extends Command
     {
         $table = $model->getConnection()->getTablePrefix() . $model->getTable();
         $schema = $model->getConnection()->getDoctrineSchemaManager($table);
-        $schema->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+
+        $databasePlatform = $schema->getDatabasePlatform();
+        $databasePlatform->registerDoctrineTypeMapping('enum', 'string');
+        $platformName = $databasePlatform->getName();
+        $customTypes = $this->laravel['config']->get("ide-helper.custom_db_types.{$platformName}", array());
+        foreach ($customTypes as $yourTypeName => $doctrineTypeName) {
+            $databasePlatform->registerDoctrineTypeMapping($yourTypeName, $doctrineTypeName);
+        }
 
         $columns = $schema->listTableColumns($table);
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -221,7 +221,7 @@ class ModelsCommand extends Command
         $databasePlatform = $schema->getDatabasePlatform();
         $databasePlatform->registerDoctrineTypeMapping('enum', 'string');
         $platformName = $databasePlatform->getName();
-        $customTypes = $this->laravel['config']->get("ide-helper.custom_db_types.{$platformName}", array());
+        $customTypes = $this->laravel['config']->get("laravel-ide-helper::custom_db_types.{$platformName}", array());
         foreach ($customTypes as $yourTypeName => $doctrineTypeName) {
             $databasePlatform->registerDoctrineTypeMapping($yourTypeName, $doctrineTypeName);
         }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -87,6 +87,34 @@ return array(
     
     'interfaces' => array(
         '\Illuminate\Auth\UserInterface' => Config::get('auth.model', 'User'),
-    )
+    ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Support for custom DB types
+    |--------------------------------------------------------------------------
+    |
+    | This setting allow you to map any custom database type (that you may have
+    | created using CREATE TYPE statement or imported using database plugin
+    | / extension to a Doctrine type.
+    |
+    | Each key in this array is a name of the Doctrine2 DBAL Platform. Currently valid names are:
+    | 'postgresql', 'db2', 'drizzle', 'mysql', 'oracle', 'sqlanywhere', 'sqlite', 'mssql'
+    |
+    | This name is returned by getName() method of the specific Doctrine/DBAL/Platforms/AbstractPlatform descendant
+    |
+    | The value of the array is an array of type mappings. Key is the name of the custom type,
+    | (for example, "jsonb" from Postgres 9.4) and the value is the name of the corresponding Doctrine2 type (in
+    | our case it is 'json_array'. Doctrine types are listed here:
+    | http://doctrine-dbal.readthedocs.org/en/latest/reference/types.html
+    |
+    | So to support jsonb in your models when working with Postgres, just add the following entry to the array below:
+    |
+    | "postgresql" => array(
+    |       "jsonb" => "json_array",
+    |  ),
+    |
+    */
+    'custom_db_types' => array(),
 
 );


### PR DESCRIPTION
This adds an ability to have custom database types in your database and still have `ide-helper:models` generate correct documentation for them. 

For example, I extensively work with PostgreSQL `jsonb`, `array` and `point` types which are currently not mapped to a valid Doctrine type. This makes ide-helper skip the model entirely. With this PR you can just add the following to your ide-helper config file and have your models documentation generated just fine.

```php
    'custom_db_types' => array(
        'postgresql' => array(
            'citext' => 'text',
            'jsonb' => 'string',
            'point' => 'text',
            'array' => 'text',
            '_int4' => 'string',
        )
    ),
```

`jsonb` is mapped to a string for me (but you can have it mapped to array using `'json_array'` instead of `'string'`. `'_int4'` is used as an internal type for `ARRAY[INT]` so I mapped it to `'string'` also (but, of course you can have it mapped to array using `'array'` instead of `'string'` if you like.

If you are using different databases, you can map types differently with this PR.