### PR TITLE
The 'artisan optimize' command is now deprecated.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ You can now re-generate the docs yourself (for future updates)
 php artisan ide-helper:generate
 ```
 
-Note: `bootstrap/compiled.php` has to be cleared first, so run `php artisan clear-compiled` before generating (and `php artisan optimize` after).
+Note: `bootstrap/compiled.php` has to be cleared first, so run `php artisan clear-compiled` before generating.
 
 You can configure your composer.json to do this after each commit:
 
@@ -75,8 +75,7 @@ You can configure your composer.json to do this after each commit:
     "post-update-cmd": [
         "Illuminate\\Foundation\\ComposerScripts::postUpdate",
         "php artisan ide-helper:generate",
-        "php artisan ide-helper:meta",
-        "php artisan optimize"
+        "php artisan ide-helper:meta"
     ]
 },
 ```


### PR DESCRIPTION
In Laravel 5.5, the `artisan optimize` command is deprecated, so this PR just removes it from the `readme.md`.

See https://laravel.com/docs/5.5/upgrade