### PR TITLE
Fix facades fullpath autocomplete

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -15,7 +15,7 @@ namespace  {
 namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
 <?php foreach($aliases as $alias): ?>
 
-    <?= $alias->getClassType() ?> <?= $alias->getShortName() ?> {
+    <?= $alias->getClassType() ?> <?= $alias->getExtendsCLass() ?> {
         <?php foreach($alias->getMethods() as $method): ?>
 
         <?= trim($method->getDocComment('        ')) ?>

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -15,6 +15,7 @@ class Alias
     protected $alias;
     protected $facade;
     protected $extends = null;
+    protected $extendsClass = null;
     protected $extendsNamespace = null;
     protected $classType = 'class';
     protected $short;
@@ -108,6 +109,16 @@ class Alias
     }
     
     /**
+     * Get the class short name which this alias extends
+     *
+     * @return null|string
+     */
+    public function getExtendsClass()
+    {
+        return $this->extendsClass;
+    }
+    
+    /**
      * Get the namespace of the class which this alias extends
      *
      * @return null|string
@@ -177,7 +188,7 @@ class Alias
     {
         if (strpos($this->extends, '\\') !== false) {
             $nsParts = explode('\\', $this->extends);
-            array_pop($nsParts);
+            $this->extendsClass = array_pop($nsParts);
             $this->extendsNamespace = implode('\\', $nsParts);
         }
     }


### PR DESCRIPTION
Fix a bug concerning PR #437 

The wrong classes were used for some facades like Eloquent.

Before :
````php
namespace Illuminate\Database\Eloquent {
    class Eloquent {

namespace {
    class Eloquent extends \Illuminate\Database\Eloquent\Model {}
````

After :
````php
namespace Illuminate\Database\Eloquent {
    class Model { // <= Good

namespace {
    class Eloquent extends \Illuminate\Database\Eloquent\Model {}
````

