### PR TITLE
Allow for camel case model properties.

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -116,4 +116,30 @@ return array(
 
     ),
 
+    /*
+     |--------------------------------------------------------------------------
+     | Support for camel cased models
+     |--------------------------------------------------------------------------
+     |
+     | There are some Laravel packages (such as Eloquence) that allow for accessing
+     | Eloquent model properties via camel case, instead of snake case.
+     |
+     | Enabling this option will support these packages by saving all model
+     | properties as camel case, instead of snake case.
+     |
+     | For example, normally you would see this:
+     |
+     |  * @property \Carbon\Carbon $created_at
+     |  * @property \Carbon\Carbon $updated_at
+     |
+     | With this enabled, the properties will be this:
+     |
+     |  * @property \Carbon\Carbon $createdAt
+     |  * @property \Carbon\Carbon $updatedAt
+     |
+     | Note, it is currently an all-or-nothing option.
+     |
+     */
+    'model_camel_case_properties' => false,
+
 );

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -476,6 +476,11 @@ class ModelsCommand extends Command
             } else {
                 $attr = 'property-read';
             }
+
+            if ($this->hasCamelCaseModelProperties()) {
+                $name = Str::camel($name);
+            }
+
             $tagLine = trim("@{$attr} {$property['type']} {$name} {$property['comment']}");
             $tag = Tag::createInstance($tagLine, $phpdoc);
             $phpdoc->appendTag($tag);
@@ -574,5 +579,13 @@ class ModelsCommand extends Command
         /** @var \Illuminate\Database\Eloquent\Model $model */
         $model = new $className;
         return '\\' . get_class($model->newCollection());
+    }
+
+    /**
+     * @return bool
+     */
+    protected function hasCamelCaseModelProperties()
+    {
+        return $this->laravel['config']->get('ide-helper.model_camel_case_properties', false);
     }
 }


### PR DESCRIPTION
Added support for camel case model properties, as I had previously requested in #312.

There are some Laravel packages (such as Eloquence) that allow for accessing Eloquent model properties via camel case, instead of snake case.

This PR adds in an option (default disabled), to support these packages by saving all model properties as camel case, instead of snake case.

For example, normally you would see this:

```
 * @property \Carbon\Carbon $created_at
 * @property \Carbon\Carbon $updated_at
```

With this enabled, the properties will be this:

```
 * @property \Carbon\Carbon $createdAt
 * @property \Carbon\Carbon $updatedAt
```

It is currently an all-or-nothing option, as that was the simplest to implement and it suits my needs.