### PR TITLE
Eloquent: Write docblocks even if no original found

### DIFF
--- a/src/Eloquent.php
+++ b/src/Eloquent.php
@@ -57,8 +57,16 @@ class Eloquent
         if ($filename) {
             $contents = $files->get($filename);
             if ($contents) {
-                $count    = 0;
-                $contents = str_replace($originalDoc, $docComment, $contents, $count);
+                $count = 0;
+                if ($originalDoc) {
+                    $contents = str_replace($originalDoc, $docComment, $contents, $count);
+                } else {
+                    $classname = $reflection->getShortName();
+                    $needle = "abstract class {$classname}";
+                    $replace = "{$docComment}\n{$needle}";
+                    $contents = str_replace($needle, $replace, $contents, $count);
+                }
+
                 if ($count > 0) {
                     if ($files->put($filename, $contents)) {
                         $command->info('Wrote @mixin \Eloquent to ' . $filename);


### PR DESCRIPTION
This should take care issue https://github.com/barryvdh/laravel-ide-helper/issues/578

So, if there isn't found any original docblocks (like in Laravel 5.5), we'll just prepend the class with generated docblock. Idea taken from ModelsCommand.

Dunno, if this docblock is the way to go atm, but atleast won't get confusing output so easily.

While checking this out, I noticed few things which I'd like to refactor, but I'll create another PR's for those if I manage to find time to them..