### PR TITLE
Fixed: fails to generate with resources

### DIFF
--- a/src/Method.php
+++ b/src/Method.php
@@ -270,6 +270,8 @@ class Method
                     $default = 'null';
                 } elseif (is_int($default)) {
                     //$default = $default;
+                } elseif (is_resource($default)) {
+                    //skip to not fail
                 } else {
                     $default = "'" . trim($default) . "'";
                 }


### PR DESCRIPTION
Without this fix script fails:
[2015-12-11 16:44:33] local.ERROR: exception 'ErrorException' with message 'trim() expects parameter 1 to be string, resource given' in /home/nikolay-zakharov/PhpstormProjects/webhosts/project/vendor/barryvdh/laravel-ide-helper/src/Method.php:274

To reproduce:
https://gist.github.com/nikolay-zakharov/df3760693593df9dea3c