### PR TITLE
Fix magic method generation & helper class aliases

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -12,8 +12,8 @@ namespace  {
 }
 
 <?php foreach($namespaces_by_extends_ns as $namespace => $aliases): ?>
-<?php if ($namespace == '\Illuminate\Database\Eloquent'): continue; endif; ?>
-namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
+<?php if($namespace == '\Illuminate\Database\Eloquent'): continue; endif; ?>
+namespace <?= ltrim($namespace, '\\') ?> { 
 <?php foreach($aliases as $alias): ?>
 
     <?= $alias->getClassType() ?> <?= $alias->getExtendsClass() ?> {
@@ -36,7 +36,7 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
 <?php endforeach; ?>
 
 <?php foreach($namespaces_by_alias_ns as $namespace => $aliases): ?>
-namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
+namespace <?= ltrim($namespace, '\\') ?> { 
 <?php foreach($aliases as $alias): ?>
 
     <?= $alias->getClassType() ?> <?= $alias->getShortName() ?> extends <?= $alias->getExtends() ?> {<?php if ($alias->getExtendsNamespace() == '\Illuminate\Database\Eloquent'): ?>

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -21,12 +21,12 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
 
         <?= trim($method->getDocComment('        ')) ?> 
         public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
-        {<?php if($method->getDeclaringClass() !== $method->getRoot()): ?>
+        {<?php if($method->getDeclaringClass() !== $method->getRootClass()): ?>
 
             //Method inherited from <?= $method->getDeclaringClass() ?>
             <?php endif; ?>
 
-            <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRoot() ?>::<?= $method->getName() ?>(<?= $method->getParams() ?>);
+            <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRootClass() ?>::<?= $method->getRootMethod() ?>(<?= $method->getParams() ?>);
         }
         <?php endforeach; ?> 
     }
@@ -43,12 +43,12 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
         <?php foreach($alias->getMethods() as $method): ?> 
             <?= trim($method->getDocComment('            ')) ?> 
             public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
-            {<?php if($method->getDeclaringClass() !== $method->getRoot()): ?>
+            {<?php if($method->getDeclaringClass() !== $method->getRootClass()): ?>
     
                 //Method inherited from <?= $method->getDeclaringClass() ?>
                 <?php endif; ?>
     
-                <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRoot() ?>::<?= $method->getName() ?>(<?= $method->getParams() ?>);
+                <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRootClass() ?>::<?= $method->getRootMethod() ?>(<?= $method->getParams() ?>);
             }
         <?php endforeach; ?>
 <?php endif; ?>}

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -11,10 +11,10 @@ namespace  {
     exit("This file should not be included, only analyzed by your IDE");
 }
 
-<?php foreach($namespaces_by_extends_ns as $namespace => $aliases): ?>
-<?php if($namespace == '\Illuminate\Database\Eloquent'): continue; endif; ?>
-namespace <?= ltrim($namespace, '\\') ?> { 
-<?php foreach($aliases as $alias): ?>
+<?php foreach($facade_aliases_by_extends_ns as $extends_ns => $facade_aliases): ?>
+<?php if($extends_ns == '\Illuminate\Database\Eloquent'): continue; endif; ?>
+namespace <?= ltrim($extends_ns, '\\') ?> {
+<?php foreach($facade_aliases as $alias): ?>
 
     <?= $alias->getClassType() ?> <?= $alias->getExtendsClass() ?> {
         <?php foreach($alias->getMethods() as $method): ?>
@@ -35,9 +35,9 @@ namespace <?= ltrim($namespace, '\\') ?> {
 
 <?php endforeach; ?>
 
-<?php foreach($namespaces_by_alias_ns as $namespace => $aliases): ?>
-namespace <?= ltrim($namespace, '\\') ?> { 
-<?php foreach($aliases as $alias): ?>
+<?php foreach($all_aliases_by_alias_ns as $alias_ns => $all_aliases): ?>
+namespace <?= ltrim($alias_ns, '\\') ?> {
+<?php foreach($all_aliases as $alias): ?>
 
     <?= $alias->getClassType() ?> <?= $alias->getShortName() ?> extends <?= $alias->getExtends() ?> {<?php if ($alias->getExtendsNamespace() == '\Illuminate\Database\Eloquent'): ?>
         <?php foreach($alias->getMethods() as $method): ?> 

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -275,7 +275,7 @@ class Alias
 
             if (!in_array($method->name, $this->usedMethods)) {
                 if ($class !== $this->root) {
-                    $this->methods[] = new Method($method, $this->alias, $class, $magic, $this->interfaces);
+                    $this->methods[] = new Method($method, $class, $magic, $this->interfaces);
                 }
                 $this->usedMethods[] = $magic;
             }
@@ -302,7 +302,6 @@ class Alias
                         if ($this->extends !== $class && substr($method->name, 0, 2) !== '__') {
                             $this->methods[] = new Method(
                                 $method,
-                                $this->alias,
                                 $reflection,
                                 $method->name,
                                 $this->interfaces
@@ -323,7 +322,6 @@ class Alias
                     // Add macros
                     $this->methods[] = new Macro(
                         $function,
-                        $this->alias,
                         $reflection,
                         $macro_name,
                         $this->interfaces

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -273,7 +273,7 @@ class Alias
             $method = new \ReflectionMethod($className, $name);
             $class = new \ReflectionClass($className);
 
-            if (!in_array($method->name, $this->usedMethods)) {
+            if (!in_array($magic, $this->usedMethods)) {
                 if ($class !== $this->root) {
                     $this->methods[] = new Method($method, $class, $magic, $this->interfaces);
                 }

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -87,6 +87,15 @@ class Alias
     }
 
     /**
+     * Check if this alias is for a facade.
+     * @return bool
+     */
+    public function isForFacade()
+    {
+        return $this->root != $this->extends;
+    }
+
+    /**
      * Get the classtype, 'interface' or 'class'
      *
      * @return string

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -197,14 +197,14 @@ class Generator
         $aliases = new Collection();
 
         // Get all aliases
-        foreach ($this->getAliases() as $name => $facade) {
+        foreach ($this->getAliases() as $name => $aliased) {
             // Skip the Redis facade, if not available (otherwise Fatal PHP Error)
-            if ($facade == 'Illuminate\Support\Facades\Redis' && !class_exists('Predis\Client')) {
+            if ($aliased == 'Illuminate\Support\Facades\Redis' && !class_exists('Predis\Client')) {
                 continue;
             }
 
             $magicMethods = array_key_exists($name, $this->magic) ? $this->magic[$name] : array();
-            $alias = new Alias($name, $facade, $magicMethods, $this->interfaces);
+            $alias = new Alias($name, $aliased, $magicMethods, $this->interfaces);
             if ($alias->isValid()) {
                 //Add extra methods, from other classes (magic static calls)
                 if (array_key_exists($name, $this->extra)) {
@@ -249,7 +249,7 @@ class Generator
             return AliasLoader::getInstance()->getAliases();
         }
 
-        $facades = [
+        $standardAliases = [
           'App' => 'Illuminate\Support\Facades\App',
           'Auth' => 'Illuminate\Support\Facades\Auth',
           'Bus' => 'Illuminate\Support\Facades\Bus',
@@ -269,11 +269,11 @@ class Generator
           //'Validator' => 'Illuminate\Support\Facades\Validator',
         ];
 
-        $facades = array_merge($facades, $this->config->get('app.aliases', []));
+        $aliases = array_merge($standardAliases, $this->config->get('app.aliases', []));
 
         // Only return the ones that actually exist
-        return array_filter($facades, function ($alias) {
-            return class_exists($alias);
+        return array_filter($aliases, function ($aliased) {
+            return class_exists($aliased);
         });
     }
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -82,8 +82,8 @@ class Generator
     {
         $app = app();
         return $this->view->make('helper')
-            ->with('namespaces_by_extends_ns', $this->getAliasesByExtendsNamespace())
-            ->with('namespaces_by_alias_ns', $this->getAliasesByAliasNamespace())
+            ->with('facade_aliases_by_extends_ns', $this->getFacadeAliasesByExtendsNamespace())
+            ->with('all_aliases_by_alias_ns', $this->getAllAliasesByAliasNamespace())
             ->with('helpers', $this->helpers)
             ->with('version', $app->version())
             ->with('include_fluent', $this->config->get('ide-helper.include_fluent', true))
@@ -219,23 +219,25 @@ class Generator
     }
     
     /**
-     * Regroup aliases by namespace of extended classes
+     * Group facade aliases by namespace of extended classes
      *
      * @return Collection
      */
-    protected function getAliasesByExtendsNamespace()
+    protected function getFacadeAliasesByExtendsNamespace()
     {
-        return $this->getValidAliases()->groupBy(function (Alias $alias) {
+        return $this->getValidAliases()->filter(function (Alias $alias) {
+            return $alias->isForFacade();
+        })->groupBy(function (Alias $alias) {
             return $alias->getExtendsNamespace();
         });
     }
     
     /**
-     * Regroup aliases by namespace of alias
+     * Group all aliases by namespace of alias
      *
      * @return Collection
      */
-    protected function getAliasesByAliasNamespace()
+    protected function getAllAliasesByAliasNamespace()
     {
         return $this->getValidAliases()->groupBy(function (Alias $alias) {
             return $alias->getNamespace();

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -46,6 +46,7 @@ class Generator
     ) {
         $this->config = $config;
         $this->view = $view;
+        $this->output = $output;
 
         // Find the drivers to add to the extra/interfaces
         $this->detectDrivers();

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -45,6 +45,7 @@ class Macro extends Method
 
         //Reference the 'real' function in the declaringclass
         $this->declaringClassName = '\\' . ltrim($class->name, '\\');
-        $this->root = '\\' . ltrim($class->getName(), '\\');
+        $this->rootClassName = '\\' . ltrim($class->getName(), '\\');
+        $this->rootMethodName = $method->name;
     }
 }

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -11,13 +11,16 @@ class Macro extends Method
      * Macro constructor.
      *
      * @param \ReflectionFunction $method
-     * @param string              $alias
      * @param \ReflectionClass    $class
-     * @param null                $methodName
+     * @param string|null         $methodName
      * @param array               $interfaces
      */
-    public function __construct(\ReflectionFunction $method, $alias, $class, $methodName = null, $interfaces = array())
-    {
+    public function __construct(
+        \ReflectionFunction $method,
+        \ReflectionClass $class,
+        $methodName = null,
+        $interfaces = array()
+    ) {
         $this->method = $method;
         $this->interfaces = $interfaces;
         $this->name = $methodName ?: $method->name;

--- a/src/Method.php
+++ b/src/Method.php
@@ -32,6 +32,10 @@ class Method
     protected $interfaces = array();
     protected $return = null;
 
+    protected $declaringClassName;
+    protected $rootClassName;
+    protected $rootMethodName;
+
     /**
      * Method constructor.
      *
@@ -71,11 +75,12 @@ class Method
         //Reference the 'real' function in the declaringclass
         $declaringClass = $method->getDeclaringClass();
         $this->declaringClassName = '\\' . ltrim($declaringClass->name, '\\');
-        $this->root = '\\' . ltrim($class->getName(), '\\');
+        $this->rootClassName = '\\' . ltrim($class->getName(), '\\');
+        $this->rootMethodName = $method->name;
     }
 
     /**
-     * Get the class wherein the function resides
+     * Get the name of the class wherein the function resides
      *
      * @return string
      */
@@ -85,13 +90,23 @@ class Method
     }
 
     /**
-     * Return the class from which this function would be called
+     * Return the name of the class from which this function would be called
      *
      * @return string
      */
-    public function getRoot()
+    public function getRootClass()
     {
-        return $this->root;
+        return $this->rootClassName;
+    }
+
+    /**
+     * Return the method name in the class from which this function would be called
+     *
+     * @return string
+     */
+    public function getRootMethod()
+    {
+        return $this->rootMethodName;
     }
 
     /**

--- a/src/Method.php
+++ b/src/Method.php
@@ -25,7 +25,6 @@ class Method
     /** @var \ReflectionMethod  */
     protected $method;
 
-    protected $output = '';
     protected $name;
     protected $namespace;
     protected $params = array();
@@ -34,14 +33,19 @@ class Method
     protected $return = null;
 
     /**
+     * Method constructor.
+     *
      * @param \ReflectionMethod $method
-     * @param string $alias
-     * @param \ReflectionClass $class
-     * @param string|null $methodName
-     * @param array $interfaces
+     * @param \ReflectionClass  $class
+     * @param string|null       $methodName
+     * @param array             $interfaces
      */
-    public function __construct(\ReflectionMethod $method, $alias, $class, $methodName = null, $interfaces = array())
-    {
+    public function __construct(
+        \ReflectionMethod $method,
+        \ReflectionClass $class,
+        $methodName = null,
+        $interfaces = array()
+    ) {
         $this->method = $method;
         $this->interfaces = $interfaces;
         $this->name = $methodName ?: $method->name;

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -18,9 +18,9 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test the output of a class
+     * Test with a method that is defined in the class itself
      */
-    public function testOutput()
+    public function testDeclaredMethod()
     {
         $reflectionClass = new \ReflectionClass(ExampleClass::class);
         $reflectionMethod = $reflectionClass->getMethod('setName');
@@ -32,27 +32,98 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
  *
  * @param string $last
  * @param string $first
+ * @return void 
  * @static 
  */';
         $this->assertEquals($output, $method->getDocComment(''));
-        $this->assertEquals('setName', $method->getName());
         $this->assertEquals('\\'.ExampleClass::class, $method->getDeclaringClass());
+        $this->assertEquals('\\'.ExampleClass::class, $method->getRootClass());
+        $this->assertEquals('setName', $method->getRootMethod());
+        $this->assertEquals('setName', $method->getName());
         $this->assertEquals('$last, $first', $method->getParams(true));
         $this->assertEquals(['$last', '$first'], $method->getParams(false));
         $this->assertEquals('$last, $first = \'Barry\'', $method->getParamsWithDefault(true));
         $this->assertEquals(['$last', '$first = \'Barry\''], $method->getParamsWithDefault(false));
+        $this->assertEquals(false, $method->shouldReturn());
+    }
+
+    /**
+     * Test a method that is added via magic
+     */
+    public function testMagicMethod()
+    {
+        $reflectionClass = new \ReflectionClass(ExampleClass::class);
+        $reflectionMethod = $reflectionClass->getMethod('setName');
+
+        $method = new Method($reflectionMethod, $reflectionClass, 'updateName');
+
+        $output = '/**
+ * 
+ *
+ * @param string $last
+ * @param string $first
+ * @return void 
+ * @static 
+ */';
+        $this->assertEquals($output, $method->getDocComment(''));
+        $this->assertEquals('\\'.ExampleClass::class, $method->getDeclaringClass());
+        $this->assertEquals('\\'.ExampleClass::class, $method->getRootClass());
+        $this->assertEquals('setName', $method->getRootMethod());
+        $this->assertEquals('updateName', $method->getName());
+        $this->assertEquals('$last, $first', $method->getParams(true));
+        $this->assertEquals(['$last', '$first'], $method->getParams(false));
+        $this->assertEquals('$last, $first = \'Barry\'', $method->getParamsWithDefault(true));
+        $this->assertEquals(['$last', '$first = \'Barry\''], $method->getParamsWithDefault(false));
+        $this->assertEquals(false, $method->shouldReturn());
+    }
+
+    /**
+     * Test with a method that is inherited from the superclass
+     */
+    public function testInheritedMethod()
+    {
+        $reflectionClass = new \ReflectionClass(ExampleClass::class);
+        $reflectionMethod = $reflectionClass->getMethod('getName');
+
+        $method = new Method($reflectionMethod, $reflectionClass);
+
+        $output = '/**
+ * 
+ *
+ * @return string 
+ * @static 
+ */';
+        $this->assertEquals($output, $method->getDocComment(''));
+        $this->assertEquals('\\'.ExampleSuperClass::class, $method->getDeclaringClass());
+        $this->assertEquals('\\'.ExampleClass::class, $method->getRootClass());
+        $this->assertEquals('getName', $method->getRootMethod());
+        $this->assertEquals('getName', $method->getName());
+        $this->assertEquals('', $method->getParams(true));
+        $this->assertEquals([], $method->getParams(false));
+        $this->assertEquals('', $method->getParamsWithDefault(true));
+        $this->assertEquals([], $method->getParamsWithDefault(false));
         $this->assertEquals(true, $method->shouldReturn());
     }
 }
 
-class ExampleClass
+class ExampleSuperClass
+{
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'Barry';
+    }
+}
+class ExampleClass extends ExampleSuperClass
 {
     /**
      * @param string $last
      * @param string $first
+     * @return void
      */
     public function setName($last, $first = 'Barry')
     {
-        return;
     }
 }

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -12,7 +12,7 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
         $reflectionClass = new \ReflectionClass(ExampleClass::class);
         $reflectionMethod = $reflectionClass->getMethod('setName');
 
-        $method = new Method($reflectionMethod, 'Example', $reflectionClass);
+        $method = new Method($reflectionMethod, $reflectionClass);
 
         $this->assertInstanceOf(Method::class, $method);
     }
@@ -25,7 +25,7 @@ class ExampleTest extends \PHPUnit_Framework_TestCase
         $reflectionClass = new \ReflectionClass(ExampleClass::class);
         $reflectionMethod = $reflectionClass->getMethod('setName');
 
-        $method = new Method($reflectionMethod, 'Example', $reflectionClass);
+        $method = new Method($reflectionMethod, $reflectionClass);
 
         $output = '/**
  * 


### PR DESCRIPTION
Main fixes:
- Fix magic method generation: Before this, methods added via the 'magic' configuration option were calling a method in the root class with the 'magic' name instead of the 'real' name.
- Fix helper class aliases: Aliases for helper classes were mistreated before: the generator would write empty classes that hid the real helper implementation from the IDE. After the change, classes with the real namespace and class name are only generated for facades.

Miscellaneous:
- Fix `Generator` error output: The `OutputInterface` given to the constructor was never saved.
- Some cleanup of `Alias`, `Method` and `Macro`