### PR TITLE
Correct Fluent helper output

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -59,11 +59,11 @@ namespace Illuminate\Support {
      * @method Fluent default(mixed $value) Add the default modifier
      * @method Fluent first() Select first row
      * @method Fluent index(string $name = null) Add the in dex clause
-     * @method Fluent on(string $column) `on` of a foreign key
+     * @method Fluent on(string $table) `on` of a foreign key
      * @method Fluent onDelete(string $action) `on delete` of a foreign key
      * @method Fluent onUpdate(string $action) `on update` of a foreign key
      * @method Fluent primary() Add the primary key modifier
-     * @method Fluent references(string $table) `references` of a foreign key
+     * @method Fluent references(string $column) `references` of a foreign key
      * @method Fluent nullable() Add the nullable modifier
      * @method Fluent unique(string $name = null) Add unique index clause
      * @method Fluent unsigned() Add the unsigned modifier


### PR DESCRIPTION
'references()' and 'on()' argument names were backwards

As a reference:
https://laravel.com/docs/5.1/migrations#foreign-key-constraints
and a screenshot from PHPStorm with parameter name hints enabled:
![laravel-ide-helper-fluent](https://cloud.githubusercontent.com/assets/1389199/22879995/1e2fc326-f1e9-11e6-9d07-4f2e365d99a0.png)
