### PR TITLE
Reversing order of default facade list

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -248,32 +248,47 @@ class Generator
             return AliasLoader::getInstance()->getAliases();
         }
 
+        // Lumen
         $facades = [
-          'App' => 'Illuminate\Support\Facades\App',
-          'Auth' => 'Illuminate\Support\Facades\Auth',
-          'Bus' => 'Illuminate\Support\Facades\Bus',
-          'DB' => 'Illuminate\Support\Facades\DB',
-          'Cache' => 'Illuminate\Support\Facades\Cache',
-          'Cookie' => 'Illuminate\Support\Facades\Cookie',
-          'Crypt' => 'Illuminate\Support\Facades\Crypt',
-          'Event' => 'Illuminate\Support\Facades\Event',
-          'Hash' => 'Illuminate\Support\Facades\Hash',
-          'Log' => 'Illuminate\Support\Facades\Log',
-          'Mail' => 'Illuminate\Support\Facades\Mail',
-          'Queue' => 'Illuminate\Support\Facades\Queue',
-          'Request' => 'Illuminate\Support\Facades\Request',
-          'Schema' => 'Illuminate\Support\Facades\Schema',
-          'Session' => 'Illuminate\Support\Facades\Session',
-          'Storage' => 'Illuminate\Support\Facades\Storage',
-          //'Validator' => 'Illuminate\Support\Facades\Validator',
+            'Illuminate\\Support\\Facades\\App' => 'App',
+            'Illuminate\\Support\\Facades\\Auth' => 'Auth',
+            'Illuminate\\Support\\Facades\\Bus' => 'Bus',
+            'Illuminate\\Support\\Facades\\DB' => 'DB',
+            'Illuminate\\Support\\Facades\\Cache' => 'Cache',
+            'Illuminate\\Support\\Facades\\Cookie' => 'Cookie',
+            'Illuminate\\Support\\Facades\\Crypt' => 'Crypt',
+            'Illuminate\\Support\\Facades\\Event' => 'Event',
+            'Illuminate\\Support\\Facades\\Hash' => 'Hash',
+            'Illuminate\\Support\\Facades\\Log' => 'Log',
+            'Illuminate\\Support\\Facades\\Mail' => 'Mail',
+            'Illuminate\\Support\\Facades\\Queue' => 'Queue',
+            'Illuminate\\Support\\Facades\\Request' => 'Request',
+            'Illuminate\\Support\\Facades\\Schema' => 'Schema',
+            'Illuminate\\Support\\Facades\\Session' => 'Session',
+            'Illuminate\\Support\\Facades\\Storage' => 'Storage',
+//            'Illuminate\Support\Facades\Validator' => 'Validator',
         ];
 
-        $facades = array_merge($facades, $this->config->get('app.aliases', []));
+        // locate user-defined aliases
+        $configured = $this->config->get('app.aliases', []);
+
+        /*
+         * Old:
+         * [ 'alias' => 'class\\name' ]
+         *
+         * New:
+         * [ 'class\\name' => 'alias' ]
+         */
+        if (0 < count($configured) && false !== strpos('\\', reset($configured))) {
+            $configured = array_flip($configured);
+        }
+
+        $facades = array_merge($facades, $configured);
 
         // Only return the ones that actually exist
-        return array_filter($facades, function ($alias) {
+        return array_flip(array_filter($facades, function ($alias) {
             return class_exists($alias);
-        });
+        }, ARRAY_FILTER_USE_KEY));
     }
 
     /**


### PR DESCRIPTION
Hi,

First off thanks for creating this lib, makes developing Lumen much less of a headache :)

Secondly, I've run into a small issue with alias name-clashing in the generated _ide_helper file that this PR hopes to rectify.

For one particular project, we are using [Event](http://docs.php.net/event) for use with React.  This extension exposes a class called `Event`, which obviously collides with the default Laravel `Event` facade class alias.

To that end, I have flipped the array in `Generate::getAliases`, making the class itself the key.  This allows me to squash the default definition for `Illuminate\Support\Facades\Event` with the alias that is actually used in my code, `LumenEvent`.

It also allows Lumen users to take advantage of this lib without having to call `array_flip` before providing their aliases to the Lumen application, as the `Application::withAliases` call expects this array format.   See [Application::withAliases](https://github.com/laravel/lumen-framework/blob/5.4/src/Application.php#L630)

This change should not pose any breaking changes for current users, and allows Lumen users to modify the aliases as they see fit.