### PR TITLE
add bin in composer

### DIFF
--- a/bin/ide-helper
+++ b/bin/ide-helper
@@ -1,0 +1,67 @@
+#!/usr/bin/env php
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Register The Auto Loader
+|--------------------------------------------------------------------------
+|
+| Composer provides a convenient, automatically generated class loader
+| for our application. We just need to utilize it! We'll require it
+| into the script here so that we do not have to worry about the
+| loading of any our classes "manually". Feels great to relax.
+|
+*/
+
+$basePath = '.';
+
+if (!is_dir($basePath.'/bootstrap')) {
+    exit("Please run the command in your root directory of your project.\n");
+}
+
+require $basePath.'/bootstrap/autoload.php';
+
+$app = require_once $basePath.'/bootstrap/app.php';
+
+$app['events']->listen('bootstrapped: *', function ($app) {
+    if (!$app->getProvider(Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class)
+        && $app->bound('config')
+        && $app->bound('files')
+        && $app->bound('view')
+    ) {
+        $app->register(Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
+    }
+});
+/*
+|--------------------------------------------------------------------------
+| Run The Artisan Application
+|--------------------------------------------------------------------------
+|
+| When we run the console application, the current CLI command will be
+| executed in this console and the response sent back to a terminal
+| or another output device for the developers. Here goes nothing!
+|
+*/
+
+$kernel = $app->make('Illuminate\Contracts\Console\Kernel');
+
+$status = $kernel->handle(
+    $input = new Symfony\Component\Console\Input\ArgvInput,
+    new Symfony\Component\Console\Output\ConsoleOutput
+);
+
+
+/*
+|--------------------------------------------------------------------------
+| Shutdown The Application
+|--------------------------------------------------------------------------
+|
+| Once Artisan has finished running. We will fire off the shutdown events
+| so that any final work may be done by the application before we shut
+| down the process. This is the last thing to happen to the request.
+|
+*/
+
+$kernel->terminate($input, $status);
+
+exit($status);

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
     "require-dev": {
         "doctrine/dbal": "~2.3"
     },
+    "bin": [
+        "bin/ide-helper"
+    ],
     "suggest": {
         "doctrine/dbal": "Load information from the database about models for phpdocs (~2.3)"
     },


### PR DESCRIPTION
Currently, we have to add the ide-helper service provider to the `providers` array in `config/app.php` to use ide-helper. With this patch, there is no need to do it. You can use it like these:

```
./vendor/bin/ide-helper ide-helper:generate
```
