### PR TITLE
Allow for configurable meta filename

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -13,6 +13,8 @@ return array(
 
     'filename'  => '_ide_helper',
     'format'    => 'php',
+    
+    'meta_filename' => '.phpstorm.meta.php',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -28,7 +28,6 @@ class MetaCommand extends Command
      * @var string
      */
     protected $name = 'ide-helper:meta';
-    protected $filename = '.phpstorm.meta.php';
 
     /**
      * The console command description.
@@ -138,8 +137,10 @@ class MetaCommand extends Command
      */
     protected function getOptions()
     {
+        $filename = $this->config->get('ide-helper.meta_filename');
+
         return array(
-            array('filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the meta file', $this->filename),
+            array('filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the meta file', $filename),
         );
     }
 }


### PR DESCRIPTION
PhpStorm supports putting multiple files in a `.phpstorm.meta.php/` directory. If you want to maintain multiple meta files, having to use the filename argument each time is a pain, so this makes that configurable.