### PR TITLE
Allow Type Overrides

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -153,6 +153,5 @@ return array(
    'type_overrides' => array(
        // 'integer' => 'int',
        // 'boolean' => 'bool',
-   )
-
+   ),
 );

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 return array(
 
@@ -71,7 +71,7 @@ return array(
             'emergency' => 'Monolog\Logger::addEmergency',
         )
     ),
-    
+
     /*
     |--------------------------------------------------------------------------
     | Interface implementations
@@ -81,7 +81,7 @@ return array(
     | are detected by the helpers, others can be listed below.
     |
     */
-    
+
     'interfaces' => array(
 
     ),
@@ -141,5 +141,18 @@ return array(
      |
      */
     'model_camel_case_properties' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Property Casts
+    |--------------------------------------------------------------------------
+    |
+    | Cast the given "real type" to the given "type".
+    |
+    */
+   'type_overrides' => array(
+       // 'integer' => 'int',
+       // 'boolean' => 'bool',
+   )
 
 );

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -151,7 +151,7 @@ return array(
     |
     */
    'type_overrides' => array(
-       // 'integer' => 'int',
-       // 'boolean' => 'bool',
+        'integer' => 'int',
+        'boolean' => 'bool',
    ),
 );

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -212,7 +212,6 @@ class ModelsCommand extends Command
         }
 
         return $output;
-
     }
 
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -279,9 +279,22 @@ class ModelsCommand extends Command
             if (!isset($this->properties[$name])) {
                 continue;
             } else {
-                $this->properties[$name]['type'] = $realType;
+                $this->properties[$name]['type'] = $this->getTypeOverride($realType);
             }
         }
+    }
+
+    /**
+     * Returns the overide type for the give type.
+     *
+     * @param string $type
+     * @return string
+     */
+    protected function getTypeOverride($type)
+    {
+        $typeOverrides = $this->laravel['config']->get('ide-helper.type_overrides', array());
+
+        return isset($typeOverrides[$type]) ? $typeOverrides[$type] : $type;
     }
 
     /**

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -118,7 +118,7 @@ class Generator
     {
         $defaultUserModel = config('auth.providers.users.model', config('auth.model', 'App\User'));
         $this->interfaces['\Illuminate\Contracts\Auth\Authenticatable'] = $defaultUserModel;
-        
+
         try {
             if (class_exists('Auth') && is_a('Auth', '\Illuminate\Support\Facades\Auth', true)) {
                 if (class_exists('\Illuminate\Foundation\Application')) {
@@ -182,7 +182,6 @@ class Generator
             }
         } catch (\Exception $e) {
         }
-
     }
 
     /**
@@ -200,7 +199,7 @@ class Generator
             if ($facade == 'Illuminate\Support\Facades\Redis' && !class_exists('Predis\Client')) {
                 continue;
             }
-            
+
             $magicMethods = array_key_exists($name, $this->magic) ? $this->magic[$name] : array();
             $alias = new Alias($name, $facade, $magicMethods, $this->interfaces);
             if ($alias->isValid()) {
@@ -246,7 +245,7 @@ class Generator
           'Storage' => 'Illuminate\Support\Facades\Storage',
           //'Validator' => 'Illuminate\Support\Facades\Validator',
         ];
-        
+
         $facades = array_merge($facades, $this->config->get('app.aliases', []));
 
         // Only return the ones that actually exist


### PR DESCRIPTION
This PR is to allow a developer to define the following in their `ide-helper.php` configuration:

```php
    /*
    |--------------------------------------------------------------------------
    | Property Casts
    |--------------------------------------------------------------------------
    |
    | Cast the given "real type" to the given "type".
    |
    */
   'type_overrides' => array(
       'integer' => 'int',
       'boolean' => 'bool',
   ),
```

This will replace `@property integer` with `@property int` when running `ide-helper:models`. This will satisfy the [phpdoc_scalar](https://styleci.readme.io/docs/fixers#phpdoc_scalar) fixer when using the Laravel preset on StyleCI.

This is also the scalar convention for Laravel and I would actually honestly consider changing `integer` to `int` and `boolean` to `bool` in the following locations:

- https://github.com/barryvdh/laravel-ide-helper/blob/master/src/Console/ModelsCommand.php#L260
- https://github.com/barryvdh/laravel-ide-helper/blob/master/src/Console/ModelsCommand.php#L332
- https://github.com/barryvdh/laravel-ide-helper/blob/master/src/Console/ModelsCommand.php#L245
- https://github.com/barryvdh/laravel-ide-helper/blob/master/src/Console/ModelsCommand.php#L339