### PR TITLE
Keep "null"-ness of column even with model casts

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -291,6 +291,10 @@ class ModelsCommand extends Command
                 continue;
             } else {
                 $this->properties[$name]['type'] = $this->getTypeOverride($realType);
+
+                if (isset($this->nullableColumns[$name])) {
+                    $this->properties[$name]['type'] .= '|null';
+                }                
             }
         }
     }


### PR DESCRIPTION
A cast in Laravel should only affect the type, but not the database intrinsics whether a column accepts `null` or not.

As an example, consider this table (Postgres syntax):
```sql
CREATE TABLE foo (
  some_column jsonb
);
```
This will be generated as: `@property string|null $some_column`

When providing a the following casts on the model:
```php
protected $casts = [
  'some_column' => 'array',
];
```
then the generated property changes to: `@property array $some_column`

However the DB still accepts `null`, but this can't be expressed via the casts.

This change will make the null "sticky" and generate: `@property array|null $some_column`