### PR TITLE
Add back leading slash on meta class names

### DIFF
--- a/resources/views/meta.php
+++ b/resources/views/meta.php
@@ -13,7 +13,7 @@ namespace PHPSTORM_META {
     override(<?= $method ?>, map([
         '' => '@',
 <?php foreach($bindings as $abstract => $class): ?>
-        '<?= $abstract ?>' => <?= $class ?>::class,
+        '<?= $abstract ?>' => \<?= $class ?>::class,
 <?php endforeach; ?>
     ]));
 <?php endforeach; ?>


### PR DESCRIPTION
After my last change to support the meta metadata format, I accidentally nuked the leading slash on the class names :(. This PR adds that slash back to fix autocompletion. 