### PR TITLE
Add facades fullpath autocomplete

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -9,14 +9,10 @@
  */
 
 <?php foreach($namespaces as $namespace => $aliases): ?>
-namespace <?= $namespace == '__root' ? '' : $namespace ?>{
-<?php if($namespace == '__root'): ?>
-    exit("This file should not be included, only analyzed by your IDE");
-<?= $helpers ?>
-<?php endif; ?>
+namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?>{
 <?php foreach($aliases as $alias): ?>
 
-    <?= $alias->getClassType() ?> <?= $alias->getShortName() ?> <?= $alias->getExtends() ? 'extends ' . $alias->getExtends() : '' ?>{
+    <?= $alias->getClassType() ?> <?= $alias->getShortName() ?>{
         <?php foreach($alias->getMethods() as $method): ?>
 
         <?= trim($method->getDocComment('        ')) ?>
@@ -30,14 +26,16 @@ namespace <?= $namespace == '__root' ? '' : $namespace ?>{
         }
         <?php endforeach; ?>
 
-    }
-
+    }         
 <?php endforeach; ?>
-
 }
-
+    
 <?php endforeach; ?>
-
+    
+namespace {
+    exit("This file should not be included, only analyzed by your IDE");
+<?= $helpers ?>
+}
 
 <?php if($include_fluent): ?>
 namespace Illuminate\Support {

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -35,6 +35,13 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?>{
 namespace {
     exit("This file should not be included, only analyzed by your IDE");
 <?= $helpers ?>
+
+<?php foreach($namespaces as $namespace => $aliases): ?>
+<?php foreach($aliases as $alias): ?>
+    <?= $alias->getClassType() ?> <?= $alias->getShortName() ?> extends <?= $alias->getExtends() ?>{}
+    
+<?php endforeach; ?>
+<?php endforeach; ?>
 }
 
 <?php if($include_fluent): ?>

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -15,6 +15,7 @@ class Alias
     protected $alias;
     protected $facade;
     protected $extends = null;
+    protected $extendsNamespace = null;
     protected $classType = 'class';
     protected $short;
     protected $namespace = '__root';
@@ -53,6 +54,7 @@ class Alias
         $this->addClass($this->root);
         $this->detectNamespace();
         $this->detectClassType();
+        $this->detectExtendsNamespace();
         
         if ($facade === '\Illuminate\Database\Eloquent\Model') {
             $this->usedMethods = array('decrement', 'increment');
@@ -103,6 +105,16 @@ class Alias
     public function getExtends()
     {
         return $this->extends;
+    }
+    
+    /**
+     * Get the namespace of the class which this alias extends
+     *
+     * @return null|string
+     */
+    public function getExtendsNamespace()
+    {
+        return $this->extendsNamespace;
     }
 
     /**
@@ -155,6 +167,18 @@ class Alias
             $this->namespace = implode('\\', $nsParts);
         } else {
             $this->short = $this->alias;
+        }
+    }
+    
+    /**
+     * Detect the extends namespace
+     */
+    protected function detectExtendsNamespace()
+    {
+        if (strpos($this->extends, '\\') !== false) {
+            $nsParts = explode('\\', $this->extends);
+            array_pop($nsParts);
+            $this->extendsNamespace = implode('\\', $nsParts);
         }
     }
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -209,7 +209,7 @@ class Generator
                     $alias->addClass($this->extra[$name]);
                 }
 
-                $namespace = $alias->getNamespace();
+                $namespace = $alias->getExtendsNamespace() ?: $alias->getNamespace();
                 if (!isset($namespaces[$namespace])) {
                     $namespaces[$namespace] = array();
                 }


### PR DESCRIPTION
After PR #394 discussion I decided to make my own version in another way.

Facades with there methods are now declared in the same namespace as in Laravel. So you can use fullname of facades to import them : `use Illuminate\Support\Facades\Auth;` This is better for using ide-helper on an old project made without ide-helper. You don't need to replace fullnames anymore.

I also noted that autocompletion is improved for some librairies like Intervention : `Image::make()` result is now well autocompleted. It's surely due to the fact that now PHPStorm use Laravel docBlocks in association with the docBlocks in `_ide-helper.php`. For example, `Auth::user()` dont only return your user model but also `Authenticatable` like the original method.

To allow usage of short names, facades are also declared in the global namespace and extends the fullname of the facade. (\App extends \Illuminate\Support\Facades\App)
