### PR TITLE
Use FQN for app() methods

### DIFF
--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -47,7 +47,7 @@ class MetaCommand extends Command
       'new \Illuminate\Contracts\Container\Container',
       '\Illuminate\Contracts\Container\Container::make(\'\')',
       '\App::make(\'\')',
-      'app(\'\')',
+      '\app(\'\')',
     ];
 
     /**


### PR DESCRIPTION
This fixes completion in PhpStorm 2016.2+, and also works in PhpStorm 10. Note: despite needing the FQN in the .meta definition, you do not need to use it in your project to get autocomplete.

FQN is [now required for function references](https://youtrack.jetbrains.com/issue/WI-31102), closes #340.

Unfortunately, this does not fix the problem in 2016.1, as you still need to use the FQN `\app('foo')->` in your project to get autocomplete, but there's nothing we can do about that - it's a PhpStorm bug, and is now fixed in 2016.2 EAP.