### PR TITLE
Ignore models by default

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -13,7 +13,6 @@ return array(
 
     'filename'  => '_ide_helper',
     'format'    => 'php',
-    
     'meta_filename' => '.phpstorm.meta.php',
 
     /*
@@ -68,6 +67,18 @@ return array(
         'app',
     ),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Ignore models
+    |--------------------------------------------------------------------------
+    |
+    | Define which of your model ide-helper:models command should ignore
+    | by default.
+    |
+    */
+    'ignored_models' => array(
+
+    ),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -73,9 +73,10 @@ return array(
     |--------------------------------------------------------------------------
     |
     | Define which of your model ide-helper:models command should ignore
-    | by default.
+    | by default. 
     |
     */
+
     'ignored_models' => array(
 
     ),

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -165,7 +165,7 @@ class ModelsCommand extends Command
             }
         }
 
-        $ignore = explode(',', $ignore);
+        $ignore = array_merge(explode(',', $ignore), $this->laravel['config']->get('ignored_models', []));
 
         foreach ($models as $name) {
             if (in_array($name, $ignore)) {


### PR DESCRIPTION
This PR adds ability to define models, which should be ignored by default in config file. Not very big deal, but can be useful in some cases. 

For now, models should be defined in same way as on `ide-helper:models`, example:
```php   
 'ignored_models' => [
        'Models\\Stock\\Products\\Brand'
    ],
```
If this feature required by community, i will try to take care about more simple and convenient way.