### PR TITLE
Add Query\Builder return type to magic scope* methods

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -303,7 +303,7 @@ class ModelsCommand extends Command
                         $args = $this->getParameters($reflection);
                         //Remove the first ($query) argument
                         array_shift($args);
-                        $this->setMethod($name, '\\' . $reflection->class, $args);
+                        $this->setMethod($name, '\Illuminate\Database\Query\Builder|\\' . $reflection->class, $args);
                     }
                 } elseif (!method_exists('Eloquent', $method) && !Str::startsWith($method, 'get')) {
 


### PR DESCRIPTION
It's needed for chain calls like 
`Model::popular()->orderBy('id','desc') /* popular() here is scopePopular() in model class */`