### PR TITLE
set `include_fluent` default to true

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -85,7 +85,7 @@ class Generator
             ->with('namespaces_by_alias_ns', $this->getAliasesByAliasNamespace())
             ->with('helpers', $this->helpers)
             ->with('version', $app->version())
-            ->with('include_fluent', $this->config->get('ide-helper.include_fluent', false))
+            ->with('include_fluent', $this->config->get('ide-helper.include_fluent', true))
             ->render();
     }
 


### PR DESCRIPTION
fluent autocomplete is really useful, but I don't think it's a good idea to generate a config file for IDE helper package.