### PR TITLE
Add support for pgsql for boolean types

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -352,8 +352,18 @@ class ModelsCommand extends Command
                         case 'integer':
                         case 'bigint':
                         case 'smallint':
-                        case 'boolean':
                             $type = 'integer';
+                            break;
+                        case 'boolean':
+                            switch (config('database.default')) {
+                                case 'sqlite':
+                                case 'mysql':
+                                    $type = 'integer';
+                                    break;
+                                default:
+                                    $type = 'boolean';
+                                    break;
+                            }
                             break;
                         case 'decimal':
                         case 'float':


### PR DESCRIPTION
As discussed in #481 

Due to the changes, `pgsql`'s `boolean` became `int` too. This change uses Laravel's `config('database.default')` to determine the db type. Where it's the case that it is `pgsql`, it will use `boolean`.

[sqlite also uses int as boolean](https://sqlite.org/datatype3.html#boolean_datatype)