### PR TITLE
Support for ::fake() calls

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -53,6 +53,7 @@ class Alias
         }
 
         $this->addClass($this->root);
+        $this->detectFake();
         $this->detectNamespace();
         $this->detectClassType();
         $this->detectExtendsNamespace();
@@ -165,6 +166,30 @@ class Alias
         $this->addMagicMethods();
         $this->detectMethods();
         return $this->methods;
+    }
+
+    /**
+     * Detect class returned by ::fake()
+     */
+    protected function detectFake()
+    {
+        $facade = $this->facade;
+        
+        if (!method_exists($facade, 'fake')) {
+            return;
+        }
+
+        $real = $facade::getFacadeRoot();
+        
+        try {
+            $facade::fake();
+            $fake = $facade::getFacadeRoot();
+            if ($fake !== $real) {
+                $this->addClass(get_class($fake));
+            }
+        } finally {
+            $facade::swap($real);
+        }
     }
 
     /**


### PR DESCRIPTION
The add support for [fakes](https://laravel.com/docs/5.5/mocking). Before, if you called `Mail::fake()`/etc, all the assertion methods would not be auto-completed. This PR fixes that.