### PR TITLE
Prevent to generate classes without methods

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -14,7 +14,7 @@
 <?php if ($namespace == '\Illuminate\Database\Eloquent'): continue; endif; ?>
 namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
 <?php foreach($aliases as $alias): ?>
-
+    <?php $methods = $alias->getMethods(); if(!count($methods)) continue; ?>
     <?= trim($alias->getDocComment('    ')) ?> 
     <?= $alias->getClassType() ?> <?= $alias->getExtendsClass() ?> {
         <?php foreach($alias->getMethods() as $method): ?>

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -474,7 +474,7 @@ class ModelsCommand extends Command
                                'morphedByMany'
                              ) as $relation) {
                         $search = '$this->' . $relation . '(';
-                        if ($pos = stripos($code, $search)) {
+                        if ($pos = stripos($code, $search) && $reflection->getNumberOfParameters() > 0) {
                             //Resolve the relation's model to a Relation object.
                             $relationObj = $model->$method();
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -474,7 +474,7 @@ class ModelsCommand extends Command
                                'morphedByMany'
                              ) as $relation) {
                         $search = '$this->' . $relation . '(';
-                        if ($pos = stripos($code, $search) && $reflection->getNumberOfParameters() > 0) {
+                        if ($pos = stripos($code, $search)) {
                             //Resolve the relation's model to a Relation object.
                             $relationObj = $model->$method();
 


### PR DESCRIPTION
Some classes generates without methods like this
class Format extends \App\Helpers\Format {}
namespace App\Helpers { 
    class Format {
     
    }
}

But App\Helpers\Format contains methods