### PR TITLE
Fix autocompletion of methods declared in facades

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -14,7 +14,10 @@ namespace  {
 <?php foreach($namespaces as $namespace => $aliases): ?>
 namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
 <?php foreach($aliases as $alias): ?>
-
+    
+    /**
+     * @mixin <?= $namespace ?>\<?= $alias->getExtendsCLass() ?> 
+     */
     <?= $alias->getClassType() ?> <?= $alias->getExtendsCLass() ?> {
         <?php foreach($alias->getMethods() as $method): ?>
 


### PR DESCRIPTION
This PR fix a problem with methods declared directly in facades like `Auth::routes()` which are not autocompleted since 2.3.

I tested it on one of my projects and it works for `Auth` but I dont use all facades...