### PR TITLE
Use new PhpStorm advanced metadata format

### DIFF
--- a/resources/views/meta.php
+++ b/resources/views/meta.php
@@ -9,13 +9,42 @@ namespace PHPSTORM_META {
     * @author Barry vd. Heuvel <barryvdh@gmail.com>
     * @see https://github.com/barryvdh/laravel-ide-helper
     */
-    $STATIC_METHOD_TYPES = [
-<?php foreach($methods as $method): ?>
-        <?= $method ?> => [
-            '' == '@',
+<?php foreach ($methods as $method): ?>
+    override(<?= $method ?>, map([
+        '' => '@',
 <?php foreach($bindings as $abstract => $class): ?>
-            '<?= $abstract ?>' instanceof \<?= $class ?>,
-<?php endforeach ?>        ],
-<?php endforeach ?>
-    ];
+        '<?= $abstract ?>' => <?= $class ?>::class,
+<?php endforeach; ?>
+    ]));
+<?php endforeach; ?>
+
+    override(\Illuminate\Support\Arr::add(0), type(0));
+    override(\Illuminate\Support\Arr::except(0), type(0));
+    override(\Illuminate\Support\Arr::first(0), elementType(0));
+    override(\Illuminate\Support\Arr::last(0), elementType(0));
+    override(\Illuminate\Support\Arr::get(0), elementType(0));
+    override(\Illuminate\Support\Arr::only(0), type(0));
+    override(\Illuminate\Support\Arr::prepend(0), type(0));
+    override(\Illuminate\Support\Arr::pull(0), elementType(0));
+    override(\Illuminate\Support\Arr::set(0), type(0));
+    override(\Illuminate\Support\Arr::shuffle(0), type(0));
+    override(\Illuminate\Support\Arr::sort(0), type(0));
+    override(\Illuminate\Support\Arr::sortRecursive(0), type(0));
+    override(\Illuminate\Support\Arr::where(0), type(0));
+    override(\array_add(0), type(0));
+    override(\array_except(0), type(0));
+    override(\array_first(0), elementType(0));
+    override(\array_last(0), elementType(0));
+    override(\array_get(0), elementType(0));
+    override(\array_only(0), type(0));
+    override(\array_prepend(0), type(0));
+    override(\array_pull(0), elementType(0));
+    override(\array_set(0), type(0));
+    override(\array_sort(0), type(0));
+    override(\array_sort_recursive(0), type(0));
+    override(\array_where(0), type(0));
+    override(\head(0), elementType(0));
+    override(\last(0), elementType(0));
+    override(\with(0), type(0));
+
 }

--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -42,12 +42,15 @@ class MetaCommand extends Command
 
     /** @var \Illuminate\Contracts\View\Factory */
     protected $view;
-    
+
     protected $methods = [
       'new \Illuminate\Contracts\Container\Container',
-      '\Illuminate\Contracts\Container\Container::make(\'\')',
-      '\App::make(\'\')',
-      '\app(\'\')',
+      '\Illuminate\Contracts\Container\Container::make(0)',
+      '\Illuminate\Contracts\Container\Container::makeWith(0)',
+      '\App::make(0)',
+      '\App::makeWith(0)',
+      '\app(0)',
+      '\resolve(0)',
     ];
 
     /**
@@ -77,7 +80,7 @@ class MetaCommand extends Command
             if (in_array($abstract, ['validator', 'seeder'])) {
                 continue;
             }
-            
+
             try {
                 $concrete = $this->laravel->make($abstract);
                 if (is_object($concrete)) {
@@ -113,7 +116,7 @@ class MetaCommand extends Command
     protected function getAbstracts()
     {
         $abstracts = $this->laravel->getBindings();
-        
+
         // Return the abstract names only
         return array_keys($abstracts);
     }


### PR DESCRIPTION
This commit adds support for the new [PhpStorm Advanced Metadata](https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata) format.

What this allows us to do is to add autocompletion for the several (array) helper methods that Laravel offers:

<img width="461" alt="array-helper-autocompletion" src="https://user-images.githubusercontent.com/4399967/27088323-a2b7cb6c-5057-11e7-832b-c36db547a26f.png">

I have also added support for the new `makeWith` and `resolve` functions.

The only thing that I think could be improved here is not having to hardcode the helper functions, but I couldn't think of a better way to handle it.