### PR TITLE
Support for using namespaced models in relations (L5)

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -512,8 +512,9 @@ class ModelsCommand extends Command
     }
 
     /**
-     * @param string $className
+     * @param string                              $className
      * @param \Illuminate\Database\Eloquent\Model $model
+     *
      * @return string
      */
     private function getClassName($className, $model)
@@ -526,9 +527,17 @@ class ModelsCommand extends Command
         // If the class name was resolved via ::class (PHP 5.5+)
         if (strpos($className, '::class') !== false) {
             $end = -1 * strlen('::class');
-            return substr($className, 0, $end);
+            $normalizedClassName = substr($className, 0, $end);
+
+            // If we need to resolve class namespace name
+            if ($normalizedClassName[0] !== "\\") {
+                $namespaceName = (new \ReflectionClass($model))->getNamespaceName();
+                return "\\" . $namespaceName . "\\" . $normalizedClassName;
+            } else {
+                return $normalizedClassName;
+            }
         }
 
-        return "\\" . ltrim(trim($className, " \"'"), "\\") ;
+        return "\\" . ltrim(trim($className, " \"'"), "\\");
     }
 }

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -357,20 +357,20 @@ class ModelsCommand extends Command
     }
 
     /**
-     * @param string $name
+     * @param string      $name
      * @param string|null $type
-     * @param bool|null $read
-     * @param bool|null $write
+     * @param bool|null   $read
+     * @param bool|null   $write
      * @param string|null $comment
      */
-    protected function setProperty($name, $type = null, $read = null, $write = null, $comment='')
+    protected function setProperty($name, $type = null, $read = null, $write = null, $comment = '')
     {
         if (!isset($this->properties[$name])) {
             $this->properties[$name] = array();
             $this->properties[$name]['type'] = 'mixed';
             $this->properties[$name]['read'] = false;
             $this->properties[$name]['write'] = false;
-            $this->properties[$name]['comment'] = (string) $comment;
+            $this->properties[$name]['comment'] = (string)$comment;
         }
         if ($type !== null) {
             $this->properties[$name]['type'] = $type;
@@ -394,6 +394,7 @@ class ModelsCommand extends Command
 
     /**
      * @param string $class
+     *
      * @return string
      */
     protected function createPhpDocs($class)
@@ -481,6 +482,7 @@ class ModelsCommand extends Command
      * Get the parameters and format them correctly
      *
      * @param $method
+     *
      * @return array
      */
     public function getParameters($method)
@@ -532,7 +534,7 @@ class ModelsCommand extends Command
             // If we need to resolve class namespace name
             if ($normalizedClassName[0] !== "\\") {
                 $namespaceName = (new \ReflectionClass($model))->getNamespaceName();
-                return "\\" . $namespaceName . "\\" . $normalizedClassName;
+                return empty($namespaceName) ? "\\$normalizedClassName" : "\\$namespaceName\\$normalizedClassName";
             } else {
                 return $normalizedClassName;
             }


### PR DESCRIPTION
I'm using relations like this:

``` php
    public function contractor()
    {
        return $this->belongsTo(User::class);
    }
```

But my `User` model is inside `FH\Stock\Model` namespace. Previously, `ide-helper` incorrectly formed docblock placing my model into root namespace. This patch fixes this.
