### PR TITLE
Changed overwriting confirmation message

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -91,7 +91,7 @@ class ModelsCommand extends Command
         //If filename is default and Write is not specified, ask what to do
         if (!$this->write && $filename === $this->filename && !$this->option('nowrite')) {
             if ($this->confirm(
-                "Do you want to overwrite the existing model files? Choose no to write to $filename instead? (Yes/No): "
+                "Do you want to overwrite the existing model files? Choose no to write to $filename instead?"
             )
             ) {
                 $this->write = true;


### PR DESCRIPTION
When running `php artisan ide-helper:models` below message was presented:
`Do you want to overwrite the existing model files? Choose no to write to _ide_helper_models.php instead? (Yes/No):  (yes/no) [no]:`
This commit changes message to:
`Do you want to overwrite the existing model files? Choose no to write to _ide_helper_models.php instead? (yes/no) [no]:`