### PR TITLE
Allow for configurable helper of eloquent namespace

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -54,6 +54,8 @@ return array(
         base_path().'/vendor/laravel/framework/src/Illuminate/Support/helpers.php',
     ),
 
+    'eloquent_namespace' => '\Illuminate\Database\Eloquent',
+
     /*
     |--------------------------------------------------------------------------
     | Model locations to include

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -38,7 +38,7 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
 namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
 <?php foreach($aliases as $alias): ?>
 
-    <?= $alias->getClassType() ?> <?= $alias->getShortName() ?> extends <?= $alias->getExtends() ?> {<?php if ($alias->getExtendsNamespace() == '\Illuminate\Database\Eloquent'): ?>
+    <?= $alias->getClassType() ?> <?= $alias->getShortName() ?> extends <?= $alias->getExtends() ?> {<?php if ($alias->getExtendsNamespace() == $eloquent_namespace): ?>
         <?php foreach($alias->getMethods() as $method): ?> 
             <?= trim($method->getDocComment('            ')) ?> 
             public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -86,6 +86,7 @@ class Generator
             ->with('helpers', $this->helpers)
             ->with('version', $app->version())
             ->with('include_fluent', $this->config->get('ide-helper.include_fluent', true))
+            ->with('eloquent_namespace', $this->config->get('ide-helper.eloquent_namespace', '\Illuminate\Database\Eloquent'))
             ->render();
     }
 


### PR DESCRIPTION
sometimes we will need post-packaging of eloquent to use it easyer,but in this case,the ide-helper cannot cue us，so i think we can make the eloquent namespace  configurable