### PR TITLE
Update to release v1.11.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /vendor
 composer.lock
-.idea
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: php
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+  allow_failures:
+    - php: hhvm
+  fast_finish: true
+
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
+
+before_script:
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction --no-suggest --no-progress
+
+script:
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,15 @@
     ],
     "require": {
         "php": ">=5.3.0",
+        "illuminate/config": "4.x",
         "illuminate/support": "4.x",
         "illuminate/console": "4.x",
         "illuminate/filesystem": "4.x",
+        "illuminate/database": "4.x",
+        "illuminate/view": "4.x",
         "barryvdh/reflection-docblock": "^2.0.4",
-        "symfony/class-loader": "~2.3"
+        "symfony/class-loader": "~2.3",
+        "kdyby/parse-use-statements": "~0.2"
     },
     "require-dev": {
         "doctrine/dbal": "~2.3"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "kdyby/parse-use-statements": "~0.2"
     },
     "require-dev": {
-        "doctrine/dbal": "~2.3"
+        "doctrine/dbal": "~2.3",
+        "phpunit/phpunit": "~4.0"
     },
     "suggest": {
         "doctrine/dbal": "Load information from the database about models for phpdocs (~2.3)"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/filesystem": "4.x",
         "illuminate/database": "4.x",
         "illuminate/view": "4.x",
-        "barryvdh/reflection-docblock": "^2.0.4",
+        "phpdocumentor/reflection-docblock": "^2.0.4",
         "symfony/class-loader": "~2.3",
         "kdyby/parse-use-statements": "~0.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
         "illuminate/database": "4.x",
         "illuminate/view": "4.x",
         "phpdocumentor/reflection-docblock": "^2.0.4",
-        "symfony/class-loader": "~2.3",
-        "kdyby/parse-use-statements": "~0.2"
+        "symfony/class-loader": "~2.3"
     },
     "require-dev": {
         "doctrine/dbal": "~2.3",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.0/phpunit.xsd"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Package Test Suite">
+            <directory suffix=".php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/readme.md
+++ b/readme.md
@@ -18,15 +18,18 @@ Note: You do need CodeIntel for Sublime Text: https://github.com/SublimeCodeInte
 
 It's possible to generate a PhpStorm meta file, to [add support for factory design pattern](https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata). For Laravel, this means we can make PhpStorm understand what kind of object we are resolving from the IoC Container. For example, `events` will return ann `Illuminate\Events\Dispatcher` object, so with the meta file you can call `app('events')` and it will autocomplete the Dispatcher methods.
 
-    php artisan ide-helper:meta
-    
-    app('events')->fire();
-    \App::make('events')->fire();
-    
-    /** @var \Illuminate\Foundation\Application $app */
-    $app->make('events')->fire();
+```bash
+php artisan ide-helper:meta
+```
+```php
+app('events')->fire();
+\App::make('events')->fire();
 
-Pre-generated example: https://gist.github.com/barryvdh/bb6ffc5d11e0a75dba67    
+/** @var \Illuminate\Foundation\Application $app */
+$app->make('events')->fire();
+```
+
+Pre-generated example: https://gist.github.com/barryvdh/bb6ffc5d11e0a75dba67
 
 > Note: You might need to restart PhpStorm and make sure `.phpstorm.meta.php` is indexed.
 
@@ -34,31 +37,41 @@ Pre-generated example: https://gist.github.com/barryvdh/bb6ffc5d11e0a75dba67
 
 Require this package with composer using the following command:
 
-    composer require barryvdh/laravel-ide-helper ~1.11
+```bash
+composer require barryvdh/laravel-ide-helper ~1.11
+```
 
 After updating composer, add the ServiceProvider to the providers array in `app/config/app.php`
 
-    'Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider',
+```php
+'Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider',
+```
 
 You can now re-generate the docs yourself (for future updates) in artisan
 
-    php artisan ide-helper:generate
+```bash
+php artisan ide-helper:generate
+```
 
 Note: bootstrap/compiled.php has to be cleared first, so run `php artisan clear-compiled` before generating (and `php artisan optimize` after..)
 
 You can configure your composer.json to do this after each commit:
 
-    "scripts":{
-        "post-update-cmd":[
-            "php artisan clear-compiled",
-            "php artisan ide-helper:generate",
-            "php artisan optimize"
-        ]
-    },
+```json
+"scripts":{
+    "post-update-cmd":[
+        "php artisan clear-compiled",
+        "php artisan ide-helper:generate",
+        "php artisan optimize"
+    ]
+},
+```
 
 You can also publish the config-file to change implementations (ie. interface to specific class) or set defaults for --helpers or --sublime.
 
-    php artisan config:publish barryvdh/laravel-ide-helper
+```bash
+php artisan config:publish barryvdh/laravel-ide-helper
+```
 
 The generator tries to identify the real class, but if it cannot be found, you can define it in the config file.
 
@@ -70,7 +83,7 @@ The Illuminate/Support/helpers.php is already set-up, but you can add/remove you
 
 ### Automatic phpDocs for Models
 
-> **Note:** Since v1.10 you need to require `doctrine/dbal: ~2.3` in your own composer.json. 
+> **Note:** Since v1.10 you need to require `doctrine/dbal: ~2.3` in your own composer.json.
 
 If you don't want to write your properties yourself, you can use the command `ide-helper:models` to generate
 phpDocs, based on table columns, relations and getters/setters. You can write the comments directly to your Model file, using the `--write (-W)` option. By default, you are asked to overwrite or write to a separate file (\_ide\_helper\_models.php) (You can force No with `--nowrite (-N)`).
@@ -78,34 +91,43 @@ Please make sure to backup your models, before writing the info.
 It should keep the existing comments and only append new properties/methods. The existing phpdoc is replaced, or added if not found.
 With the `--reset (-R)` option, the existing phpdocs are ignored, only the newly found columns/relations are saved as phpdocs.
 
-    php artisan ide-helper:models Post
-
-    /**
-     * An Eloquent Model: 'Post'
-     *
-     * @property integer $id
-     * @property integer $author_id
-     * @property string $title
-     * @property string $text
-     * @property \Carbon\Carbon $created_at
-     * @property \Carbon\Carbon $updated_at
-     * @property-read \User $author
-     * @property-read \Illuminate\Database\Eloquent\Collection|\Comment[] $comments
-     */
+```bash
+php artisan ide-helper:models Post
+```
+```php
+/**
+ * An Eloquent Model: 'Post'
+ *
+ * @property integer $id
+ * @property integer $author_id
+ * @property string $title
+ * @property string $text
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ * @property-read \User $author
+ * @property-read \Illuminate\Database\Eloquent\Collection|\Comment[] $comments
+ */
+```
 
 By default, models in app/models are scanned. The optional argument tells what models to use (also outside app/models).
 
-    php artisan ide-helper:models Post User
+```bash
+php artisan ide-helper:models Post User
+```
 
 You can also scan a different directory, using the --dir option (relative from the base path):
 
-    php artisan ide-helper:models --dir="app/workbench/name/package/models" --dir="app/src/Model"
-   
+```bash
+php artisan ide-helper:models --dir="app/workbench/name/package/models" --dir="app/src/Model"
+```
+
 You can publish the config file (`php artisan config:publish barryvdh/laravel-ide-helper`) and set the default directories.
 
 Models can be ignored using the --ignore (-I) option
 
-    php artisan ide-helper:models --ignore="Post,User"
+```bash
+php artisan ide-helper:models --ignore="Post,User"
+```
 
 Note: With namespaces, wrap your model name in " signs: `php artisan ide-helper:models "API\User"`, or escape the slashes (`Api\\User`)
 

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 
 _Checkout [this Laracasts video](https://laracasts.com/series/how-to-be-awesome-in-phpstorm/episodes/15) for a quick introduction/explanation!_
 
-This packages generates a file that your IDE can understand, so it can provide accurate autocompletion. Generation is done, based on the files in your project, so they are alway up-to-date.
+This packages generates a file that your IDE can understand, so it can provide accurate autocompletion. Generation is done, based on the files in your project, so they are always up-to-date.
 If you don't want to generate it, you can add a pre-generated file to the root folder of your laravel project. (But this isn't as up-to-date as self generated files)
 
 * Generated version: https://gist.github.com/barryvdh/5227822

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -53,8 +53,8 @@ class Alias
         $this->addClass($this->root);
         $this->detectNamespace();
         $this->detectClassType();
-        
-        if($facade === '\Illuminate\Database\Eloquent\Model'){
+
+        if ($facade === '\Illuminate\Database\Eloquent\Model') {
             $this->usedMethods = array('decrement', 'increment');
         }
     }
@@ -70,8 +70,8 @@ class Alias
         foreach ($classes as $class) {
             if (class_exists($class) || interface_exists($class)) {
                 $this->classes[] = $class;
-            }else{
-                echo "Class not exists: $class\r\n";
+            } else {
+                $this->error('Class not exists: ' . $class);
             }
         }
     }
