### PR TITLE
Support php's array callable format for macro's.

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -319,10 +319,9 @@ class Alias
                 $properties = $reflection->getStaticProperties();
                 $macros = isset($properties['macros']) ? $properties['macros'] : [];
                 foreach ($macros as $macro_name => $macro_func) {
-                    $function = new \ReflectionFunction($macro_func);
                     // Add macros
                     $this->methods[] = new Macro(
-                        $function,
+                        $this->getMacroFunction($macro_func),
                         $this->alias,
                         $reflection,
                         $macro_name,
@@ -331,6 +330,21 @@ class Alias
                 }
             }
         }
+    }
+
+    /**
+     * @param $macro_func
+     *
+     * @return \ReflectionFunctionAbstract
+     * @throws \ReflectionException
+     */
+    protected function getMacroFunction($macro_func)
+    {
+        if (is_array($macro_func) && is_callable($macro_func)) {
+            return new \ReflectionMethod($macro_func[0], $macro_func[1]);
+        }
+
+        return new \ReflectionFunction($macro_func);
     }
 
     /**

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -10,14 +10,19 @@ class Macro extends Method
     /**
      * Macro constructor.
      *
-     * @param \ReflectionFunction $method
+     * @param \ReflectionFunctionAbstract $method
      * @param string              $alias
      * @param \ReflectionClass    $class
      * @param null                $methodName
      * @param array               $interfaces
      */
-    public function __construct(\ReflectionFunction $method, $alias, $class, $methodName = null, $interfaces = array())
-    {
+    public function __construct(
+        \ReflectionFunctionAbstract $method,
+        $alias,
+        $class,
+        $methodName = null,
+        $interfaces = array()
+    ) {
         $this->method = $method;
         $this->interfaces = $interfaces;
         $this->name = $methodName ?: $method->name;


### PR DESCRIPTION
Hi Barry,

We've been defining our macro's as callables of a class instead of using closures, sadly this breaks ide-helper because it expects only closures as macros.

This patch allows you to define methods like this as well: Str::macro('name', [$this, 'method']);

(This patch was based on the latest stable tag [2.4.1] because dev-master was broken for me, i'm not sure what branch you want me to push this to, if you want it on another branch so it's easier to tag please let me know)

