### PR TITLE
The command `php artisan optimize` is deprecated

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,8 +75,7 @@ You can configure your composer.json to do this after each commit:
     "post-update-cmd": [
         "Illuminate\\Foundation\\ComposerScripts::postUpdate",
         "php artisan ide-helper:generate",
-        "php artisan ide-helper:meta",
-        "php artisan optimize"
+        "php artisan ide-helper:meta"
     ]
 },
 ```


### PR DESCRIPTION
The command `php artisan optimize` is deprecated from Laravel 5.6 and above.

[Proof](https://laravel-news.com/laravel-5-6-removes-artisan-optimize)