### PR TITLE
Laravel 5.3  - Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/console": "^5.0,<5.4",
         "illuminate/filesystem": "^5.0,<5.4",
         "barryvdh/reflection-docblock": "^2.0.4",
-        "symfony/class-loader": "^2.3|^3.0"
+        "symfony/class-loader": "^2.3|^3.1"
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*",


### PR DESCRIPTION
bump symfony/class-loader to at least 3.1 in order to use this package with Laravel 5.3