### PR TITLE
Bugfix: Undefined property: $config

### DIFF
--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -42,6 +42,9 @@ class MetaCommand extends Command
     /** @var \Illuminate\Contracts\View\Factory */
     protected $view;
 
+    /** @var \Illuminate\Contracts\Config */
+    protected $config;
+
     protected $methods = [
       'new \Illuminate\Contracts\Container\Container',
       '\Illuminate\Contracts\Container\Container::make(0)',
@@ -56,11 +59,13 @@ class MetaCommand extends Command
      *
      * @param \Illuminate\Contracts\Filesystem\Filesystem $files
      * @param \Illuminate\Contracts\View\Factory $view
+     * @param \Illuminate\Contracts\Config $config
      */
-    public function __construct($files, $view)
+    public function __construct($files, $view, $config)
     {
         $this->files = $files;
         $this->view = $view;
+        $this->config = $config;
         parent::__construct();
     }
 

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -38,7 +38,7 @@ class IdeHelperServiceProvider extends ServiceProvider
     {
         $viewPath = __DIR__.'/../resources/views';
         $this->loadViewsFrom($viewPath, 'ide-helper');
-        
+
         $configPath = __DIR__ . '/../config/ide-helper.php';
         if (function_exists('config_path')) {
             $publishPath = config_path('ide-helper.php');
@@ -58,7 +58,7 @@ class IdeHelperServiceProvider extends ServiceProvider
         $configPath = __DIR__ . '/../config/ide-helper.php';
         $this->mergeConfigFrom($configPath, 'ide-helper');
         $localViewFactory = $this->createLocalViewFactory();
-        
+
         $this->app->singleton(
             'command.ide-helper.generate',
             function ($app) use ($localViewFactory) {
@@ -72,11 +72,11 @@ class IdeHelperServiceProvider extends ServiceProvider
                 return new ModelsCommand($app['files']);
             }
         );
-        
+
         $this->app->singleton(
             'command.ide-helper.meta',
             function ($app) use ($localViewFactory) {
-                return new MetaCommand($app['files'], $localViewFactory);
+                return new MetaCommand($app['files'], $localViewFactory, $app['config']);
             }
         );
 


### PR DESCRIPTION
In a recent pull request https://github.com/barryvdh/laravel-ide-helper/commit/55c9bfc33b0e8fc35a8f7939f1d4afe5debf1eb3 checking configuration file for `meta_filename` was added, but there was no config object provided for the class so `Undefined property: Barryvdh\LaravelIdeHelper\Console\MetaCommand::$config` error was thrown. Now I've passed the app config object to the class and instantiated as such.