### PR TITLE
Fix "Using $this when not in object context" bug

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -200,8 +200,8 @@ You can install Laravel IDE Helper in `app/Providers/AppServiceProvider.php`, an
 If you are not using that line, that is usually handy to manage gracefully multiple Laravel/Lumen installations, you will have to add this line of code under the `Register Service Providers` section of your `bootstrap/app.php`.
 
 ```php
-if ($this->app->environment() !== 'production') {
-    $this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
+if ($app->environment() !== 'production') {
+    $app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
 }
 ```
 


### PR DESCRIPTION
This pull request fixes the "Using $this when not in object context" bug for the Lumen configuration. Since the `bootstrap/app.php`-file is not in object context, and the `app` instance accessible using the `$app` variable directly, using `$this->app` will result in a fatal error.