### PR TITLE
Prevent loading views if `view` class not in container

### DIFF
--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -37,8 +37,10 @@ class IdeHelperServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $viewPath = __DIR__.'/../resources/views';
-        $this->loadViewsFrom($viewPath, 'ide-helper');
+        if ($this->app->has('view')) {
+            $viewPath = __DIR__ . '/../resources/views';
+            $this->loadViewsFrom($viewPath, 'ide-helper');
+        }
 
         $configPath = __DIR__ . '/../config/ide-helper.php';
         if (function_exists('config_path')) {


### PR DESCRIPTION
If views are disabled in application an error is encountered:

```
In Container.php line 767:

  Class view does not exist
```

This pull requires will prevent loading views in `IdeHelperServiceProvider` if there is no `view` binding in application container.