### PR TITLE
Replace Symfony ClassMapGenerator with Composer ClassMapGenerator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/console": "^5.0,<5.7",
         "illuminate/filesystem": "^5.0,<5.7",
         "barryvdh/reflection-docblock": "^2.0.4",
-        "symfony/class-loader": "^2.3|^3.0"
+        "composer/composer": "^1.6",
     },
     "require-dev": {
         "illuminate/config": "^5.0,<5.7",

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -10,6 +10,7 @@
 
 namespace Barryvdh\LaravelIdeHelper\Console;
 
+use Composer\Autoload\ClassMapGenerator;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
@@ -17,7 +18,6 @@ use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\ClassLoader\ClassMapGenerator;
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Context;
 use Barryvdh\Reflection\DocBlock\Tag;


### PR DESCRIPTION
Closes #659.

Remove dependecy to Symfony\Component\ClassLoader\ClassMapGenerator and replace it with Composer\Autoload\ClassMapGenerator.