### PR TITLE
Resolve displaying @return types with descriptions

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -741,7 +741,7 @@ class ModelsCommand extends Command
         $phpdoc = new DocBlock($reflection);
 
         if ($phpdoc->hasTag('return')) {
-            $type = $phpdoc->getTagsByName('return')[0]->getContent();
+            $type = $phpdoc->getTagsByName('return')[0]->getType();
         }
 
         return $type;


### PR DESCRIPTION
This resolves #490, where the return type of a function would include the return description in the class-level docBlock.

Using the example in #490, the result will now correctly display as '* @property-read bool $example'.