### PR TITLE
"smart-reset": Reset properties/methods, but keep the text

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -63,7 +63,7 @@ class Alias
         $this->detectClassType();
         $this->detectExtendsNamespace();
 
-        if(!empty($this->namespace)) {
+        if (!empty($this->namespace)) {
             //Create a DocBlock and serializer instance
             $this->phpdoc = new DocBlock(new ReflectionClass($alias), new Context($this->namespace));
         }
@@ -119,7 +119,7 @@ class Alias
     {
         return $this->extends;
     }
-    
+
     /**
      * Get the class short name which this alias extends
      *
@@ -129,7 +129,7 @@ class Alias
     {
         return $this->extendsClass;
     }
-    
+
     /**
      * Get the namespace of the class which this alias extends
      *
@@ -192,7 +192,7 @@ class Alias
             $this->short = $this->alias;
         }
     }
-    
+
     /**
      * Detect the extends namespace
      */

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -56,6 +56,7 @@ class ModelsCommand extends Command
     protected $write = false;
     protected $dirs = array();
     protected $reset;
+    protected $keep_text;
     /**
      * @var bool[string]
      */
@@ -86,6 +87,9 @@ class ModelsCommand extends Command
         $model = $this->argument('model');
         $ignore = $this->option('ignore');
         $this->reset = $this->option('reset');
+        if ($this->option('smart-reset')) {
+            $this->keep_text = $this->reset = true;
+        }
         $this->write_model_magic_where = $this->laravel['config']->get('ide-helper.write_model_magic_where', true);
 
         //If filename is default and Write is not specified, ask what to do
@@ -136,6 +140,7 @@ class ModelsCommand extends Command
           array('write', 'W', InputOption::VALUE_NONE, 'Write to Model file'),
           array('nowrite', 'N', InputOption::VALUE_NONE, 'Don\'t write to Model file'),
           array('reset', 'R', InputOption::VALUE_NONE, 'Remove the original phpdocs instead of appending'),
+          array('smart-reset', 'r', InputOption::VALUE_NONE, 'Remove the original phpdocs properties/methods, but keep the text'),
           array('ignore', 'I', InputOption::VALUE_OPTIONAL, 'Which models to ignore', ''),
         );
     }
@@ -582,6 +587,11 @@ class ModelsCommand extends Command
 
         if ($this->reset) {
             $phpdoc = new DocBlock('', new Context($namespace));
+            if ($this->keep_text) {
+                $phpdoc->setText(
+                    (new DocBlock($reflection, new Context($namespace)))->getText()
+                );
+            }
         } else {
             $phpdoc = new DocBlock($reflection, new Context($namespace));
         }

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -140,7 +140,7 @@ class ModelsCommand extends Command
           array('write', 'W', InputOption::VALUE_NONE, 'Write to Model file'),
           array('nowrite', 'N', InputOption::VALUE_NONE, 'Don\'t write to Model file'),
           array('reset', 'R', InputOption::VALUE_NONE, 'Remove the original phpdocs instead of appending'),
-          array('smart-reset', 'r', InputOption::VALUE_NONE, 'Remove the original phpdocs properties/methods, but keep the text'),
+          array('smart-reset', 'r', InputOption::VALUE_NONE, 'Refresh the properties/methods list, but keep the text'),
           array('ignore', 'I', InputOption::VALUE_OPTIONAL, 'Which models to ignore', ''),
         );
     }


### PR DESCRIPTION
I really like to regenerate the complete set of properties and methods to keep everything sorted, but when I do that the text is removed. This adds an option somewhere in between (`-r` or `--smart-reset`) that transfers the text from the original docBlock to the new version, but discards all the rest.