### PR TITLE
Sort keys for generating stable .phpstorm.meta.php

### DIFF
--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -122,7 +122,11 @@ class MetaCommand extends Command
         $abstracts = $this->laravel->getBindings();
 
         // Return the abstract names only
-        return array_keys($abstracts);
+        $keys = array_keys($abstracts);
+
+        sort($keys);
+
+        return $keys;
     }
 
     /**


### PR DESCRIPTION
The getAbstracts() method may get $abstracts whose keys' order is not fixed from laravel application. It may result to the .phpstorm.meta.php file not be stable, it is a problem when commit this file to Git.