### PR TITLE
Don't use Facade alias but actual class

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -634,7 +634,7 @@ class ModelsCommand extends Command
         }
 
         if ($this->write && ! $phpdoc->getTagsByName('mixin')) {
-            $phpdoc->appendTag(Tag::createInstance("@mixin \\Eloquent", $phpdoc));
+            $phpdoc->appendTag(Tag::createInstance("@mixin \\Illuminate\\Database\\Eloquent\\Model", $phpdoc));
         }
 
         $serializer = new DocBlockSerializer();


### PR DESCRIPTION
There may be projects who don't have/need this particular alias.

---
IMHO it's good practice to only use facade alias locally in your project but not as 3rd party add-on: you can never now if it's really there.