### PR TITLE
Eloquent mixin

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -43,6 +43,19 @@ return array(
     'model_locations' => array(
         'app',
     ),
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Model options
+    |--------------------------------------------------------------------------
+    |
+    | Define additional options for model docblock generation
+    |
+    */
+    
+    'model_options' => array(
+        'include_eloquent_mixin'=>true
+    ),
 
 
     /*

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -416,12 +416,15 @@ class ModelsCommand extends Command
 
         $properties = array();
         $methods = array();
+        $mixins = array();
         foreach ($phpdoc->getTags() as $tag) {
             $name = $tag->getName();
             if ($name == "property" || $name == "property-read" || $name == "property-write") {
                 $properties[] = $tag->getVariableName();
             } elseif ($name == "method") {
                 $methods[] = $tag->getMethodName();
+            } elseif($name == "mixin"){
+                $mixins[] = $tag->getContent();
             }
         }
 
@@ -448,6 +451,13 @@ class ModelsCommand extends Command
             $arguments = implode(', ', $method['arguments']);
             $tag = Tag::createInstance("@method static {$method['type']} {$name}({$arguments})", $phpdoc);
             $phpdoc->appendTag($tag);
+        }
+        
+        if( $this->laravel['config']->get('ide-helper.model_options.include_eloquent_mixin') ){
+            if( $reflection->isSubclassOf('\Illuminate\Database\Eloquent\Model') && !in_array('\Eloquent',$mixins) ) {
+                $tag = Tag::createInstance('@mixin \Eloquent', $phpdoc);
+                $phpdoc->appendTag($tag);
+            }
         }
 
         $serializer = new DocBlockSerializer();


### PR DESCRIPTION
Option to add ```@mixin \Eloquent``` to model doc block if the model extends from Illuminate\Database\Eloquent\Model.