### PR TITLE
PHPDoc for Fluent methods commonly used in migrations

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -37,3 +37,26 @@ namespace <?= $namespace == '__root' ? '' : $namespace ?>{
 }
 
 <?php endforeach; ?>
+
+namespace Illuminate\Support {
+    /**
+    * Methods commonly used in migrations
+    *
+    * @method Fluent nullable()
+    * @method Fluent default($value)
+    * @method Fluent unsigned()
+    * @method Fluent unique()
+    * @method Fluent charset($charset)
+    * @method Fluent collation($collation)
+    * @method Fluent onUpdate($action)
+    * @method Fluent onDelete($action)
+    * @method Fluent references($table)
+    * @method Fluent on($column)
+    * @method Fluent after($column)
+    * @method Fluent first()
+    * @method Fluent comment($comment)
+    */
+    class Fluent {
+        //
+    }
+}


### PR DESCRIPTION
Laravel built-in "Fluent" class is commonly used in migrations but it doesn't give any hints about it's methods. Here we hardcode it so that when you write a new migration then IDE will hint you possible methods.
