### PR TITLE
Trim tag text.…

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -474,7 +474,8 @@ class ModelsCommand extends Command
             } else {
                 $attr = 'property-read';
             }
-            $tag = Tag::createInstance("@{$attr} {$property['type']} {$name} {$property['comment']}", $phpdoc);
+            $tagLine = trim("@{$attr} {$property['type']} {$name} {$property['comment']}");
+            $tag = Tag::createInstance($tagLine, $phpdoc);
             $phpdoc->appendTag($tag);
         }
 


### PR DESCRIPTION
 If tag doesn't have comment or the comment has any space at the end of line, phpcs (with --standard=PSR2) dedects an error.