### PR TITLE
ide-helper:models error when model's method has parameters and also has relation

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -476,6 +476,11 @@ class ModelsCommand extends Command
                         $search = '$this->' . $relation . '(';
                         if ($pos = stripos($code, $search)) {
                             //Resolve the relation's model to a Relation object.
+                            $methodReflection = new \ReflectionMethod($model, $method);
+                            if ($methodReflection->getNumberOfParameters()) {
+                                return;
+                            }
+
                             $relationObj = $model->$method();
 
                             if ($relationObj instanceof Relation) {


### PR DESCRIPTION
Hi @barryvdh,

When I use `artisan ide-helper:models`, it will have error when model's method has parameters and it also has relation.

Example (source [here](https://github.com/AsgardCms/Platform/blob/3.0/Modules/Media/Support/Traits/MediaRelation.php)):
```
   /**
     * Make the Many to Many Morph to Relation with specific zone
     * @param string $zone
     * @return object
     */
    public function filesByZone($zone)
    {
        return $this->morphToMany(File::class, 'imageable', 'media__imageables')
            ->withPivot('zone', 'id')
            ->wherePivot('zone', '=', $zone)
            ->withTimestamps()
            ->orderBy('order');
    }
```
So I suggest to ignore model's method that have parameter.

Regards,
Huy Dang