@@ -86,11 +86,11 @@ class Alias
     }
 
     /**
-     * Get the classtype, 'interface' or 'class'
+     * Get the classType, 'interface' or 'class'
      *
      * @return string
      */
-    public function getClasstype()
+    public function getClassType()
     {
         return $this->classType;
     }
@@ -117,10 +117,14 @@ class Alias
 
     /**
      * Return the short name (without namespace)
+     *
+     * @return string
      */
-    public function getShortName(){
+    public function getShortName()
+    {
         return $this->short;
     }
+
     /**
      * Get the namespace from the alias
      *
@@ -134,7 +138,7 @@ class Alias
     /**
      * Get the methods found by this Alias
      *
-     * @return array
+     * @return array|Method[]
      */
     public function getMethods()
     {
@@ -152,7 +156,7 @@ class Alias
             $nsParts = explode('\\', $this->alias);
             $this->short = array_pop($nsParts);
             $this->namespace = implode('\\', $nsParts);
-        }else{
+        } else {
             $this->short = $this->alias;
         }
     }
@@ -201,10 +205,10 @@ class Alias
             //When the database connection is not set, some classes will be skipped
         } catch (\PDOException $e) {
             $this->error(
-                "PDOException: " . $e->getMessage() . "\nPlease configure your database connection correctly, or use the sqlite memory driver (-M). Skipping $facade."
+                'PDOException: ' . $e->getMessage() . "\nPlease configure your database connection correctly, or use the sqlite memory driver (-M). Skipping $facade."
             );
         } catch (\Exception $e) {
-            $this->error("Exception: " . $e->getMessage() . "\nSkipping $facade.");
+            $this->error('Exception: ' . $e->getMessage() . "\nSkipping $facade.");
         }
     }
 
