### PR TITLE
Look for additional facade aliases in app config array

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -237,6 +237,8 @@ class Generator
           'Storage' => 'Illuminate\Support\Facades\Storage',
           //'Validator' => 'Illuminate\Support\Facades\Validator',
         ];
+        
+        $facades = array_merge($facades, $this->config->get('app.aliases', []));
 
         // Only return the ones that actually exist
         return array_filter($facades, function($alias){


### PR DESCRIPTION
In my Lumen app, I load my providers and aliases from a `config/app.php` file like in Laravel. Maybe that is uncommon, but this simple PR will include those aliases as well if any are present.