### PR TITLE
Use Illuminate\Support\Carbon instead of Carbon\Carbon

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -153,13 +153,13 @@ return array(
      |
      | For example, normally you would see this:
      |
-     |  * @property \Carbon\Carbon $created_at
-     |  * @property \Carbon\Carbon $updated_at
+     |  * @property \Illuminate\Support\Carbon $created_at
+     |  * @property \Illuminate\Support\Carbon $updated_at
      |
      | With this enabled, the properties will be this:
      |
-     |  * @property \Carbon\Carbon $createdAt
-     |  * @property \Carbon\Carbon $updatedAt
+     |  * @property \Illuminate\Support\Carbon $createdAt
+     |  * @property \Illuminate\Support\Carbon $updatedAt
      |
      | Note, it is currently an all-or-nothing option.
      |

--- a/readme.md
+++ b/readme.md
@@ -122,8 +122,8 @@ php artisan ide-helper:models Post
  * @property integer $author_id
  * @property string $title
  * @property string $text
- * @property \Carbon\Carbon $created_at
- * @property \Carbon\Carbon $updated_at
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property \Illuminate\Support\Carbon $updated_at
  * @property-read \User $author
  * @property-read \Illuminate\Database\Eloquent\Collection|\Comment[] $comments
  */

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -277,7 +277,7 @@ class ModelsCommand extends Command
                     break;
                 case 'date':
                 case 'datetime':
-                    $realType = '\Carbon\Carbon';
+                    $realType = '\Illuminate\Support\Carbon';
                     break;
                 case 'collection':
                     $realType = '\Illuminate\Support\Collection';
@@ -337,7 +337,7 @@ class ModelsCommand extends Command
             foreach ($columns as $column) {
                 $name = $column->getName();
                 if (in_array($name, $model->getDates())) {
-                    $type = '\Carbon\Carbon';
+                    $type = '\Illuminate\Support\Carbon';
                 } else {
                     $type = $column->getType()->getName();
                     switch ($type) {


### PR DESCRIPTION
Laravel has a wrapper class for Carbon that it uses for model attributes in the `$dates` array and the `created_at` and `updated_at` attributes. This pull request changes all model docblocks to use the wrapper class instead of the base class.