### PR TITLE
Added functionality for platform specific datatypes

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -84,6 +84,22 @@ return array(
     
     'interfaces' => array(
         '\Illuminate\Contracts\Auth\Authenticatable' => config('auth.model', 'App\User'),
+    ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Platform specific datatype mappings
+    |--------------------------------------------------------------------------
+    |
+    | These mappings will translate specific database types to php datatypes. The
+    | platform names are from the \Doctrine\DBAL library.
+    |
+    */
+
+    'datatype_mappings' => array(
+        'postgresql' => array(
+            'json' => 'string'
+        )
     )
 
 );

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -219,6 +219,15 @@ class ModelsCommand extends Command
         $schema = $model->getConnection()->getDoctrineSchemaManager($table);
         $schema->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
 
+        // Register platform specific dataTypes
+        $platform_name = $schema->getDatabasePlatform()->getName();
+        $datatype_mappings = $this->laravel['config']->get('ide-helper.datatype_mappings');
+        if(array_key_exists($platform_name, $datatype_mappings)){
+            foreach($datatype_mappings[$platform_name] as $datatype => $mapping){
+                $schema->getDatabasePlatform()->registerDoctrineTypeMapping($datatype, $mapping);
+            }
+        }
+
         $columns = $schema->listTableColumns($table);
 
         if ($columns) {


### PR DESCRIPTION
I've been using ide-helper for a while with MySQL databases. But i switched to PostgreSQL for a recent project. However ide-helper didn't support all datatypes from PosgreSQL. This addition is aimed at creating better support for other database platforms. 

The config has an array with platform from \Doctrine\DBAL and the mappings are specified like a key value pair. 

I included the JSON mapping for PostgreSQL as example. However this needs to be extended to included more types. 