### PR TITLE
fix model docBlocks duplicates

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -181,6 +181,7 @@ class ModelsCommand extends Command
 
                     $this->getPropertiesFromMethods($model);
                     $output .= $this->createPhpDocs($name);
+                    $ignore[] = $name;
                 } catch (\Exception $e) {
                     $this->error("Exception: " . $e->getMessage() . "\nCould not analyze class $name.");
                 }


### PR DESCRIPTION
This commit fixes the issue #240 
The issue takes place because we set --dir option with the folder that already in app folder, so the models are parsed from app folder and then from inner folder app/Models and that is why there are duplicates. As a workaround I add every parsed models to ignore list, so they will not be parsed twice.