### PR TITLE
removed static declaration

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -21,7 +21,7 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
 
         <?= trim($method->getDocComment('        ')) ?>
 
-        public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
+        public function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
         {<?php if($method->getDeclaringClass() !== $method->getRoot()): ?>
 
             //Method inherited from <?= $method->getDeclaringClass() ?>
@@ -47,7 +47,7 @@ namespace {
 
         <?= trim($method->getDocComment('        ')) ?>
 
-        public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
+        public function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
         {<?php if($method->getDeclaringClass() !== $method->getRoot()): ?>
 
             //Method inherited from <?= $method->getDeclaringClass() ?>

--- a/src/Method.php
+++ b/src/Method.php
@@ -61,9 +61,6 @@ class Method
         //Get the parameters, including formatted default values
         $this->getParameters($method);
 
-        //Make the method static
-        $this->phpdoc->appendTag(Tag::createInstance('@static', $this->phpdoc));
-
         //Reference the 'real' function in the declaringclass
         $declaringClass = $method->getDeclaringClass();
         $this->declaringClassName = '\\' . ltrim($declaringClass->name, '\\');

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -32,7 +32,6 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
  *
  * @param string $last
  * @param string $first
- * @static 
  */';
         $this->assertEquals($output, $method->getDocComment(''));
         $this->assertEquals('setName', $method->getName());


### PR DESCRIPTION
Because the function of Laravel are not static and phpstorms complains about it.

Before this:
![image](https://cloud.githubusercontent.com/assets/6141652/23404661/61b06398-fdb6-11e6-952a-314d70ae57dc.png)

And after:
![image](https://cloud.githubusercontent.com/assets/6141652/23404681/7c38abda-fdb6-11e6-9f7d-1bbf56d3e79d.png)

I'm not sure if this is a proper fix, or why the function are static..
If there is a better way of getting rid of those errors im open for them 😀 