### PR TITLE
Support for using namespaced models in relations (L4)

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -532,7 +532,7 @@ class ModelsCommand extends Command
             // If we need to resolve class namespace name
             if ($normalizedClassName[0] !== "\\") {
                 $namespaceName = (new \ReflectionClass($model))->getNamespaceName();
-                return "\\" . $namespaceName . "\\" . $normalizedClassName;
+                return empty($namespaceName) ? "\\$normalizedClassName" : "\\$namespaceName\\$normalizedClassName";
             } else {
                 return $normalizedClassName;
             }

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -512,8 +512,9 @@ class ModelsCommand extends Command
     }
 
     /**
-     * @param string $className
+     * @param string                              $className
      * @param \Illuminate\Database\Eloquent\Model $model
+     *
      * @return string
      */
     private function getClassName($className, $model)
@@ -526,9 +527,17 @@ class ModelsCommand extends Command
         // If the class name was resolved via ::class (PHP 5.5+)
         if (strpos($className, '::class') !== false) {
             $end = -1 * strlen('::class');
-            return substr($className, 0, $end);
+            $normalizedClassName = substr($className, 0, $end);
+
+            // If we need to resolve class namespace name
+            if ($normalizedClassName[0] !== "\\") {
+                $namespaceName = (new \ReflectionClass($model))->getNamespaceName();
+                return "\\" . $namespaceName . "\\" . $normalizedClassName;
+            } else {
+                return $normalizedClassName;
+            }
         }
 
-        return "\\" . ltrim(trim($className, " \"'"), "\\") ;
+        return "\\" . ltrim(trim($className, " \"'"), "\\");
     }
 }


### PR DESCRIPTION
I'm using relations like this:

```php
    public function contractor()
    {
        return $this->belongsTo(User::class);
    }
```

But my `User` model is inside `FH\Stock\Model` namespace. Previously, `ide-helper` incorrectly formed docblock placing my model into root namespace. This patch fixes this.