### PR TITLE
ignore custom intermediate table models ( Laravel 5.4 )

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -175,7 +175,8 @@ class ModelsCommand extends Command
                     // handle abstract classes, interfaces, ...
                     $reflectionClass = new \ReflectionClass($name);
 
-                    if (!$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Model')) {
+                    if (!$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Model')
+                            || $reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Relations\Pivot')) {
                         continue;
                     }
 


### PR DESCRIPTION
Laravel 5.4

i have Intermediate Table Model (pivot) in my models directory and after run

php artisan ide-helper:models

I get error: 
Exception: Target [Illuminate\Database\Eloquent\Model] is not instantiable while building [class]
Could not analyze class 
