### PR TITLE
Add support for Lumen 5.0, 5.1 and 5.2+

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -11,8 +11,8 @@
 namespace Barryvdh\LaravelIdeHelper;
 
 use Illuminate\Foundation\AliasLoader;
-use Illuminate\Foundation\Application;
 use Illuminate\Config\Repository as ConfigRepository;
+use ReflectionClass;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Generator
@@ -118,7 +118,13 @@ class Generator
         
         try{
             if (class_exists('Auth') && is_a('Auth', '\Illuminate\Support\Facades\Auth', true)) {
-                $authMethod = version_compare(Application::VERSION, '5.2', '>=') ? 'guard' : 'driver';
+				if (class_exists('\Illuminate\Foundation\Application')) {
+					$authMethod = version_compare(\Illuminate\Foundation\Application::VERSION, '5.2', '>=') ? 'guard' : 'driver';
+				} else {
+                    $refClass = new ReflectionClass('\Laravel\Lumen\Application');
+                    $versionStr = $refClass->newInstanceWithoutConstructor()->version();
+					$authMethod = strpos($versionStr, 'Lumen (5.0') === 0 ? 'driver' : (strpos($versionStr, 'Lumen (5.1') === 0 ? 'driver' : 'guard');
+				}
                 $class = get_class(\Auth::$authMethod());
                 $this->extra['Auth'] = array($class);
                 $this->interfaces['\Illuminate\Auth\UserProviderInterface'] = $class;


### PR DESCRIPTION
This addresses issue #306 by loading the framework version using the right Application depending on Laravel/Lumen.