### PR TITLE
Remove `mixed` typehint from `Fluent::default` method

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -72,7 +72,7 @@ namespace Illuminate\Support {
      * @method Fluent charset(string $charset) Add the character set modifier
      * @method Fluent collation(string $collation) Add the collation modifier
      * @method Fluent comment(string $comment) Add comment
-     * @method Fluent default(mixed $value) Add the default modifier
+     * @method Fluent default($value) Add the default modifier
      * @method Fluent first() Select first row
      * @method Fluent index(string $name = null) Add the in dex clause
      * @method Fluent on(string $table) `on` of a foreign key


### PR DESCRIPTION
After some PhpStorm's update I noticed that it expects instance of `Illuminate\Support\mixed` as first argument of `default` method in migration files (see screenshot below).

I'm not sure if this is a PhpStorm's bug or something is wrong with my configs, but removing the `mixed` typehint (which is actually not an allowed typehint) fixes this inspection warning.

![Screenshot](https://i.imgur.com/YIJFUIN.png)