### PR TITLE
Fixes a bug where a missing DocBlock caused errors

### DIFF
--- a/src/Eloquent.php
+++ b/src/Eloquent.php
@@ -48,7 +48,7 @@ class Eloquent
         foreach ($mixins as $m) {
             $mixin = $m->getContent();
 
-            if(isset($expectedMixins[$mixin])) {
+            if (isset($expectedMixins[$mixin])) {
                 $command->info('Tag Exists: @mixin ' . $mixin . ' in ' . $class);
 
                 $expectedMixins[$mixin] = true;
@@ -56,8 +56,8 @@ class Eloquent
         }
 
         $changed = false;
-        foreach($expectedMixins as $expectedMixin => $present) {
-            if($present === false) {
+        foreach ($expectedMixins as $expectedMixin => $present) {
+            if ($present === false) {
                 $phpdoc->appendTag(Tag::createInstance('@mixin ' . $expectedMixin, $phpdoc));
 
                 $changed = true;
@@ -65,7 +65,7 @@ class Eloquent
         }
 
         // If nothing's changed, stop here.
-        if(!$changed) {
+        if (!$changed) {
             return;
         }
 

--- a/src/Eloquent.php
+++ b/src/Eloquent.php
@@ -32,26 +32,56 @@ class Eloquent
         $reflection  = new \ReflectionClass($class);
         $namespace   = $reflection->getNamespaceName();
         $originalDoc = $reflection->getDocComment();
+
         if (!$originalDoc) {
             $command->info('Unexpected no document on ' . $class);
         }
         $phpdoc = new DocBlock($reflection, new Context($namespace));
 
         $mixins = $phpdoc->getTagsByName('mixin');
-        foreach ($mixins as $m) {
-            if ($m->getContent() === '\Eloquent') {
-                $command->info('Tag Exists: @mixin \Eloquent in ' . $class);
+        $expectedMixins = [
+            '\Eloquent'                             => false,
+            '\Illuminate\Database\Eloquent\Builder' => false,
+            '\Illuminate\Database\Query\Builder'    => false,
+        ];
 
-                return;
+        foreach ($mixins as $m) {
+            $mixin = $m->getContent();
+
+            if(isset($expectedMixins[$mixin])) {
+                $command->info('Tag Exists: @mixin ' . $mixin . ' in ' . $class);
+
+                $expectedMixins[$mixin] = true;
             }
         }
 
-        // add the Eloquent mixin
-        $phpdoc->appendTag(Tag::createInstance("@mixin \\Eloquent", $phpdoc));
+        $changed = false;
+        foreach($expectedMixins as $expectedMixin => $present) {
+            if($present === false) {
+                $phpdoc->appendTag(Tag::createInstance('@mixin ' . $expectedMixin, $phpdoc));
+
+                $changed = true;
+            }
+        }
+
+        // If nothing's changed, stop here.
+        if(!$changed) {
+            return;
+        }
 
         $serializer = new DocBlockSerializer();
         $serializer->getDocComment($phpdoc);
         $docComment = $serializer->getDocComment($phpdoc);
+
+        /*
+            The new DocBlock is appended to the beginning of the class declaration.
+            Since there is no DocBlock, the declaration is used as a guide.
+        */
+        if (!$originalDoc) {
+            $originalDoc = 'abstract class Model implements';
+
+            $docComment .= "\nabstract class Model implements";
+        }
 
         $filename = $reflection->getFileName();
         if ($filename) {
@@ -61,7 +91,7 @@ class Eloquent
                 $contents = str_replace($originalDoc, $docComment, $contents, $count);
                 if ($count > 0) {
                     if ($files->put($filename, $contents)) {
-                        $command->info('Wrote @mixin \Eloquent to ' . $filename);
+                        $command->info('Wrote expected docblock to ' . $filename);
                     } else {
                         $command->error('File write failed to ' . $filename);
                     }


### PR DESCRIPTION
Hi,

This will fix the bug that has occurred since [Laravel removed the DocBlock](https://github.com/laravel/framework/commit/6f518a8a534702da9166ef2fc5e297a06ed5cc18). This fix ensures that all expected mixin entries are present.

Fixes #623 