### PR TITLE
Use accessor docblock return type to guess property type

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -386,7 +386,9 @@ class ModelsCommand extends Command
                     //Magic get<name>Attribute
                     $name = Str::snake(substr($method, 3, -9));
                     if (!empty($name)) {
-                        $this->setProperty($name, null, true, null);
+                        $reflection = new \ReflectionMethod($model, $method);
+                        $type = $this->getReturnTypeFromDocBlock($reflection);
+                        $this->setProperty($name, $type, true, null);
                     }
                 } elseif (Str::startsWith($method, 'set') && Str::endsWith(
                     $method,
@@ -668,5 +670,24 @@ class ModelsCommand extends Command
     protected function hasCamelCaseModelProperties()
     {
         return $this->laravel['config']->get('ide-helper.model_camel_case_properties', false);
+    }
+
+    /**
+     * Get method return type based on it DocBlock comment
+     *
+     * @param \ReflectionMethod $reflection
+     *
+     * @return null|string
+     */
+    protected function getReturnTypeFromDocBlock(\ReflectionMethod $reflection)
+    {
+        $type = null;
+        $phpdoc = new DocBlock($reflection);
+
+        if ($phpdoc->hasTag('return')) {
+            $type = $phpdoc->getTagsByName('return')[0]->getContent();
+        }
+
+        return $type;
     }
 }


### PR DESCRIPTION
This change allow to use return type from accessor's dockblock to specify parameter type in generated class-level docblock.

For example, for this class
```php
class Test extends Model
{
    /**
     * Test getter
     *
     * @return string
     */
    public function getTestAttribute()
    {
        return 'test';
    }
}
```
generated docblock will look like 

```php
/**
 * Test
 *
 * @property-readonly string $test
 * @mixin \Eloquent
 */
```

This small change will lead to better code completion and should improve developer's experience for those who have plenty of custom getters/setters.
