### PR TITLE
Add configurable Formatter Control tags around model docblocks

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -176,4 +176,23 @@ return array(
         'integer' => 'int',
         'boolean' => 'bool',
    ),
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Formatter Control
+    |--------------------------------------------------------------------------
+    |
+    | Writes Formatter Control tags around model docblocks, to prevent automatic
+    | IDE reformatting changing any of the docblocks written by the IDE helper.
+    | This is useful when using the --write flag, to help keep version control
+    | histories clean between re-formats and IDE Helper re-writes.
+    |
+    */
+
+    'write_formatter_controls' => false,
+    
+    'formatter_control_tags'   => array(
+        'formatter_off' => "// @formatter:off\n",
+        'formatter_on'  => "\n// @formatter:on\n",
+    ),
 );

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -182,15 +182,15 @@ return array(
     | Formatter Control
     |--------------------------------------------------------------------------
     |
-    | Writes Formatter Control tags around model docblocks, to prevent automatic
+    | Writes formatter control tags around model docblocks, to prevent automatic
     | IDE reformatting changing any of the docblocks written by the IDE helper.
-    | This is useful when using the --write flag, to help keep version control
-    | histories clean between re-formats and IDE Helper re-writes.
+    | This is useful when using the --write and --reset flags, to help keep
+    | version control histories clean between re-formats and IDE Helper re-writes.
     |
     */
 
     'write_formatter_controls' => false,
-    
+
     'formatter_control_tags'   => array(
         'formatter_off' => "// @formatter:off\n",
         'formatter_on'  => "\n// @formatter:on\n",

--- a/readme.md
+++ b/readme.md
@@ -105,10 +105,11 @@ composer require doctrine/dbal
 ```
 
 If you don't want to write your properties yourself, you can use the command `php artisan ide-helper:models` to generate
-phpDocs, based on table columns, relations and getters/setters. You can write the comments directly to your Model file, using the `--write (-W)` option. By default, you are asked to overwrite or write to a separate file (`_ide_helper_models.php`). You can force No with `--nowrite (-N)`.
-Please make sure to backup your models, before writing the info.
-It should keep the existing comments and only append new properties/methods. The existing phpdoc is replaced, or added if not found.
-With the `--reset (-R)` option, the existing phpdocs are ignored, and only the newly found columns/relations are saved as phpdocs.
+phpDocs, based on table columns, relations and getters/setters.
+
+You can write the comments directly to your Model file, using the `--write (-W)` option. By default, you are asked to overwrite or write to a separate file (`_ide_helper_models.php`). You can force No with `--nowrite (-N)`. Please make sure to backup your models, before writing the info. It should keep the existing comments and only append new properties/methods. The existing phpdoc is replaced, or added if not found. With the `--reset (-R)` option, the existing phpdocs are ignored, and only the newly found columns/relations are saved as phpdocs.
+
+If you use the `--write --reset` flags regularly, and also use the code style auto-reformatting ability provided by IDEs like PhpStorm, you may find your version control history unnecessarily filled up with docblock re-formats (e.g. alignment of parameters). Laravel IDE Helper can be configured to write [formatter control tags](https://www.jetbrains.com/help/phpstorm/code-style.html#d366576e184) around the docblocks, which will prevent automatic code style reformatting from interfering with IDE Helper's docs. Formatter control tags can be enabled and configured in the `ide-helper.php` config file.
 
 ```bash
 php artisan ide-helper:models Post

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -663,10 +663,6 @@ class ModelsCommand extends Command
             $filename = $reflection->getFileName();
             $contents = $this->files->get($filename);
 
-            if ($this->write_formatter_controls) {
-                $docComment = $this->formatter_control_off.$docComment.$this->formatter_control_on;
-            }
-            
             if ($originalDoc) {
                 $contents = str_replace($originalDoc, $docComment, $contents);
             } else {
@@ -677,6 +673,15 @@ class ModelsCommand extends Command
                     $contents = substr_replace($contents, $replace, $pos, strlen($needle));
                 }
             }
+
+            // Write formatter controls, if they've not already been placed on the model
+            if ($this->write_formatter_controls) {
+                $docCommentWithFormatters = $this->formatter_control_off.$docComment.$this->formatter_control_on;
+                if (strpos($contents, $docCommentWithFormatters) === false) {
+                    $contents = str_replace($docComment, $docCommentWithFormatters, $contents);
+                }
+            }
+
             if ($this->files->put($filename, $contents)) {
                 $this->info('Written new phpDocBlock to ' . $filename);
             }


### PR DESCRIPTION
Firstly, thanks for such an invaluable package! I have only one minor irritation with it - that this pull request fixes - so I hope it's useful to others too. 😄 

I regularly use `php artisan ide-helper:models --write --reset` to keep model documentation up-to-date and accurate. IDE Helper writes docblocks like so:

```
/**
 * App\MyModel
 *
 * @property int $id Model identifier
 * @property string $name Name of model entry
 * @property Carbon $created_at Date of creation
 */
```

However, my PhpStorm auto-reformatting is configured to align docblock tags, like so:

```
/**
 * App\MyModel
 *
 * @property int    $id         Model identifier
 * @property string $name       Name of model entry
 * @property Carbon $created_at Date of creation
 */
```

So if I do an auto-reformat of my file, all tags that IDE Helper generated are neatly aligned. However, the next time I run `php artisan ide-helper:models --write --reset`, all that auto-formatting is undone. Unless I manually re-format everything again, my git history gets filled up with every model's docblock being rewritten in many commits.

To get around this, I've added configuration options to IDE Helper that allow you to set [formatter control tags](https://www.jetbrains.com/help/phpstorm/code-style.html#d366576e184) that surround the docblocks that are written to models. With this enabled, you can auto-reformat as much as you like, whilst still automatically keeping your docblocks up-to-date, without filling your git history with unnecessary reformatting commits.

With the option enabled, by default, docblocks are written like this:

```
// @formatter:off
/**
 * App\MyModel
 *
 * @property int $id Model identifier
 * @property string $name Name of model entry
 * @property Carbon $created_at Date of creation
 */
// @formatter:on

```