### PR TITLE
Generate standalone metafile or use new meta folder option.

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -54,6 +54,18 @@ return array(
 
     /*
     |--------------------------------------------------------------------------
+    | Use special meta folder
+    |--------------------------------------------------------------------------
+    |
+    | Set to true to save the generated phpstorm.meta.php file to a folder that
+    | allows new versions of phpstorm ( >2016.2) to read multiple files from.
+    |
+    */
+
+    'use_meta_folder' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Model locations to include
     |--------------------------------------------------------------------------
     |

--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -95,7 +95,9 @@ class MetaCommand extends Command
           'methods' => $this->methods,
         ])->render();
 
-        $filename = $this->option('filename');
+        $metaFolderName = $this->metaFolderName();
+
+        $filename = $metaFolderName.$this->option('filename');
         $written = $this->files->put($filename, $content);
 
         if ($written !== false) {
@@ -138,5 +140,24 @@ class MetaCommand extends Command
         return array(
             array('filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the meta file', $this->filename),
         );
+    }
+
+    /**
+     * Determines if the user wants to use the new meta folder in phpstorm
+     * that allows multiple files to be parse, or to default to the
+     * normal single meta file option.
+     *
+     * @return string
+     */
+    protected function metaFolderName()
+    {
+        if (config('ide-helper.use_meta_folder', false)) {
+            $this->files->delete($this->filename);
+            $this->files->makeDirectory($this->filename);
+
+            return $this->filename . '/';
+        }
+
+        return '';
     }
 }


### PR DESCRIPTION
This PR is a rough outline of what we might be able to do with regards https://github.com/barryvdh/laravel-ide-helper/issues/469

I think it's a non BC because nothing will change unless you now enable the option in the config file. 

Two things I wasn't sure about:

1) Is it ok to use the `config()` helper in a command class?
2) I was of the option that when using the file `flysystem`, when you `->put` a file to a location, if the folder in the full filename given did not already exist, it would be created for you. 

In my testing on homestead, I could not get that to work, so had to make the folder programmatically  before saving the meta file. Perhaps someone can point out where I went wrong.

Thanks.