### PR TITLE
Fix vendor:publish provider name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ You can configure your composer.json to do this after each commit:
 
 You can also publish the config file to change implementations (ie. interface to specific class) or set defaults for `--helpers` or `--sublime`.
 
-    php artisan vendor:publish --provider=barryvdh/laravel-ide-helper --tag=config
+    php artisan vendor:publish --provider="Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider" --tag=config
 
 The generator tries to identify the real class, but if it cannot be found, you can define it in the config file.
 


### PR DESCRIPTION
Before

```bash
$ php artisan vendor:publish --provider=barryvdh/laravel-ide-helper --tag=config
Nothing to publish for tag [config].
```

After

```bash
$ php artisan vendor:publish --provider="Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider" --tag=config
Publishing complete for tag [config]!
```