@@ -227,16 +231,16 @@ class Alias
      */
     protected function addMagicMethods()
     {
-        foreach($this->magicMethods as $magic => $real){
+        foreach ($this->magicMethods as $magic => $real) {
             list($className, $name) = explode('::', $real);
-            if(!class_exists($className) && !interface_exists($className)){
+            if (!class_exists($className) && !interface_exists($className)) {
                 continue;
             }
             $method = new \ReflectionMethod($className, $name);
             $class = new \ReflectionClass($className);
 
-            if(!in_array($method->name, $this->usedMethods)){
-                if($class !== $this->root){
+            if (!in_array($method->name, $this->usedMethods)) {
+                if ($class !== $this->root) {
                     $this->methods[] = new Method($method, $this->alias, $class, $magic, $this->interfaces);
                 }
                 $this->usedMethods[] = $magic;
@@ -251,7 +255,6 @@ class Alias
      */
     protected function detectMethods()
     {
-
         foreach ($this->classes as $class) {
             $reflection = new \ReflectionClass($class);
 
@@ -274,7 +277,7 @@ class Alias
     /**
      * Output an error.
      *
-     * @param  string  $string
+     * @param  string $string
      * @return void
      */
     protected function error($string)

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -17,7 +17,6 @@ use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
-
 /**
  * A command to generate autocomplete information for your IDE
  *
@@ -27,16 +26,12 @@ class GeneratorCommand extends Command
 {
 
     /**
-     * The console command name.
-     *
-     * @var string
+     * {@inheritdoc}
      */
     protected $name = 'ide-helper:generate';
 
     /**
-     * The console command description.
-     *
-     * @var string
+     * {@inheritdoc}
      */
     protected $description = 'Generate a new IDE Helper file.';
 
@@ -51,18 +46,14 @@ class GeneratorCommand extends Command
 
     protected $onlyExtend;
 
-
     /**
+     * {@inheritdoc}
      *
      * @param \Illuminate\Config\Repository $config
      * @param \Illuminate\Filesystem\Filesystem $files
      * @param \Illuminate\View\Factory $view
      */
-    public function __construct(
-        ConfigRepository $config,
-        Filesystem $files, /* Illuminate\View\Factory */
-        $view
-    ) {
+    public function __construct(ConfigRepository $config, Filesystem $files, $view) {
         $this->config = $config;
         $this->files = $files;
         $this->view = $view;
@@ -94,7 +85,6 @@ class GeneratorCommand extends Command
             if ($this->option('memory')) {
                 $this->useMemoryDriver();
             }
-
 
             $helpers = '';
             if ($this->option('helpers') || ($this->config->get('laravel-ide-helper::include_helpers'))) {
@@ -133,9 +123,7 @@ class GeneratorCommand extends Command
     }
 
     /**
-     * Get the console command arguments.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     protected function getArguments()
     {
@@ -149,19 +137,17 @@ class GeneratorCommand extends Command
     }
 
     /**
-     * Get the console command options.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     protected function getOptions()
     {
         $format = $this->config->get('laravel-ide-helper::format');
 
         return array(
-            array('format', "F", InputOption::VALUE_OPTIONAL, 'The format for the IDE Helper', $format),
-            array('helpers', "H", InputOption::VALUE_NONE, 'Include the helper files'),
-            array('memory', "M", InputOption::VALUE_NONE, 'Use sqlite memory driver'),
-            array('sublime', "S", InputOption::VALUE_NONE, 'DEPRECATED: Use different style for SublimeText CodeIntel'),
+            array('format', 'F', InputOption::VALUE_OPTIONAL, 'The format for the IDE Helper', $format),
+            array('helpers', 'H', InputOption::VALUE_NONE, 'Include the helper files'),
+            array('memory', 'M', InputOption::VALUE_NONE, 'Use sqlite memory driver'),
+            array('sublime', 'S', InputOption::VALUE_NONE, 'DEPRECATED: Use different style for SublimeText CodeIntel'),
         );
     }
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -15,10 +15,9 @@ use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\ClassLoader\ClassMapGenerator;
-use Barryvdh\Reflection\DocBlock;
-use Barryvdh\Reflection\DocBlock\Context;
-use Barryvdh\Reflection\DocBlock\Tag;
-use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\Context;
+use phpDocumentor\Reflection\DocBlock\Tag;
 
 /**
  * A command to generate autocomplete information for your IDE
@@ -399,7 +398,7 @@ class ModelsCommand extends Command
         $properties = array();
         $methods = array();
         foreach ($phpdoc->getTags() as $tag) {
-            /* @var Tag|\Barryvdh\Reflection\DocBlock\Tag\PropertyTag|\Barryvdh\Reflection\DocBlock\Tag\MethodTag $tag */
+            /* @var Tag|Tag\PropertyTag|Tag\MethodTag $tag */
             $name = $tag->getName();
             if ($name == 'property' || $name == 'property-read' || $name == 'property-write') {
                 $properties[] = $tag->getVariableName();
@@ -433,7 +432,7 @@ class ModelsCommand extends Command
             $phpdoc->appendTag($tag);
         }
 
-        $serializer = new DocBlockSerializer();
+        $serializer = new DocBlock\Serializer();
         $serializer->getDocComment($phpdoc);
         $docComment = $serializer->getDocComment($phpdoc);
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -10,7 +10,7 @@
 
 namespace Barryvdh\LaravelIdeHelper;
 
-use Illuminate\Foundation\AliasLoader;
+use /** @noinspection PhpUndefinedNamespaceInspection,PhpUndefinedClassInspection */Illuminate\Foundation\AliasLoader;
 use Illuminate\Config\Repository as ConfigRepository;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -36,11 +36,8 @@ class Generator
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @param string $helpers
      */
-    public function __construct(ConfigRepository $config,
-        /* Illuminate\View\Factory */ $view,
-        OutputInterface $output = null,
-        $helpers = ''
-    ) {
+    public function __construct(ConfigRepository $config, $view, OutputInterface $output = null, $helpers = '')
+    {
         $this->config = $config;
         $this->view = $view;
 
@@ -50,6 +47,7 @@ class Generator
         $this->extra = array_merge($this->extra, $this->config->get('laravel-ide-helper::extra'));
         $this->magic = array_merge($this->magic, $this->config->get('laravel-ide-helper::magic'));
         $this->interfaces = array_merge($this->interfaces, $this->config->get('laravel-ide-helper::interfaces'));
+
         // Make all interface classes absolute
         foreach ($this->interfaces as &$interface) {
             $interface = '\\' . ltrim($interface, '\\');
@@ -60,13 +58,13 @@ class Generator
     /**
      * Generate the helper file contents;
      *
-     * @param  string  $format  The format to generate the helper in (php/json)
+     * @param  string $format The format to generate the helper in (php/json)
      * @return string;
      */
     public function generate($format = 'php')
     {
         // Check if the generator for this format exists
-        $method = 'generate'.ucfirst($format).'Helper';
+        $method = 'generate' . ucfirst($format) . 'Helper';
         if (method_exists($this, $method)) {
             return $this->$method();
         }
@@ -88,10 +86,10 @@ class Generator
     {
         $classes = array();
         foreach ($this->getNamespaces() as $aliases) {
-            foreach($aliases as $alias) {
+            foreach ($aliases as $alias) {
                 $functions = array();
                 foreach ($alias->getMethods() as $method) {
-                    $functions[$method->getName()] = '('. $method->getParamsWithDefault().')';
+                    $functions[$method->getName()] = '(' . $method->getParamsWithDefault() . ')';
                 }
                 $classes[$alias->getAlias()] = array(
                     'functions' => $functions,
@@ -113,59 +111,66 @@ class Generator
 
     protected function detectDrivers()
     {
-        try{
+        try {
             if (class_exists('Auth') && is_a('Auth', '\Illuminate\Support\Facades\Auth', true)) {
+                /** @noinspection PhpUndefinedClassInspection */
                 $class = get_class(\Auth::driver());
                 $this->extra['Auth'] = array($class);
                 $this->interfaces['\Illuminate\Auth\UserProviderInterface'] = $class;
             }
-        }catch (\Exception $e) {}
+        } catch (\Exception $e) {}
 
-        try{
+        try {
             if (class_exists('DB') && is_a('DB', '\Illuminate\Support\Facades\DB', true)) {
+                /** @noinspection PhpUndefinedClassInspection */
                 $class = get_class(\DB::connection());
                 $this->extra['DB'] = array($class);
                 $this->interfaces['\Illuminate\Database\ConnectionInterface'] = $class;
             }
-        }catch (\Exception $e) {}
+        } catch (\Exception $e) {}
 
-        try{
+        try {
             if (class_exists('Cache') && is_a('Cache', '\Illuminate\Support\Facades\Cache', true)) {
+                /** @noinspection PhpUndefinedClassInspection */
                 $driver = get_class(\Cache::driver());
+                /** @noinspection PhpUndefinedClassInspection */
                 $store = get_class(\Cache::getStore());
                 $this->extra['Cache'] = array($driver, $store);
                 $this->interfaces['\Illuminate\Cache\StoreInterface'] = $store;
             }
-        }catch (\Exception $e) {}
+        } catch (\Exception $e) {}
 
-        try{
+        try {
             if (class_exists('Queue') && is_a('Queue', '\Illuminate\Support\Facades\Queue', true)) {
+                /** @noinspection PhpUndefinedClassInspection */
                 $class = get_class(\Queue::connection());
                 $this->extra['Queue'] = array($class);
                 $this->interfaces['\Illuminate\Queue\QueueInterface'] = $class;
             }
-        }catch (\Exception $e) {}
+        } catch (\Exception $e) {}
 
-        try{
-            if (class_exists('SSH') && is_a('SSH', '\Illuminate\Support\Facades\SSH', true)){
+        try {
+            if (class_exists('SSH') && is_a('SSH', '\Illuminate\Support\Facades\SSH', true)) {
+                /** @noinspection PhpUndefinedClassInspection */
                 $class = get_class(\SSH::connection());
                 $this->extra['SSH'] = array($class);
                 $this->interfaces['\Illuminate\Remote\ConnectionInterface'] = $class;
             }
-        }catch (\Exception $e) {}
+        } catch (\Exception $e) {}
 
     }
 
     /**
      * Find all namespaces/aliases that are valid for us to render
      *
-     * @return array
+     * @return array|Alias[][]
      */
     protected function getNamespaces()
     {
         $namespaces = array();
 
         // Get all aliases
+        /** @noinspection PhpUndefinedClassInspection */
         foreach (AliasLoader::getInstance()->getAliases() as $name => $facade) {
             $magicMethods = array_key_exists($name, $this->magic) ? $this->magic[$name] : array();
             $alias = new Alias($name, $facade, $magicMethods, $this->interfaces);
@@ -197,15 +202,20 @@ class Generator
     public function getDriver($alias)
     {
         try {
-            if ($alias == "Auth") {
+            if ($alias == 'Auth') {
+                /** @noinspection PhpUndefinedClassInspection */
                 $driver = \Auth::driver();
-            } elseif ($alias == "DB") {
+            } elseif ($alias == 'DB') {
+                /** @noinspection PhpUndefinedClassInspection */
                 $driver = \DB::connection();
-            } elseif ($alias == "Cache") {
+            } elseif ($alias == 'Cache') {
+                /** @noinspection PhpUndefinedClassInspection */
                 $driver = get_class(\Cache::driver());
+                /** @noinspection PhpUndefinedClassInspection */
                 $store = get_class(\Cache::getStore());
                 return array($driver, $store);
-            } elseif ($alias == "Queue") {
+            } elseif ($alias == 'Queue') {
+                /** @noinspection PhpUndefinedClassInspection */
                 $driver = \Queue::connection();
             } else {
                 return false;
@@ -221,14 +231,14 @@ class Generator
     /**
      * Write a string as error output.
      *
-     * @param  string  $string
+     * @param  string $string
      * @return void
      */
     protected function error($string)
     {
-        if($this->output){
+        if ($this->output) {
             $this->output->writeln("<error>$string</error>");
-        }else{
+        } else {
             echo $string . "\r\n";
         }
     }

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -15,20 +15,19 @@ use Barryvdh\LaravelIdeHelper\Console\MetaCommand;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Console\GeneratorCommand;
 
+/**
+ * @property \Illuminate\Container\Container $app
+ */
 class IdeHelperServiceProvider extends ServiceProvider
 {
 
     /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
+     * {@inheritdoc}
      */
     protected $defer = true;
 
     /**
-     * Bootstrap the application events.
-     *
-     * @return void
+     * {@inheritdoc}
      */
     public function boot()
     {
@@ -36,9 +35,7 @@ class IdeHelperServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register the service provider.
-     *
-     * @return void
+     * {@inheritdoc}
      */
     public function register()
     {
@@ -49,60 +46,34 @@ class IdeHelperServiceProvider extends ServiceProvider
         );
 
         $this->app['command.ide-helper.models'] = $this->app->share(
-            function () {
-                return new ModelsCommand();
+            function ($app) {
+                return new ModelsCommand($app);
             }
         );
-        
+
         $this->app['command.ide-helper.meta'] = $this->app->share(
-          function ($app) {
-              return new MetaCommand($app['files'], $app['view']);
-          }
+            function ($app) {
+                return new MetaCommand($app);
+            }
         );
 
         $this->commands('command.ide-helper.generate', 'command.ide-helper.models', 'command.ide-helper.meta');
     }
 
     /**
-     * Get the services provided by the provider.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function provides()
     {
-        return array('command.ide-helper.generate', 'command.ide-helper.models');
+        return array('command.ide-helper.generate', 'command.ide-helper.models', 'command.ide-helper.meta');
     }
-    
+
     /**
-     * Register the package's component namespaces.
-     *
-     * @param  string  $package
-     * @param  string  $namespace
-     * @param  string  $path
-     * @return void
+     * {@inheritdoc}
      */
-    public function package($package, $namespace = null, $path = null)
+    protected function getAppViewPath($package, $namespace = null)
     {
-
-        // Is it possible to register the config?
-        if (method_exists($this->app['config'], 'package')) {
-            $this->app['config']->package($package, $path.'/config', $namespace);
-        } else {
-            // Load the config for now..
-            $config = $this->app['files']->getRequire($path .'/config/config.php');
-            foreach($config as $key => $value){
-                $this->app['config']->set($namespace.'::'.$key, $value);
-            }
-        }
-
-        // Register view files
-        $appView = $this->app['path']."/views/packages/{$package}";
-        if ($this->app['files']->isDirectory($appView))
-        {
-            $this->app['view']->addNamespace($namespace, $appView);
-        }
-
-        $this->app['view']->addNamespace($namespace, $path.'/views');
+        return $this->app['path'] . "/views/packages/{$package}";
     }
 
 }

--- a/src/Method.php
+++ b/src/Method.php
@@ -24,7 +24,6 @@ class Method
     /** @var \ReflectionMethod */
     protected $method;
 
-    protected $output = '';
     protected $name;
     protected $namespace;
     protected $params = array();
@@ -230,7 +229,16 @@ class Method
      */
     protected static function convertKeywords($string)
     {
-        return preg_replace(array('/(^|\|)Closure(\||$)/', '/(^|\|)dynamic(\||$)/'), array('$1\Closure$2', '$1mixed$2'), $string);
+        $types = explode('|', $string);
+        foreach ($types as &$type) {
+            if ($type === 'Closure')
+                $type = '\Closure';
+            elseif ($type === 'dynamic')
+                $type = 'mixed';
+            elseif (strrpos($type, '\\') && $type[0] !== '\\' && (class_exists($type) || interface_exists($type)))
+                $type = '\\' . $type;
+        }
+        return implode('|', $types);
     }
 
     /**

--- a/src/Method.php
+++ b/src/Method.php
@@ -16,13 +16,14 @@ use Barryvdh\Reflection\DocBlock\Tag;
 use Barryvdh\Reflection\DocBlock\Tag\ReturnTag;
 use Barryvdh\Reflection\DocBlock\Tag\ParamTag;
 use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
+use Kdyby\ParseUseStatements\UseStatements;
 
 class Method
 {
-    /** @var \Barryvdh\Reflection\DocBlock  */
+    /** @var \Barryvdh\Reflection\DocBlock */
     protected $phpdoc;
 
-    /** @var \ReflectionMethod  */
+    /** @var \ReflectionMethod */
     protected $method;
 
     protected $output = '';
@@ -36,7 +37,7 @@ class Method
     /**
      * @param \ReflectionMethod $method
      * @param string $alias
-     * @param string $class
+     * @param \ReflectionClass $class
      * @param string|null $methodName
      * @param array $interfaces
      */
@@ -45,15 +46,15 @@ class Method
         $this->method = $method;
         $this->interfaces = $interfaces;
         $this->name = $methodName ?: $method->name;
-        $this->namespace = $method->getDeclaringClass()->getNamespaceName();
+        $declaringClass = $method->getDeclaringClass();
+        $this->namespace = $declaringClass->getNamespaceName();
 
         //Create a DocBlock and serializer instance
-        $this->phpdoc = new DocBlock($method, new Context($this->namespace));
+        $this->phpdoc = new DocBlock($method, new Context($this->namespace, static::getUseStatements($declaringClass)));
 
         //Normalize the description and inherit the docs from parents/interfaces
         try {
-            $this->normalizeParams($this->phpdoc);
-            $this->normalizeReturn($this->phpdoc);
+            $this->normalizeReturnTags($this->phpdoc);
             $this->normalizeDescription($this->phpdoc);
         } catch (\Exception $e) {}
 
@@ -61,10 +62,9 @@ class Method
         $this->getParameters($method);
 
         //Make the method static
-        $this->phpdoc->appendTag(Tag::createInstance('@static', $this->phpdoc));
+        //$this->phpdoc->appendTag(Tag::createInstance('@static', $this->phpdoc));
 
-        //Reference the 'real' function in the declaringclass
-        $declaringClass = $method->getDeclaringClass();
+        //Reference the 'real' function in the declaringClass
         $this->declaringClassName = '\\' . ltrim($declaringClass->name, '\\');
         $this->root = '\\' . ltrim($class->getName(), '\\');
     }
@@ -93,12 +93,17 @@ class Method
      * Get the docblock for this method
      *
      * @param string $prefix
-     * @return mixed
+     * @param bool $trim
+     * @return string
      */
-    public function getDocComment($prefix = "\t\t")
+    public function getDocComment($prefix = "\t\t", $trim = false)
     {
         $serializer = new DocBlockSerializer(1, $prefix);
-        return $serializer->getDocComment($this->phpdoc);
+        $str = $serializer->getDocComment($this->phpdoc);
+        if ($trim) {
+            $str = preg_replace(array('/\s+$/m', '#^(\s*/\*\*[\r\n])(?:\s*\*[\r\n])+#u', '#(?:[\r\n]\s*\*)+([\r\n]\s*\*/)$#u'), array('', '$1', '$1'), $str);
+        }
+        return $str;
     }
 
     /**
@@ -112,10 +117,30 @@ class Method
     }
 
     /**
+     * Checks whether the method is deprecated
+     *
+     * @return bool
+     */
+    public function isDeprecated()
+    {
+        return $this->phpdoc->hasTag('deprecated');
+    }
+
+    /**
+     * Get the declared parameters for this method
+     *
+     * @return array
+     */
+    public function getDocParams()
+    {
+        return $this->phpdoc->getTagsByName('param');
+    }
+
+    /**
      * Get the parameters for this method
      *
-     * @param bool $implode Wether to implode the array or not
-     * @return string
+     * @param bool $implode Whether to implode the array or not
+     * @return string|array
      */
     public function getParams($implode = true)
     {
@@ -125,8 +150,8 @@ class Method
     /**
      * Get the parameters for this method including default values
      *
-     * @param bool $implode Wether to implode the array or not
-     * @return string
+     * @param bool $implode Whether to implode the array or not
+     * @return string|array
      */
     public function getParamsWithDefault($implode = true)
     {
@@ -144,47 +169,18 @@ class Method
         $description = $phpdoc->getText();
 
         //Loop through parents/interfaces, to fill in {@inheritdoc}
-        if (strpos($description, '{@inheritdoc}') !== false) {
-            $inheritdoc = $this->getInheritDoc($this->method);
+        if (stripos($description, '{@inheritdoc}') !== false && ($inheritdoc = $this->getInheritDoc($this->method))) {
             $inheritDescription = $inheritdoc->getText();
 
-            $description = str_replace('{@inheritdoc}', $inheritDescription, $description);
+            $description = str_ireplace('{@inheritdoc}', $inheritDescription, $description);
             $phpdoc->setText($description);
 
-            $this->normalizeParams($inheritdoc);
-            $this->normalizeReturn($inheritdoc);
+            $this->normalizeReturnTags($inheritdoc);
 
             //Add the tags that are inherited
-            $inheritTags = $inheritdoc->getTags();
-            if ($inheritTags) {
-                /** @var Tag $tag */
-                foreach ($inheritTags as $tag) {
-                    $tag->setDocBlock();
-                    $phpdoc->appendTag($tag);
-                }
-            }
-        }
-    }
-
-    /**
-     * Normalize the parameters
-     *
-     * @param DocBlock $phpdoc
-     */
-    protected function normalizeParams(DocBlock $phpdoc)
-    {
-        //Get the return type and adjust them for beter autocomplete
-        $paramTags = $phpdoc->getTagsByName('param');
-        if ($paramTags) {
-            /** @var ParamTag $tag */
-            foreach($paramTags as $tag){
-                // Convert the keywords
-                $content = $this->convertKeywords($tag->getContent());
-                $tag->setContent($content);
-
-                // Get the expanded type and re-set the content
-                $content = $tag->getType() . ' ' . $tag->getVariableName() . ' ' . $tag->getDescription();
-                $tag->setContent(trim($content));
+            foreach ($inheritdoc->getTags() as $tag) {
+                $tag->setDocBlock();
+                $phpdoc->appendTag($tag);
             }
         }
     }
@@ -194,53 +190,54 @@ class Method
      *
      * @param DocBlock $phpdoc
      */
-    protected function normalizeReturn(DocBlock $phpdoc)
+    protected function normalizeReturnTags(DocBlock $phpdoc)
     {
-        //Get the return type and adjust them for beter autocomplete
-        $returnTags = $phpdoc->getTagsByName('return');
-        if ($returnTags) {
-            /** @var ReturnTag $tag */
-            $tag = reset($returnTags);
-            // Get the expanded type
-            $returnValue = $tag->getType();
+        $this->return = null;
 
-            // Replace the interfaces
-            foreach($this->interfaces as $interface => $real){
-                $returnValue = str_replace($interface, $real, $returnValue);
+        //Get the return type and adjust them for better autocomplete
+        foreach ($phpdoc->getTags() as $tag) {
+            if ($tag instanceof ReturnTag) {
+                // Convert the keywords
+                $typeValue = static::convertKeywords($tag->getType(false));
+                $tag->setType($typeValue);
+
+                // Get the expanded type
+                $typeValue = $tag->getType();
+
+                // Replace the interfaces
+                if (get_class($tag) === ReturnTag::class) {
+                    foreach ($this->interfaces as $interface => $real) {
+                        $typeValue = preg_replace('/(^|\|)' . preg_quote($interface, '/') . '\b/', $real, $typeValue);
+                    }
+                    $this->return = $typeValue;
+                }
+
+                // Re-set the type
+                $tag->setType($typeValue);
             }
-
-            // Set the changed content
-            $tag->setContent($returnValue . ' ' . $tag->getDescription());
-            $this->return = $returnValue;
-        }else{
-            $this->return = null;
         }
     }
 
     /**
-     * Convert keywwords that are incorrect.
+     * Convert keywords that are incorrect.
      *
      * @param  string $string
      * @return string
      */
-    protected function convertKeywords($string)
+    protected static function convertKeywords($string)
     {
-        $string = str_replace('\Closure', 'Closure', $string);
-        $string = str_replace('Closure', '\Closure', $string);
-        $string = str_replace('dynamic', 'mixed', $string);
-
-        return $string;
+        return preg_replace(array('/(^|\|)Closure(\||$)/', '/(^|\|)dynamic(\||$)/'), array('$1\Closure$2', '$1mixed$2'), $string);
     }
 
     /**
      * Should the function return a value?
      *
-     * @return bool
+     * @return bool|int
      */
     public function shouldReturn()
     {
-        if($this->return !== "void" && $this->method->name !== "__construct"){
-            return true;
+        if ($this->return !== 'void' && $this->method->name !== '__construct') {
+            return isset($this->return) ? true : 1;
         }
 
         return false;
@@ -249,17 +246,19 @@ class Method
     /**
      * Get the parameters and format them correctly
      *
-     * @param $method
-     * @return array
+     * @param \ReflectionMethod $method
+     * @return void
      */
     public function getParameters($method)
     {
-        //Loop through the default values for paremeters, and make the correct output string
+        //Loop through the default values for parameters, and make the correct output string
         $params = array();
         $paramsWithDefault = array();
+
         foreach ($method->getParameters() as $param) {
             $paramStr = '$' . $param->getName();
             $params[] = $paramStr;
+
             if ($param->isOptional()) {
                 $default = $param->isDefaultValueAvailable() ? $param->getDefaultValue() : null;
                 if (is_bool($default)) {
@@ -275,6 +274,7 @@ class Method
                 }
                 $paramStr .= " = $default";
             }
+
             $paramsWithDefault[] = $paramStr;
         }
 
@@ -284,7 +284,7 @@ class Method
 
     /**
      * @param \ReflectionMethod $reflectionMethod
-     * @return DocBlock
+     * @return DocBlock|null
      */
     protected function getInheritDoc($reflectionMethod)
     {
@@ -298,14 +298,24 @@ class Method
         }
         if ($method) {
             $namespace = $method->getDeclaringClass()->getNamespaceName();
-            $phpdoc = new DocBlock($method, new Context($namespace));
-            
-            if (strpos($phpdoc->getText(), '{@inheritdoc}') !== false) {
+            $phpdoc = new DocBlock($method, new Context($namespace, static::getUseStatements($method->getDeclaringClass())));
+
+            if (stripos($phpdoc->getText(), '{@inheritdoc}') !== false) {
                 //Not at the end yet, try another parent/interface..
                 return $this->getInheritDoc($method);
             } else {
                 return $phpdoc;
             }
+        }
+        return null;
+    }
+
+    protected static function getUseStatements(\ReflectionClass $class)
+    {
+        try {
+            return UseStatements::getUseStatements($class);
+        } catch (\Exception $e) {
+            return array();
         }
     }
 }

--- a/src/Method.php
+++ b/src/Method.php
@@ -14,7 +14,6 @@ use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlock\Context;
 use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Reflection\DocBlock\Tag\ReturnTag;
-use Kdyby\ParseUseStatements\UseStatements;
 
 class Method
 {
@@ -325,7 +324,7 @@ class Method
     protected static function getUseStatements(\ReflectionClass $class)
     {
         try {
-            return UseStatements::getUseStatements($class);
+            return PhpReflection::getUseStatements($class);
         } catch (\Exception $e) {
             return array();
         }

--- a/src/PhpReflection.php
+++ b/src/PhpReflection.php
@@ -1,0 +1,166 @@
+<?php namespace Barryvdh\LaravelIdeHelper;
+
+/**
+ * PHP reflection helpers.
+ *
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ *
+ * @see https://github.com/nette/di/blob/v2.4/src/DI/PhpReflection.php
+ */
+class PhpReflection
+{
+    /**
+     * Expands class name into full name.
+     *
+     * @param  string $name
+     * @param  \ReflectionClass $rc
+     * @return string  full name
+     * @throws \InvalidArgumentException
+     */
+    public static function expandClassName($name, \ReflectionClass $rc)
+    {
+        $lower = strtolower($name);
+        if (empty($name)) {
+            throw new \InvalidArgumentException('Class name must not be empty.');
+        } elseif (self::isBuiltinType($lower)) {
+            return $lower;
+        } elseif ($lower === 'self' || $lower === 'static' || $lower === '$this') {
+            return $rc->getName();
+        } elseif ($name[0] === '\\') { // fully qualified name
+            return ltrim($name, '\\');
+        }
+
+        $uses = self::getUseStatements($rc);
+        $parts = explode('\\', $name, 2);
+        if (isset($uses[$parts[0]])) {
+            $parts[0] = $uses[$parts[0]];
+            return implode('\\', $parts);
+        } elseif ($rc->inNamespace()) {
+            return $rc->getNamespaceName() . '\\' . $name;
+        } else {
+            return $name;
+        }
+    }
+
+    /**
+     * @param  \ReflectionClass
+     * @return array of [alias => class]
+     */
+    public static function getUseStatements(\ReflectionClass $class)
+    {
+        static $cache = array();
+        if (!isset($cache[$name = $class->getName()])) {
+            if ($class->isInternal() || !($code = @file_get_contents($class->getFileName()))) {
+                $cache[$name] = array();
+            } else {
+                $cache = self::parseUseStatements($code, $name) + $cache;
+            }
+        }
+        return $cache[$name];
+    }
+
+    /**
+     * @param  string
+     * @return bool
+     */
+    public static function isBuiltinType($type)
+    {
+        return in_array(strtolower($type), array('string', 'int', 'float', 'bool', 'array', 'callable'), true);
+    }
+
+    /**
+     * Parses PHP code.
+     *
+     * @param  string $code
+     * @param  string $forClass
+     * @return array of [class => [alias => class, ...]]
+     */
+    public static function parseUseStatements($code, $forClass = null)
+    {
+        $tokens = token_get_all($code);
+        $namespace = $class = $classLevel = $level = null;
+        $res = $uses = array();
+
+        while ($token = current($tokens)) {
+            next($tokens);
+            switch (is_array($token) ? $token[0] : $token) {
+                case T_NAMESPACE:
+                    $namespace = ltrim(self::fetch($tokens, array(T_STRING, T_NS_SEPARATOR)) . '\\', '\\');
+                    $uses = array();
+                    break;
+
+                case T_CLASS:
+                case T_INTERFACE:
+                case PHP_VERSION_ID < 50400 ? -1 : T_TRAIT:
+                    if ($name = self::fetch($tokens, T_STRING)) {
+                        $class = $namespace . $name;
+                        $classLevel = $level + 1;
+                        $res[$class] = $uses;
+                        if ($class === $forClass) {
+                            return $res;
+                        }
+                    }
+                    break;
+
+                case T_USE:
+                    while (!$class && ($name = self::fetch($tokens, array(T_STRING, T_NS_SEPARATOR)))) {
+                        $name = ltrim($name, '\\');
+                        if (self::fetch($tokens, '{')) {
+                            while ($suffix = self::fetch($tokens, array(T_STRING, T_NS_SEPARATOR))) {
+                                if (self::fetch($tokens, T_AS)) {
+                                    $uses[self::fetch($tokens, T_STRING)] = $name . $suffix;
+                                } else {
+                                    $tmp = explode('\\', $suffix);
+                                    $uses[end($tmp)] = $name . $suffix;
+                                }
+                                if (!self::fetch($tokens, ',')) {
+                                    break;
+                                }
+                            }
+
+                        } elseif (self::fetch($tokens, T_AS)) {
+                            $uses[self::fetch($tokens, T_STRING)] = $name;
+
+                        } else {
+                            $tmp = explode('\\', $name);
+                            $uses[end($tmp)] = $name;
+                        }
+                        if (!self::fetch($tokens, ',')) {
+                            break;
+                        }
+                    }
+                    break;
+
+                case T_CURLY_OPEN:
+                case T_DOLLAR_OPEN_CURLY_BRACES:
+                case '{':
+                    $level++;
+                    break;
+
+                case '}':
+                    if ($level === $classLevel) {
+                        $class = $classLevel = null;
+                    }
+                    $level--;
+            }
+        }
+
+        return $res;
+    }
+
+    private static function fetch(&$tokens, $take)
+    {
+        $res = null;
+        while ($token = current($tokens)) {
+            list($token, $s) = is_array($token) ? $token : array($token, $token);
+            if (in_array($token, (array)$take, true)) {
+                $res .= $s;
+            } elseif (!in_array($token, array(T_DOC_COMMENT, T_WHITESPACE, T_COMMENT), true)) {
+                break;
+            }
+            next($tokens);
+        }
+        return $res;
+    }
+}

--- a/src/views/ide-helper.php
+++ b/src/views/ide-helper.php
@@ -29,7 +29,7 @@ namespace <?= $namespace == '__root' ? '' : $namespace ?>{
 		<?= $docComment ?>
 
 <?php endif; ?>
-		public static function <?= $method->getName() ?>(<?= $nParams < count($mParams) ? '/** @noinspection PhpDocSignatureInspection */' . implode(', /** @noinspection PhpDocSignatureInspection */', $mParams) : $method->getParamsWithDefault() ?>){
+		public static function <?= $method->getName() ?>(<?= ($docComment && $nParams < count($mParams)) ? '/** @noinspection PhpDocSignatureInspection */' . implode(', /** @noinspection PhpDocSignatureInspection */', $mParams) : $method->getParamsWithDefault() ?>){
 <?php if ($method->getDeclaringClass() !== $method->getRoot()): ?>
 			//Method inherited from <?= $method->getDeclaringClass() ?>
 

--- a/src/views/ide-helper.php
+++ b/src/views/ide-helper.php
@@ -2,38 +2,45 @@
 
 /**
  * An helper file for Laravel 4, to provide autocomplete information to your IDE
- * Generated for Laravel <?= $version ?> on <?= date("Y-m-d") ?>.
+ * Generated for Laravel <?= $version ?> on <?= date('Y-m-d') ?>.
  *
  * @author Barry vd. Heuvel <barryvdh@gmail.com>
  * @see https://github.com/barryvdh/laravel-ide-helper
  */
 
-<?php foreach($namespaces as $namespace => $aliases): ?>
+<?php foreach ($namespaces as $namespace => $aliases/* @var \Barryvdh\LaravelIdeHelper\Alias[] $aliases */): ?>
 namespace <?= $namespace == '__root' ? '' : $namespace ?>{
-<?php if($namespace == '__root'): ?>
-    exit("This file should not be included, only analyzed by your IDE");
+<?php if ($namespace == '__root'): ?>
+	exit('This file should not be included, only analyzed by your IDE');
 <?= $helpers ?>
 <?php endif; ?>
-<?php foreach($aliases as $alias): ?>
+<?php foreach ($aliases as $alias): ?>
 
-    <?= $alias->getClassType() ?> <?= $alias->getShortName() ?> <?= $alias->getExtends() ? 'extends ' . $alias->getExtends() : '' ?>{
-        <?php foreach($alias->getMethods() as $method): ?>
+<?php if (($cBase = class_basename($alias->getExtends())) != $alias->getExtends() && $cBase != $alias->getShortName()): ?>
+	/** @noinspection PhpUnnecessaryFullyQualifiedNameInspection */
+<?php endif; ?>
+	<?= $alias->getClassType() ?> <?= $alias->getShortName() ?> <?= $alias->getExtends() ? 'extends ' . $alias->getExtends() : '' ?>{
+<?php foreach ($alias->getMethods() as $method): ?>
 
-        <?= trim($method->getDocComment('        ')) ?>
+<?php if (($nParams = count($method->getDocParams())) > count($mParams = $method->getParamsWithDefault(false))): ?>
+		/** @noinspection PhpDocSignatureInspection */
+<?php endif; ?>
+<?php if ($docComment = str_replace("/**\n\t\t */", '', trim($method->getDocComment("\t\t", true)))): ?>
+		<?= $docComment ?>
 
-        public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>){<?php if($method->getDeclaringClass() !== $method->getRoot()): ?>
+<?php endif; ?>
+		public static function <?= $method->getName() ?>(<?= $nParams < count($mParams) ? '/** @noinspection PhpDocSignatureInspection */' . implode(', /** @noinspection PhpDocSignatureInspection */', $mParams) : $method->getParamsWithDefault() ?>){
+<?php if ($method->getDeclaringClass() !== $method->getRoot()): ?>
+			//Method inherited from <?= $method->getDeclaringClass() ?>
 
-            //Method inherited from <?= $method->getDeclaringClass() ?>
-            <?php endif; ?>
+<?php endif; ?>
+			/** @noinspection PhpUnnecessaryFullyQualifiedNameInspection,PhpDynamicAsStaticMethodCallInspection<?= ($method->shouldReturn() === 1 ? ',PhpVoidFunctionResultUsedInspection' : '') . ($method->isDeprecated() ? ',PhpDeprecationInspection' : '') ?> */
+			<?= $method->shouldReturn() ? 'return ' : '' ?><?= $method->getRoot() ?>::<?= $method->getName() ?>(<?= $method->getParams() ?>);
+		}
+<?php endforeach; ?>
 
-            <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRoot() ?>::<?= $method->getName() ?>(<?= $method->getParams() ?>);
-        }
-        <?php endforeach; ?>
-
-    }
-
+	}
 <?php endforeach; ?>
 
 }
-
 <?php endforeach; ?>

--- a/src/views/meta.php
+++ b/src/views/meta.php
@@ -13,7 +13,7 @@
 <?php foreach ($methods as $method): ?>
 		<?= strpos($method, 'new ') === 0 ? $method : $method . '(\'\')' ?> => array(
 <?php foreach ($bindings as $abstract => $class): ?>
-			'<?= $abstract ?>' instanceof \<?= $class ?>,
+			<?= var_export($abstract, true) ?> instanceof \<?= $class ?>,
 <?php endforeach ?>
 		),
 <?php endforeach ?>

--- a/src/views/meta.php
+++ b/src/views/meta.php
@@ -1,22 +1,22 @@
 <?= '<?php' ?> namespace PHPSTORM_META {
 
-   /**
-    * PhpStorm Meta file, to provide autocomplete information for PhpStorm
-    * Generated on <?= date("Y-m-d") ?>.
-    *
-    * @author Barry vd. Heuvel <barryvdh@gmail.com>
-    * @see https://github.com/barryvdh/laravel-ide-helper
-    */
+	/**
+	 * PhpStorm Meta file, to provide autocomplete information for PhpStorm
+	 * Generated on <?= date('Y-m-d') ?>.
+	 *
+	 * @author Barry vd. Heuvel <barryvdh@gmail.com>
+	 * @see https://github.com/barryvdh/laravel-ide-helper
+	 */
 
-    /** @noinspection PhpIllegalArrayKeyTypeInspection */
-    /** @noinspection PhpUnusedLocalVariableInspection */
-    /** @noinspection PhpUnnecessaryFullyQualifiedNameInspection */
-    $STATIC_METHOD_TYPES = array(
-<?php foreach($methods as $method): ?>
-        <?= $method ?>('') => array(
-<?php foreach($bindings as $abstract => $class): ?>
-            '<?= $abstract ?>' instanceof \<?= $class ?>,
-<?php endforeach ?>        ),
+	/** @noinspection PhpIllegalArrayKeyTypeInspection,PhpUnusedLocalVariableInspection,PhpUnnecessaryFullyQualifiedNameInspection */
+	$STATIC_METHOD_TYPES = array(
+<?php foreach ($methods as $method): ?>
+		<?= strpos($method, 'new ') === 0 ? $method : $method . '(\'\')' ?> => array(
+<?php foreach ($bindings as $abstract => $class): ?>
+			'<?= $abstract ?>' instanceof \<?= $class ?>,
 <?php endforeach ?>
-    );
+		),
+<?php endforeach ?>
+	);
+
 }

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -1,0 +1,38 @@
+<?php namespace Barryvdh\LaravelIdeHelper;
+
+class MethodTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * @expectedException \PHPUnit_Framework_Error
+	 * @expectedExceptionMessage Argument 1 passed to
+	 */
+	public function testConstructorWithoutMethod()
+	{
+		new Method(null, null, null);
+	}
+
+	public function testConstructor()
+	{
+		$method = new \ReflectionMethod('PHPUnit_Framework_TestCase', 'getMock');
+		$object = new Method($method, null, new \ReflectionClass(get_class($this)));
+
+		$this->assertSame('\PHPUnit_Framework_TestCase', $object->getDeclaringClass());
+		$this->assertSame('\\' . get_class($this), $object->getRoot());
+		$this->assertSame('getMock', $object->getName());
+
+		$prop = new \ReflectionProperty(get_class($object), 'namespace');
+		$prop->setAccessible(true);
+		$this->assertSame('', $prop->getValue($object));
+
+		$this->assertFalse($object->isDeprecated());
+		$this->assertCount($method->getNumberOfParameters(), $object->getDocParams());
+
+		$doc = $object->getDocComment('', true);
+		$this->assertContains("\n * " . '@param array|null $methods', $doc);
+		$this->assertContains("\n * " . '@return \PHPUnit_Framework_MockObject_MockObject', $doc);
+		$this->assertContains("\n * " . '@throws \PHPUnit_Framework_Exception', $doc);
+
+		$this->assertTrue($object->shouldReturn());
+	}
+
+}

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -1,0 +1,83 @@
+<?php namespace Barryvdh\LaravelIdeHelper;
+
+class ServiceProviderTest extends \PHPUnit_Framework_TestCase
+{
+	/** @var \PHPUnit_Framework_MockObject_MockObject|\Illuminate\Container\Container */
+	protected $app;
+	/** @var IdeHelperServiceProvider */
+	protected $provider;
+
+	static function makeAppMock(\PHPUnit_Framework_TestCase $testCase)
+	{
+		$app = $testCase->getMock('Illuminate\Container\Container', array('make', 'bind'));
+
+		$fs = $testCase->getMock('Illuminate\Filesystem\Filesystem', null);
+		$config = $testCase->getMock('Illuminate\Config\Repository', array('get', 'set', 'package'), array(), '', false);
+		$events = $testCase->getMock('Illuminate\Events\Dispatcher', array('listen'), array($app));
+		$view = $testCase->getMock('Illuminate\View\Factory', array('addNamespace'), array(), '', false);
+
+		$app->expects($testCase->any())->method('make')->willReturnMap(array(
+			array('files', array(), $fs),
+			array('config', array(), $config),
+			array('events', array(), $events),
+			array('view', array(), $view),
+			array('path', array(), __DIR__),
+		));
+
+		return $app;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function setUp()
+	{
+		$this->app = static::makeAppMock($this);
+		/** @noinspection PhpParamsInspection */
+		$this->provider = new IdeHelperServiceProvider($this->app);
+	}
+
+	public function testDeferred()
+	{
+		$this->assertTrue($this->provider->isDeferred());
+	}
+
+	public function testProvides()
+	{
+		$this->assertEquals(array('command.ide-helper.generate', 'command.ide-helper.models', 'command.ide-helper.meta'), $this->provider->provides());
+	}
+
+	public function testRegister()
+	{
+		$this->app->expects($this->exactly(3))->method('bind')->withConsecutive(
+			array('command.ide-helper.generate', $this->isType(\PHPUnit_Framework_Constraint_IsType::TYPE_CALLABLE), $this->isFalse()),
+			array('command.ide-helper.models', $this->isType(\PHPUnit_Framework_Constraint_IsType::TYPE_CALLABLE), $this->isFalse()),
+			array('command.ide-helper.meta', $this->isType(\PHPUnit_Framework_Constraint_IsType::TYPE_CALLABLE), $this->isFalse())
+		);
+
+		/** @var \PHPUnit_Framework_MockObject_MockObject|\Illuminate\Events\Dispatcher $events */
+		$events = $this->app['events'];
+		$events->expects($this->once())->method('listen')->with('artisan.start', $this->callback(function ($listener) {
+			$params = print_r(array('commands' => array('command.ide-helper.generate', 'command.ide-helper.models', 'command.ide-helper.meta')), true);
+			return strpos(preg_replace('/^\s+/mu', '', print_r($listener, true)), preg_replace('/^\s+/mu', '', $params));
+		}), 0);
+
+		$this->provider->register();
+	}
+
+	public function testBoot()
+	{
+		$path = realpath(__DIR__ . '/../src');
+
+		/** @var \PHPUnit_Framework_MockObject_MockObject|\Illuminate\Config\Repository $config */
+		$config = $this->app['config'];
+		$config->expects($this->once())->method('package')->with('barryvdh/laravel-ide-helper', $path . '/config', 'laravel-ide-helper');
+
+		/** @var \PHPUnit_Framework_MockObject_MockObject|\Illuminate\View\Factory $view */
+		$view = $this->app['view'];
+		$view->expects($this->once())->method('addNamespace')->with('laravel-ide-helper', $path . '/views');
+
+		$this->provider->boot();
+	}
+
+}


### PR DESCRIPTION
* Add required composer dependencies for development such as `illuminate/config`, `illuminate/view`
* Correct spelling for README document
* Improve `MetaCommand` to support auto-completion in ArrayAccess mode (e.g. `$app['foo']`)
* Re-format and correct spelling for all source code
* Improve `Method` class to reduce generated filesize
* Correct FQN types for generated phpDoc by using PHP use statements
* Support case-insensitive `@inheritDoc` for phpDoc generation
* Reuse library "phpdocumentor/reflection-docblock" instead of custom one "barryvdh/reflection-docblock", because of using `setType` via PHP `ReflectionProperty`
* Add some `@noinspection` to generated file (_ide_helper.php) to bypass PhpStorm inspection
* And many stuffs :-)