### PR TITLE
Allow command to find and use pivot models

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -182,7 +182,7 @@ class ModelsCommand extends Command
                     $reflectionClass = new \ReflectionClass($name);
 
                     if (!$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Model')
-                            || $reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Relations\Pivot')) {
+                            || !$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Relations\Pivot')) {
                         continue;
                     }
 


### PR DESCRIPTION
Allowing the `ide-helper:models` command to find and use pivot models. Fixing the problem in https://github.com/barryvdh/laravel-ide-helper/issues/253