### PR TITLE
Support for MSSQL tables not in the 'dbo' schema

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -319,7 +319,16 @@ class ModelsCommand extends Command
 
         $database = null;
         if (strpos($table, '.')) {
-            list($database, $table) = explode('.', $table);
+            if ($platformName == 'mssql') {
+                $parts = explode('.', $table);
+                if (sizeof($parts) == 3) {
+                    $database = $parts[0];
+                    $table = $parts[1].$parts[2];
+                }
+            }
+            else {
+                list($database, $table) = explode('.', $table);
+            }
         }
 
         $columns = $schema->listTableColumns($table, $database);


### PR DESCRIPTION
I'm working with a database that uses custom schemas in MSSQL to organize the tables. In specifying my Eloquent models, the table names take the form **schema.tableName**. This appears to conflict with the expectations in laravel-ide-helper, as it acted as though the table had no columns.

Upon investigation, I found that the problem was in this location, where it split the table name on a period, interpreting the name as **database.tableName**,

In MSSQL fully qualified table names take the form of **database.schema.tableName**, or more specifically, table names can be specified as **[[database.]schema.]tableName**, where if the database is specified, the schema needs to be specified as well, but the table can be named by **schema** and **tableName** alone, and the database will be assumed to be the currently connected database. And finally, if just the **tableName** is specified, then the **schema** is assumed to be the default schema (usually 'dbo') and the connected database is used.

As you can see in the code change below, I've added an mssql-driver-specific code block to handle this cascading naming standard to properly extract / seperate the **database** from the **tableName** (which should contain the **schema** to correctly pull back the column data in the following lines).