### PR TITLE
Simple support for @mixin annotation

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -10,9 +10,6 @@
 
 namespace Barryvdh\LaravelIdeHelper;
 
-use Barryvdh\Reflection\DocBlock;
-use Barryvdh\Reflection\DocBlock\Context;
-
 class Alias
 {
     protected $alias;
@@ -24,20 +21,20 @@ class Alias
     protected $short;
     protected $namespace = '__root';
     protected $root = null;
-    protected $classes = [];
-    protected $methods = [];
-    protected $usedMethods = [];
+    protected $classes = array();
+    protected $methods = array();
+    protected $usedMethods = array();
     protected $valid = false;
-    protected $magicMethods = [];
-    protected $interfaces = [];
+    protected $magicMethods = array();
+    protected $interfaces = array();
 
     /**
      * @param string $alias
      * @param string $facade
-     * @param array  $magicMethods
-     * @param array  $interfaces
+     * @param array $magicMethods
+     * @param array $interfaces
      */
-    public function __construct($alias, $facade, $magicMethods = [], $interfaces = [])
+    public function __construct($alias, $facade, $magicMethods = array(), $interfaces = array())
     {
         $this->alias = $alias;
         $this->magicMethods = $magicMethods;
@@ -59,9 +56,9 @@ class Alias
         $this->detectNamespace();
         $this->detectClassType();
         $this->detectExtendsNamespace();
-
+        
         if ($facade === '\Illuminate\Database\Eloquent\Model') {
-            $this->usedMethods = ['decrement', 'increment'];
+            $this->usedMethods = array('decrement', 'increment');
         }
     }
 
@@ -110,7 +107,7 @@ class Alias
     {
         return $this->extends;
     }
-
+    
     /**
      * Get the class short name which this alias extends
      *
@@ -120,7 +117,7 @@ class Alias
     {
         return $this->extendsClass;
     }
-
+    
     /**
      * Get the namespace of the class which this alias extends
      *
@@ -148,7 +145,6 @@ class Alias
     {
         return $this->short;
     }
-
     /**
      * Get the namespace from the alias
      *
@@ -184,7 +180,7 @@ class Alias
             $this->short = $this->alias;
         }
     }
-
+    
     /**
      * Detect the extends namespace
      */
@@ -391,8 +387,7 @@ class Alias
     /**
      * Output an error.
      *
-     * @param  string $string
-     *
+     * @param  string  $string
      * @return void
      */
     protected function error($string)

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -300,9 +300,15 @@ class Alias
         $mixins = [];
         foreach ($match[1] as $mixin) {
             $quoted = preg_quote($mixin);
-            if (preg_match('@^\s*use (([^;]*\\\\)?' . $quoted . '|[^;]*\s+as\s+' . $quoted . ')@m', $source, $m)) {
-                if ($m[1]) {
-                    $mixins[] = $m[1];
+            if (preg_match('@^\s*use ((?P<name>([^;\s]*\\\\)?' . $quoted . ')|(?P<name_alias>[^;\s]*)\s+as\s+' . $quoted . ')@m', $source, $m)) {
+                if (!empty($m['name']) || !empty($m['name_alias'])) {
+                    if (!empty($m['name'])) {
+                        $mixins[] = $m['name'];
+                    } else {
+                        $mixins[] = $m['name_alias'];
+                    }
+                } else {
+                    $mixins[] = $reflection->getNamespaceName() . '\\' . $mixin;
                 }
             }
         }

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -56,7 +56,7 @@ class Alias
         $this->detectNamespace();
         $this->detectClassType();
         $this->detectExtendsNamespace();
-        
+
         if ($facade === '\Illuminate\Database\Eloquent\Model') {
             $this->usedMethods = array('decrement', 'increment');
         }
@@ -107,7 +107,7 @@ class Alias
     {
         return $this->extends;
     }
-    
+
     /**
      * Get the class short name which this alias extends
      *
@@ -117,7 +117,7 @@ class Alias
     {
         return $this->extendsClass;
     }
-    
+
     /**
      * Get the namespace of the class which this alias extends
      *
@@ -180,7 +180,7 @@ class Alias
             $this->short = $this->alias;
         }
     }
-    
+
     /**
      * Detect the extends namespace
      */
@@ -300,7 +300,8 @@ class Alias
         $mixins = [];
         foreach ($match[1] as $mixin) {
             $quoted = preg_quote($mixin);
-            if (preg_match('@^\s*use ((?P<name>([^;\s]*\\\\)?' . $quoted . ')|(?P<name_alias>[^;\s]*)\s+as\s+' . $quoted . ')@m', $source, $m)) {
+            $pattern = '@^\s*use ((?P<name>([^;\s]*\\\\)?'.$quoted.')|(?P<name_alias>[^;\s]*)\s+as\s+'.$quoted.')@m';
+            if (preg_match( $pattern, $source, $m)) {
                 if (!empty($m['name']) || !empty($m['name_alias'])) {
                     if (!empty($m['name'])) {
                         $mixins[] = $m['name'];

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -299,17 +299,27 @@ class Alias
 
         $mixins = [];
         foreach ($match[1] as $mixin) {
-            $quoted = preg_quote($mixin);
-            $pattern = '@^\s*use ((?P<name>([^;\s]*\\\\)?'.$quoted.')|(?P<name_alias>[^;\s]*)\s+as\s+'.$quoted.')@m';
-            if (preg_match( $pattern, $source, $m)) {
-                if (!empty($m['name']) || !empty($m['name_alias'])) {
-                    if (!empty($m['name'])) {
-                        $mixins[] = $m['name'];
+            if (strpos($mixin, '\\') === false) {
+                $mixins[] = $reflection->getNamespaceName() . '\\' . $mixin;
+            } else {
+                $quoted = preg_quote($mixin);
+                $pattern = (
+                    '@^\s*use ((?P<name>([^;\s]*\\\\)?'
+                    .$quoted
+                    .')|(?P<name_alias>[^;\s]*)\s+as\s+'
+                    .$quoted
+                    .')@m'
+                );
+                if (preg_match( $pattern, $source, $m)) {
+                    if (!empty($m['name']) || !empty($m['name_alias'])) {
+                        if (!empty($m['name'])) {
+                            $mixins[] = $m['name'];
+                        } else {
+                            $mixins[] = $m['name_alias'];
+                        }
                     } else {
-                        $mixins[] = $m['name_alias'];
+                        $mixins[] = $reflection->getNamespaceName() . '\\' . $mixin;
                     }
-                } else {
-                    $mixins[] = $reflection->getNamespaceName() . '\\' . $mixin;
                 }
             }
         }


### PR DESCRIPTION
Allow @mixin classes to be included into target class's alias.
```php
/**
 * Class UserLogic
 *
 * @mixin UserCRUDLogic
 * @mixin UserRelationsLogic
 */
class UserLogic
{
```