### PR TITLE
Remove Eloquent Model Helper from generate command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,3 @@ before_script:
 script:
   - vendor/bin/phpcs --standard=psr2 src/
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
-
-after_script:
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 
 matrix:
   include:
-    - php: 5.5
+    - php: 5.6
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ before_script:
 
 script:
   - vendor/bin/phpcs --standard=psr2 src/
-  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+  - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-Copyright (c) 2016 Barry vd. Heuvel <barryvdh@gmail.com>
+Copyright (c) Barry vd. Heuvel <barryvdh@gmail.com>
 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/console": "^5.0,<5.7",
         "illuminate/filesystem": "^5.0,<5.7",
         "barryvdh/reflection-docblock": "^2.0.4",
-        "symfony/class-loader": "^2.3|^3.0"
+        "composer/composer": "^1.6",
     },
     "require-dev": {
         "illuminate/config": "^5.0,<5.7",

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,10 @@
     "require-dev": {
         "illuminate/config": "^5.0,<5.7",
         "illuminate/view": "^5.0,<5.7",
+        "phpro/grumphp": "^0.14",
         "phpunit/phpunit" : "4.*",
         "scrutinizer/ocular": "~1.1",
-        "squizlabs/php_codesniffer": "~2.3",
+        "squizlabs/php_codesniffer": "^3",
         "doctrine/dbal": "~2.3"
     },
     "suggest": {
@@ -35,12 +36,13 @@
     },
     "autoload-dev": {
         "psr-4": {
-            ":vendor\\:package_name\\": "tests"
+            "Barryvdh\\LaravelIdeHelper\\": "tests"
         }
     },
     "scripts": {
         "test": "phpunit",
-        "cs": "phpcs --standard=psr2 src/"
+        "check-style": "phpcs -p --standard=PSR2 src/",
+        "fix-style": "phpcbf -p --standard=PSR2 src/"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.3-dev"
+            "dev-master": "2.5-dev"
         },
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -10,16 +10,16 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "illuminate/support": "^5.0,<5.7",
-        "illuminate/console": "^5.0,<5.7",
-        "illuminate/filesystem": "^5.0,<5.7",
+        "php": ">=5.6.0",
+        "illuminate/support": "^5.1,<5.7",
+        "illuminate/console": "^5.1,<5.7",
+        "illuminate/filesystem": "^5.1,<5.7",
         "barryvdh/reflection-docblock": "^2.0.4",
         "composer/composer": "^1.6"
     },
     "require-dev": {
-        "illuminate/config": "^5.0,<5.7",
-        "illuminate/view": "^5.0,<5.7",
+        "illuminate/config": "^5.1,<5.7",
+        "illuminate/view": "^5.1,<5.7",
         "phpro/grumphp": "^0.14",
         "phpunit/phpunit" : "4.*",
         "scrutinizer/ocular": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/console": "^5.0,<5.7",
         "illuminate/filesystem": "^5.0,<5.7",
         "barryvdh/reflection-docblock": "^2.0.4",
-        "composer/composer": "^1.6",
+        "composer/composer": "^1.6"
     },
     "require-dev": {
         "illuminate/config": "^5.0,<5.7",

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -153,13 +153,13 @@ return array(
      |
      | For example, normally you would see this:
      |
-     |  * @property \Carbon\Carbon $created_at
-     |  * @property \Carbon\Carbon $updated_at
+     |  * @property \Illuminate\Support\Carbon $created_at
+     |  * @property \Illuminate\Support\Carbon $updated_at
      |
      | With this enabled, the properties will be this:
      |
-     |  * @property \Carbon\Carbon $createdAt
-     |  * @property \Carbon\Carbon $updatedAt
+     |  * @property \Illuminate\Support\Carbon $createdAt
+     |  * @property \Illuminate\Support\Carbon $updatedAt
      |
      | Note, it is currently an all-or-nothing option.
      |

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,0 +1,15 @@
+parameters:
+    git_dir: .
+    bin_dir: vendor/bin
+    tasks:
+        phpunit:
+            config_file: ~
+            testsuite: ~
+            group: []
+            always_execute: false
+        phpcs:
+            standard: PSR2
+            warning_severity: ~
+            ignore_patterns:
+              - tests/
+            triggered_by: [php]

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
-        <testsuite name=":vendor Test Suite">
+        <testsuite name="Unit Tests">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
@@ -19,11 +19,4 @@
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,7 @@ After updating composer, add the service provider to the `providers` array in `c
 ```php
 Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class,
 ```
+**Laravel 5.5** uses Package Auto-Discovery, so doesn't require you to manually add the ServiceProvider.
 
 To install this package on only development systems, add the `--dev` flag to your composer command:
 

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ You can now re-generate the docs yourself (for future updates)
 php artisan ide-helper:generate
 ```
 
-Note: `bootstrap/compiled.php` has to be cleared first, so run `php artisan clear-compiled` before generating (and `php artisan optimize` after).
+Note: `bootstrap/compiled.php` has to be cleared first, so run `php artisan clear-compiled` before generating.
 
 You can configure your composer.json to do this after each commit:
 
@@ -75,8 +75,7 @@ You can configure your composer.json to do this after each commit:
     "post-update-cmd": [
         "Illuminate\\Foundation\\ComposerScripts::postUpdate",
         "php artisan ide-helper:generate",
-        "php artisan ide-helper:meta",
-        "php artisan optimize"
+        "php artisan ide-helper:meta"
     ]
 },
 ```

--- a/readme.md
+++ b/readme.md
@@ -122,8 +122,8 @@ php artisan ide-helper:models Post
  * @property integer $author_id
  * @property string $title
  * @property string $text
- * @property \Carbon\Carbon $created_at
- * @property \Carbon\Carbon $updated_at
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property \Illuminate\Support\Carbon $updated_at
  * @property-read \User $author
  * @property-read \Illuminate\Database\Eloquent\Collection|\Comment[] $comments
  */

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -80,7 +80,7 @@ namespace Illuminate\Support {
      * @method Fluent onUpdate(string $action) `on update` of a foreign key
      * @method Fluent primary() Add the primary key modifier
      * @method Fluent references(string $column) `references` of a foreign key
-     * @method Fluent nullable() Add the nullable modifier
+     * @method Fluent nullable(bool $value = true) Add the nullable modifier
      * @method Fluent unique(string $name = null) Add unique index clause
      * @method Fluent unsigned() Add the unsigned modifier
      * @method Fluent useCurrent() Add the default timestamp value

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -72,7 +72,7 @@ namespace Illuminate\Support {
      * @method Fluent charset(string $charset) Add the character set modifier
      * @method Fluent collation(string $collation) Add the collation modifier
      * @method Fluent comment(string $comment) Add comment
-     * @method Fluent default(mixed $value) Add the default modifier
+     * @method Fluent default($value) Add the default modifier
      * @method Fluent first() Select first row
      * @method Fluent index(string $name = null) Add the in dex clause
      * @method Fluent on(string $table) `on` of a foreign key

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -383,7 +383,8 @@ class Alias
 
         return new \ReflectionFunction($macro_func);
     }
-  
+
+    /*
      * Get the docblock for this alias
      *
      * @param string $prefix
@@ -392,7 +393,12 @@ class Alias
     public function getDocComment($prefix = "\t\t")
     {
         $serializer = new DocBlockSerializer(1, $prefix);
-        return ($this->phpdoc) ? $serializer->getDocComment($this->phpdoc) : '';
+
+        if ($this->phpdoc) {
+            return $serializer->getDocComment($this->phpdoc);
+        }
+        
+        return '';
     }
 
     /**

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -331,10 +331,9 @@ class Alias
                 $properties = $reflection->getStaticProperties();
                 $macros = isset($properties['macros']) ? $properties['macros'] : [];
                 foreach ($macros as $macro_name => $macro_func) {
-                    $function = new \ReflectionFunction($macro_func);
                     // Add macros
                     $this->methods[] = new Macro(
-                        $function,
+                        $this->getMacroFunction($macro_func),
                         $this->alias,
                         $reflection,
                         $macro_name,
@@ -346,6 +345,20 @@ class Alias
     }
 
     /**
+     * @param $macro_func
+     *
+     * @return \ReflectionFunctionAbstract
+     * @throws \ReflectionException
+     */
+    protected function getMacroFunction($macro_func)
+    {
+        if (is_array($macro_func) && is_callable($macro_func)) {
+            return new \ReflectionMethod($macro_func[0], $macro_func[1]);
+        }
+
+        return new \ReflectionFunction($macro_func);
+    }
+  
      * Get the docblock for this alias
      *
      * @param string $prefix

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -59,6 +59,7 @@ class Alias
         }
 
         $this->addClass($this->root);
+        $this->detectFake();
         $this->detectNamespace();
         $this->detectClassType();
         $this->detectExtendsNamespace();
@@ -177,6 +178,30 @@ class Alias
         $this->addMagicMethods();
         $this->detectMethods();
         return $this->methods;
+    }
+
+    /**
+     * Detect class returned by ::fake()
+     */
+    protected function detectFake()
+    {
+        $facade = $this->facade;
+        
+        if (!method_exists($facade, 'fake')) {
+            return;
+        }
+
+        $real = $facade::getFacadeRoot();
+        
+        try {
+            $facade::fake();
+            $fake = $facade::getFacadeRoot();
+            if ($fake !== $real) {
+                $this->addClass(get_class($fake));
+            }
+        } finally {
+            $facade::swap($real);
+        }
     }
 
     /**

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -63,7 +63,7 @@ class Alias
         $this->detectClassType();
         $this->detectExtendsNamespace();
 
-        if(!empty($this->namespace)) {
+        if (!empty($this->namespace)) {
             //Create a DocBlock and serializer instance
             $this->phpdoc = new DocBlock(new ReflectionClass($alias), new Context($this->namespace));
         }
@@ -119,7 +119,7 @@ class Alias
     {
         return $this->extends;
     }
-    
+
     /**
      * Get the class short name which this alias extends
      *
@@ -129,7 +129,7 @@ class Alias
     {
         return $this->extendsClass;
     }
-    
+
     /**
      * Get the namespace of the class which this alias extends
      *
@@ -192,7 +192,7 @@ class Alias
             $this->short = $this->alias;
         }
     }
-    
+
     /**
      * Detect the extends namespace
      */

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -115,7 +115,6 @@ class GeneratorCommand extends Command
 
             if ($written !== false) {
                 $this->info("A new helper file was written to $filename");
-                Eloquent::writeEloquentModelHelper($this, $this->files);
             } else {
                 $this->error("The helper file could not be created at $filename");
             }

--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -122,7 +122,11 @@ class MetaCommand extends Command
         $abstracts = $this->laravel->getBindings();
 
         // Return the abstract names only
-        return array_keys($abstracts);
+        $keys = array_keys($abstracts);
+
+        sort($keys);
+
+        return $keys;
     }
 
     /**

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -95,7 +95,7 @@ class ModelsCommand extends Command
         //If filename is default and Write is not specified, ask what to do
         if (!$this->write && $filename === $this->filename && !$this->option('nowrite')) {
             if ($this->confirm(
-                "Do you want to overwrite the existing model files? Choose no to write to $filename instead? (Yes/No): "
+                "Do you want to overwrite the existing model files? Choose no to write to $filename instead?"
             )
             ) {
                 $this->write = true;

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -300,7 +300,7 @@ class ModelsCommand extends Command
 
                 if (isset($this->nullableColumns[$name])) {
                     $this->properties[$name]['type'] .= '|null';
-                }                
+                }
             }
         }
     }

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -476,6 +476,11 @@ class ModelsCommand extends Command
                         $search = '$this->' . $relation . '(';
                         if ($pos = stripos($code, $search)) {
                             //Resolve the relation's model to a Relation object.
+                            $methodReflection = new \ReflectionMethod($model, $method);
+                            if ($methodReflection->getNumberOfParameters()) {
+                                return;
+                            }
+
                             $relationObj = $model->$method();
 
                             if ($relationObj instanceof Relation) {

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -145,6 +145,7 @@ class ModelsCommand extends Command
 
 
         $output = "<?php
+//@formatter:off
 /**
  * A helper file for your Eloquent Models
  * Copy the phpDocs from this file to the correct Model,

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -10,6 +10,7 @@
 
 namespace Barryvdh\LaravelIdeHelper\Console;
 
+use Composer\Autoload\ClassMapGenerator;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
@@ -17,7 +18,6 @@ use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\ClassLoader\ClassMapGenerator;
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Context;
 use Barryvdh\Reflection\DocBlock\Tag;

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -187,8 +187,7 @@ class ModelsCommand extends Command
                     // handle abstract classes, interfaces, ...
                     $reflectionClass = new \ReflectionClass($name);
 
-                    if (!$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Model')
-                            || !$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Relations\Pivot')) {
+                    if (!$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Model')) {
                         continue;
                     }
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -461,7 +461,8 @@ class ModelsCommand extends Command
                                'morphOne',
                                'morphTo',
                                'morphMany',
-                               'morphToMany'
+                               'morphToMany',
+                               'morphedByMany'
                              ) as $relation) {
                         $search = '$this->' . $relation . '(';
                         if ($pos = stripos($code, $search)) {
@@ -471,7 +472,14 @@ class ModelsCommand extends Command
                             if ($relationObj instanceof Relation) {
                                 $relatedModel = '\\' . get_class($relationObj->getRelated());
 
-                                $relations = ['hasManyThrough', 'belongsToMany', 'hasMany', 'morphMany', 'morphToMany'];
+                                $relations = [
+                                    'hasManyThrough',
+                                    'belongsToMany',
+                                    'hasMany',
+                                    'morphMany',
+                                    'morphToMany',
+                                    'morphedByMany',
+                                ];
                                 if (in_array($relation, $relations)) {
                                     //Collection or array of models (because Collection is Arrayable)
                                     $this->setProperty(

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -56,6 +56,7 @@ class ModelsCommand extends Command
     protected $write = false;
     protected $dirs = array();
     protected $reset;
+    protected $keep_text;
     /**
      * @var bool[string]
      */
@@ -86,6 +87,9 @@ class ModelsCommand extends Command
         $model = $this->argument('model');
         $ignore = $this->option('ignore');
         $this->reset = $this->option('reset');
+        if ($this->option('smart-reset')) {
+            $this->keep_text = $this->reset = true;
+        }
         $this->write_model_magic_where = $this->laravel['config']->get('ide-helper.write_model_magic_where', true);
 
         //If filename is default and Write is not specified, ask what to do
@@ -136,6 +140,7 @@ class ModelsCommand extends Command
           array('write', 'W', InputOption::VALUE_NONE, 'Write to Model file'),
           array('nowrite', 'N', InputOption::VALUE_NONE, 'Don\'t write to Model file'),
           array('reset', 'R', InputOption::VALUE_NONE, 'Remove the original phpdocs instead of appending'),
+          array('smart-reset', 'r', InputOption::VALUE_NONE, 'Refresh the properties/methods list, but keep the text'),
           array('ignore', 'I', InputOption::VALUE_OPTIONAL, 'Which models to ignore', ''),
         );
     }
@@ -591,6 +596,11 @@ class ModelsCommand extends Command
 
         if ($this->reset) {
             $phpdoc = new DocBlock('', new Context($namespace));
+            if ($this->keep_text) {
+                $phpdoc->setText(
+                    (new DocBlock($reflection, new Context($namespace)))->getText()
+                );
+            }
         } else {
             $phpdoc = new DocBlock($reflection, new Context($namespace));
         }

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -188,7 +188,7 @@ class ModelsCommand extends Command
                     $reflectionClass = new \ReflectionClass($name);
 
                     if (!$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Model')
-                            || $reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Relations\Pivot')) {
+                            || !$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Relations\Pivot')) {
                         continue;
                     }
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -283,7 +283,7 @@ class ModelsCommand extends Command
                     break;
                 case 'date':
                 case 'datetime':
-                    $realType = '\Carbon\Carbon';
+                    $realType = '\Illuminate\Support\Carbon';
                     break;
                 case 'collection':
                     $realType = '\Illuminate\Support\Collection';
@@ -347,7 +347,7 @@ class ModelsCommand extends Command
             foreach ($columns as $column) {
                 $name = $column->getName();
                 if (in_array($name, $model->getDates())) {
-                    $type = '\Carbon\Carbon';
+                    $type = '\Illuminate\Support\Carbon';
                 } else {
                     $type = $column->getType()->getName();
                     switch ($type) {

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -297,6 +297,10 @@ class ModelsCommand extends Command
                 continue;
             } else {
                 $this->properties[$name]['type'] = $this->getTypeOverride($realType);
+
+                if (isset($this->nullableColumns[$name])) {
+                    $this->properties[$name]['type'] .= '|null';
+                }                
             }
         }
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -209,14 +209,14 @@ class Generator
                 if (array_key_exists($name, $this->extra)) {
                     $alias->addClass($this->extra[$name]);
                 }
-                
+
                 $aliases[] = $alias;
             }
         }
 
         return $aliases;
     }
-    
+
     /**
      * Regroup aliases by namespace of extended classes
      *
@@ -228,7 +228,7 @@ class Generator
             return $alias->getExtendsNamespace();
         });
     }
-    
+
     /**
      * Regroup aliases by namespace of alias
      *
@@ -265,7 +265,8 @@ class Generator
           'Schema' => 'Illuminate\Support\Facades\Schema',
           'Session' => 'Illuminate\Support\Facades\Session',
           'Storage' => 'Illuminate\Support\Facades\Storage',
-          //'Validator' => 'Illuminate\Support\Facades\Validator',
+          'Validator' => 'Illuminate\Support\Facades\Validator',
+          'Gate' => 'Illuminate\Support\Facades\Gate',
         ];
 
         $facades = array_merge($facades, $this->config->get('app.aliases', []));

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -10,14 +10,19 @@ class Macro extends Method
     /**
      * Macro constructor.
      *
-     * @param \ReflectionFunction $method
+     * @param \ReflectionFunctionAbstract $method
      * @param string              $alias
      * @param \ReflectionClass    $class
      * @param null                $methodName
      * @param array               $interfaces
      */
-    public function __construct(\ReflectionFunction $method, $alias, $class, $methodName = null, $interfaces = array())
-    {
+    public function __construct(
+        \ReflectionFunctionAbstract $method,
+        $alias,
+        $class,
+        $methodName = null,
+        $interfaces = array()
+    ) {
         $this->method = $method;
         $this->interfaces = $interfaces;
         $this->name = $methodName ?: $method->name;


### PR DESCRIPTION
It’s presence in the default ```generate``` command still generates an error:
```
Unexpected no document on Illuminate\Database\Eloquent\Model
Content did not change
```
Rather than reverting the #624 fix, this restores it, but just makes it entirely optional. This leaves the ```eloquent``` command available as a separate command, but doesn’t run it as part of the default command.

This restores what I’ve come to see as the correct behaviour of PHPStorm and ide-helper (static methods resolve correctly in the IDE), and addresses #628,  #421, #535, #542, #556 

If you _really, really_ want to add the mixins to the Eloquent\Model, you still can use the ```eloquent``` command. But doing that overrides the judgement of the Laravel project and ’breaks’ PHPStorm (it doesn’t look like that will ever be ‘fixed’). 

The perfect is the enemy of the good.