### PR TITLE
Optionally write missing Laravel Model DocBlock

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -1,6 +1,6 @@
 <?php
 
-return [
+return array(
 
     /*
     |--------------------------------------------------------------------------
@@ -11,9 +11,9 @@ return [
     |
     */
 
-    'filename' => '_ide_helper',
-    'format'   => 'php',
-
+    'filename'  => '_ide_helper',
+    'format'    => 'php',
+    
     'meta_filename' => '.phpstorm.meta.php',
 
     /*
@@ -65,9 +65,9 @@ return [
 
     'include_helpers' => false,
 
-    'helper_files' => [
+    'helper_files' => array(
         base_path().'/vendor/laravel/framework/src/Illuminate/Support/helpers.php',
-    ],
+    ),
 
     /*
     |--------------------------------------------------------------------------
@@ -79,9 +79,9 @@ return [
     |
     */
 
-    'model_locations' => [
+    'model_locations' => array(
         'app',
-    ],
+    ),
 
 
     /*
@@ -93,13 +93,13 @@ return [
     |
     */
 
-    'extra' => [
-        'Eloquent' => ['Illuminate\Database\Eloquent\Builder', 'Illuminate\Database\Query\Builder'],
-        'Session'  => ['Illuminate\Session\Store'],
-    ],
+    'extra' => array(
+        'Eloquent' => array('Illuminate\Database\Eloquent\Builder', 'Illuminate\Database\Query\Builder'),
+        'Session' => array('Illuminate\Session\Store'),
+    ),
 
-    'magic' => [
-        'Log' => [
+    'magic' => array(
+        'Log' => array(
             'debug'     => 'Monolog\Logger::addDebug',
             'info'      => 'Monolog\Logger::addInfo',
             'notice'    => 'Monolog\Logger::addNotice',
@@ -108,8 +108,8 @@ return [
             'critical'  => 'Monolog\Logger::addCritical',
             'alert'     => 'Monolog\Logger::addAlert',
             'emergency' => 'Monolog\Logger::addEmergency',
-        ],
-    ],
+        )
+    ),
 
     /*
     |--------------------------------------------------------------------------
@@ -121,9 +121,9 @@ return [
     |
     */
 
-    'interfaces'                  => [
+    'interfaces' => array(
 
-    ],
+    ),
 
     /*
     |--------------------------------------------------------------------------
@@ -151,9 +151,9 @@ return [
     |  ),
     |
     */
-    'custom_db_types'             => [
+    'custom_db_types' => array(
 
-    ],
+    ),
 
     /*
      |--------------------------------------------------------------------------
@@ -189,8 +189,8 @@ return [
     | Cast the given "real type" to the given "type".
     |
     */
-    'type_overrides'              => [
+   'type_overrides' => array(
         'integer' => 'int',
         'boolean' => 'bool',
-    ],
-];
+   ),
+);

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -40,7 +40,7 @@ return array(
 
     /*
     |--------------------------------------------------------------------------
-    | Write Model Magic methods
+    | Write Eloquent Model Mixins
     |--------------------------------------------------------------------------
     |
     | This will add the necessary DocBlock mixins to the model class

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -1,6 +1,6 @@
 <?php
 
-return array(
+return [
 
     /*
     |--------------------------------------------------------------------------
@@ -11,9 +11,9 @@ return array(
     |
     */
 
-    'filename'  => '_ide_helper',
-    'format'    => 'php',
-    
+    'filename' => '_ide_helper',
+    'format'   => 'php',
+
     'meta_filename' => '.phpstorm.meta.php',
 
     /*
@@ -40,6 +40,21 @@ return array(
 
     /*
     |--------------------------------------------------------------------------
+    | Write Model Magic methods
+    |--------------------------------------------------------------------------
+    |
+    | This will add the necessary DocBlock mixins to the model class
+    | contained in the Laravel Framework. This helps the IDE with
+    | auto-completion.
+    |
+    | Please be aware that this setting changes a file within the /vendor directory.
+    |
+    */
+
+    'write_eloquent_model_mixins' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Helper files to include
     |--------------------------------------------------------------------------
     |
@@ -50,9 +65,9 @@ return array(
 
     'include_helpers' => false,
 
-    'helper_files' => array(
+    'helper_files' => [
         base_path().'/vendor/laravel/framework/src/Illuminate/Support/helpers.php',
-    ),
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -64,9 +79,9 @@ return array(
     |
     */
 
-    'model_locations' => array(
+    'model_locations' => [
         'app',
-    ),
+    ],
 
 
     /*
@@ -78,13 +93,13 @@ return array(
     |
     */
 
-    'extra' => array(
-        'Eloquent' => array('Illuminate\Database\Eloquent\Builder', 'Illuminate\Database\Query\Builder'),
-        'Session' => array('Illuminate\Session\Store'),
-    ),
+    'extra' => [
+        'Eloquent' => ['Illuminate\Database\Eloquent\Builder', 'Illuminate\Database\Query\Builder'],
+        'Session'  => ['Illuminate\Session\Store'],
+    ],
 
-    'magic' => array(
-        'Log' => array(
+    'magic' => [
+        'Log' => [
             'debug'     => 'Monolog\Logger::addDebug',
             'info'      => 'Monolog\Logger::addInfo',
             'notice'    => 'Monolog\Logger::addNotice',
@@ -93,8 +108,8 @@ return array(
             'critical'  => 'Monolog\Logger::addCritical',
             'alert'     => 'Monolog\Logger::addAlert',
             'emergency' => 'Monolog\Logger::addEmergency',
-        )
-    ),
+        ],
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -106,9 +121,9 @@ return array(
     |
     */
 
-    'interfaces' => array(
+    'interfaces'                  => [
 
-    ),
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -136,9 +151,9 @@ return array(
     |  ),
     |
     */
-    'custom_db_types' => array(
+    'custom_db_types'             => [
 
-    ),
+    ],
 
     /*
      |--------------------------------------------------------------------------
@@ -174,8 +189,8 @@ return array(
     | Cast the given "real type" to the given "type".
     |
     */
-   'type_overrides' => array(
+    'type_overrides'              => [
         'integer' => 'int',
         'boolean' => 'bool',
-   ),
-);
+    ],
+];

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -166,7 +166,7 @@ class GeneratorCommand extends Command
 
         return array(
             array('format', "F", InputOption::VALUE_OPTIONAL, 'The format for the IDE Helper', $format),
-            array('write_mixins', "WM", InputOption::VALUE_OPTIONAL, 'Write mixins to Laravel Model?', $writeMixins),
+            array('write_mixins', "W", InputOption::VALUE_OPTIONAL, 'Write mixins to Laravel Model?', $writeMixins),
             array('helpers', "H", InputOption::VALUE_NONE, 'Include the helper files'),
             array('memory', "M", InputOption::VALUE_NONE, 'Use sqlite memory driver'),
             array('sublime', "S", InputOption::VALUE_NONE, 'DEPRECATED: Use different style for SublimeText CodeIntel'),

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -115,6 +115,10 @@ class GeneratorCommand extends Command
 
             if ($written !== false) {
                 $this->info("A new helper file was written to $filename");
+
+                if ($this->option('write_mixins')) {
+                    Eloquent::writeEloquentModelHelper($this, $this->files);
+                }
             } else {
                 $this->error("The helper file could not be created at $filename");
             }
@@ -158,9 +162,11 @@ class GeneratorCommand extends Command
     protected function getOptions()
     {
         $format = $this->config->get('ide-helper.format');
+        $writeMixins = $this->config->get('ide-helper.write_eloquent_model_mixins');
 
         return array(
             array('format', "F", InputOption::VALUE_OPTIONAL, 'The format for the IDE Helper', $format),
+            array('write_mixins', "WM", InputOption::VALUE_OPTIONAL, 'Write mixins to Laravel Model?', $writeMixins),
             array('helpers', "H", InputOption::VALUE_NONE, 'Include the helper files'),
             array('memory', "M", InputOption::VALUE_NONE, 'Use sqlite memory driver'),
             array('sublime', "S", InputOption::VALUE_NONE, 'DEPRECATED: Use different style for SublimeText CodeIntel'),

--- a/src/Eloquent.php
+++ b/src/Eloquent.php
@@ -32,26 +32,56 @@ class Eloquent
         $reflection  = new \ReflectionClass($class);
         $namespace   = $reflection->getNamespaceName();
         $originalDoc = $reflection->getDocComment();
+
         if (!$originalDoc) {
             $command->info('Unexpected no document on ' . $class);
         }
         $phpdoc = new DocBlock($reflection, new Context($namespace));
 
         $mixins = $phpdoc->getTagsByName('mixin');
-        foreach ($mixins as $m) {
-            if ($m->getContent() === '\Eloquent') {
-                $command->info('Tag Exists: @mixin \Eloquent in ' . $class);
+        $expectedMixins = [
+            '\Eloquent'                             => false,
+            '\Illuminate\Database\Eloquent\Builder' => false,
+            '\Illuminate\Database\Query\Builder'    => false,
+        ];
 
-                return;
+        foreach ($mixins as $m) {
+            $mixin = $m->getContent();
+
+            if (isset($expectedMixins[$mixin])) {
+                $command->info('Tag Exists: @mixin ' . $mixin . ' in ' . $class);
+
+                $expectedMixins[$mixin] = true;
             }
         }
 
-        // add the Eloquent mixin
-        $phpdoc->appendTag(Tag::createInstance("@mixin \\Eloquent", $phpdoc));
+        $changed = false;
+        foreach ($expectedMixins as $expectedMixin => $present) {
+            if ($present === false) {
+                $phpdoc->appendTag(Tag::createInstance('@mixin ' . $expectedMixin, $phpdoc));
+
+                $changed = true;
+            }
+        }
+
+        // If nothing's changed, stop here.
+        if (!$changed) {
+            return;
+        }
 
         $serializer = new DocBlockSerializer();
         $serializer->getDocComment($phpdoc);
         $docComment = $serializer->getDocComment($phpdoc);
+
+        /*
+            The new DocBlock is appended to the beginning of the class declaration.
+            Since there is no DocBlock, the declaration is used as a guide.
+        */
+        if (!$originalDoc) {
+            $originalDoc = 'abstract class Model implements';
+
+            $docComment .= "\nabstract class Model implements";
+        }
 
         $filename = $reflection->getFileName();
         if ($filename) {
@@ -61,7 +91,7 @@ class Eloquent
                 $contents = str_replace($originalDoc, $docComment, $contents, $count);
                 if ($count > 0) {
                     if ($files->put($filename, $contents)) {
-                        $command->info('Wrote @mixin \Eloquent to ' . $filename);
+                        $command->info('Wrote expected docblock to ' . $filename);
                     } else {
                         $command->error('File write failed to ' . $filename);
                     }


### PR DESCRIPTION
Hi,

This will solve the problem from #699, #697 and #695.

This patch will not completely disable the addition of mixins like https://github.com/barryvdh/laravel-ide-helper/commit/7db1843473e1562d8e0490b51db847d3a1415140, but make them optional.

It would be really wonderful to continue to have this option as it greatly simplifies the work. But since not everyone wants `/vendor` files to be changed, this behavior is now optional.

The changes to add the mixins are the same as in #624 .

Best,
Patrick

---

Fixes: #715 #716 