### PR TITLE
Scope parameter typehints

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -622,7 +622,8 @@ class ModelsCommand extends Command
         $paramsWithDefault = array();
         /** @var \ReflectionParameter $param */
         foreach ($method->getParameters() as $param) {
-            $paramStr = '$' . $param->getName();
+            $paramClass = $param->getClass();
+            $paramStr = (!is_null($paramClass) ? '\\' . $paramClass->getName() . ' ' : '') . '$' . $param->getName();
             $params[] = $paramStr;
             if ($param->isOptional() && $param->isDefaultValueAvailable()) {
                 $default = $param->getDefaultValue();


### PR DESCRIPTION
If a scope has a typehint, e.g.
```php
public function scopeBeforeDate($query, \Carbon\Carbon $date)
{
    return $query->where('date', '<', $date->startOfDay()->toDateTimeString());
}
```
The docblock `@method` lacks the `\Carbon\Carbon` typehint. This pull request adds that missing functionality.