### PR TITLE
Fix #480 where tinyint is casts as bool

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -347,14 +347,15 @@ class ModelsCommand extends Command
                         case 'integer':
                         case 'bigint':
                         case 'smallint':
+                        /**
+                         * @see https://github.com/barryvdh/laravel-ide-helper/issues/480
+                         */
+                        case 'boolean':
                             $type = 'integer';
                             break;
                         case 'decimal':
                         case 'float':
                             $type = 'float';
-                            break;
-                        case 'boolean':
-                            $type = 'boolean';
                             break;
                         default:
                             $type = 'mixed';

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -347,10 +347,7 @@ class ModelsCommand extends Command
                         case 'integer':
                         case 'bigint':
                         case 'smallint':
-                        /**
-                         * @see https://github.com/barryvdh/laravel-ide-helper/issues/480
-                         */
-                        case 'boolean':
+                        case 'boolean': // See issue #480
                             $type = 'integer';
                             break;
                         case 'decimal':

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -347,7 +347,7 @@ class ModelsCommand extends Command
                         case 'integer':
                         case 'bigint':
                         case 'smallint':
-                        case 'boolean': // See issue #480
+                        case 'boolean':
                             $type = 'integer';
                             break;
                         case 'decimal':


### PR DESCRIPTION
For issue https://github.com/barryvdh/laravel-ide-helper/issues/480

Explanation of changes:
`tinyint` is classified as `bool` by doctrine/dbal, but it should not be so in our use case. `tinyint` is better PHPDoc'ed as `int` (as it can be used for many reasons). **If the user wants `bool`, he should use Eloquent's `$casts` property to do that.**

I have therefore, moved doctrine/dbal's `boolean` to set the property type as `int` in PHPDoc.