### PR TITLE
Replaced the reflection-docblock with version of barryvdh

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/support": "4.x",
         "illuminate/console": "4.x",
         "illuminate/filesystem": "4.x",
-        "phpdocumentor/reflection-docblock": "2.0.4",
+        "barryvdh/reflection-docblock": "^2.0.4",
         "symfony/class-loader": "~2.3"
     },
     "require-dev": {

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -15,10 +15,10 @@ use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\ClassLoader\ClassMapGenerator;
-use phpDocumentor\Reflection\DocBlock;
-use phpDocumentor\Reflection\DocBlock\Context;
-use phpDocumentor\Reflection\DocBlock\Tag;
-use phpDocumentor\Reflection\DocBlock\Serializer as DocBlockSerializer;
+use Barryvdh\Reflection\DocBlock;
+use Barryvdh\Reflection\DocBlock\Context;
+use Barryvdh\Reflection\DocBlock\Tag;
+use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
 
 /**
  * A command to generate autocomplete information for your IDE

--- a/src/Method.php
+++ b/src/Method.php
@@ -10,16 +10,16 @@
 
 namespace Barryvdh\LaravelIdeHelper;
 
-use phpDocumentor\Reflection\DocBlock;
-use phpDocumentor\Reflection\DocBlock\Context;
-use phpDocumentor\Reflection\DocBlock\Tag;
-use phpDocumentor\Reflection\DocBlock\Tag\ReturnTag;
-use phpDocumentor\Reflection\DocBlock\Tag\ParamTag;
-use phpDocumentor\Reflection\DocBlock\Serializer as DocBlockSerializer;
+use Barryvdh\Reflection\DocBlock;
+use Barryvdh\Reflection\DocBlock\Context;
+use Barryvdh\Reflection\DocBlock\Tag;
+use Barryvdh\Reflection\DocBlock\Tag\ReturnTag;
+use Barryvdh\Reflection\DocBlock\Tag\ParamTag;
+use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
 
 class Method
 {
-    /** @var \phpDocumentor\Reflection\DocBlock  */
+    /** @var \Barryvdh\Reflection\DocBlock  */
     protected $phpdoc;
 
     /** @var \ReflectionMethod  */


### PR DESCRIPTION
Hello @barryvdh ,

Can you please consider this Pull Request if it makes sense to you.

**Background:**

We are on Laravel 4 but have want to use some library which demand 3.1 version of `phpdocumentor/reflection-docblock` and we get conflict on version `1.11` of ide-helper because it uses `phpdocumentor/reflection-docblock": "2.0.4`.

So  I noticed your latest master branch where you are using your own fork of `barryvdh/reflection-docblock": "^2.0.4`. So I branched out from `1.11` and checked your fork of reflection-dockblock which seems to be working fine with 1.11 also.

For me I've forked your branch already but it would be great if you can merge it too. 

Thanks in Advance.

-Ahsan