### PR TITLE
Only skip non-models when generating docs

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -187,8 +187,7 @@ class ModelsCommand extends Command
                     // handle abstract classes, interfaces, ...
                     $reflectionClass = new \ReflectionClass($name);
 
-                    if (!$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Model')
-                            || !$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Relations\Pivot')) {
+                    if (!$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Model')) {
                         continue;
                     }
 


### PR DESCRIPTION
The fix made in PR https://github.com/barryvdh/laravel-ide-helper/pull/614 for issue https://github.com/barryvdh/laravel-ide-helper/issues/253 was incorrect as it resulted in comments
no longer being generated for Models that are not Pivot Rlations.

This PR allow comments to be generated for both Pivot Models (as they are
a subclass of Eloquent\Model) and normal Models.