### PR TITLE
 Remove DocBlocks for classes. It will Cause conflict in IDE.

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -17,7 +17,6 @@
 namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
 <?php foreach($aliases as $alias): ?>
 
-    <?= trim($alias->getDocComment('    ')) ?> 
     <?= $alias->getClassType() ?> <?= $alias->getExtendsClass() ?> {
         <?php foreach($alias->getMethods() as $method): ?>
 


### PR DESCRIPTION
The DocBlocks in _ide_helper.php will cause conflict and the generated IDE helper classes will not work.