### PR TITLE
bugfix - Space/Enter between starting php tag and comment for PHPStan

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -1,5 +1,6 @@
 <?= '<?php' ?>
-//@formatter:off
+
+// @formatter:off
 
 /**
  * A helper file for Laravel 5, to provide autocomplete information to your IDE

--- a/resources/views/meta.php
+++ b/resources/views/meta.php
@@ -1,5 +1,6 @@
 <?= '<?php' ?>
-//@formatter:off
+
+// @formatter:off
 
 namespace PHPSTORM_META {
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -151,7 +151,8 @@ class ModelsCommand extends Command
 
 
         $output = "<?php
-//@formatter:off
+
+// @formatter:off
 /**
  * A helper file for your Eloquent Models
  * Copy the phpDocs from this file to the correct Model,


### PR DESCRIPTION
The added comment with `//@formatter:off` isn't valid PHP code. There must be a space/enter between the php opening tag and the comment. PHPStan crashes/cries at this. This fix will make PHPStan happy again!