### PR TITLE
Fix alias class existence determination #698

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -272,9 +272,13 @@ class Generator
         $facades = array_merge($facades, $this->config->get('app.aliases', []));
 
         // Only return the ones that actually exist
-        return array_filter($facades, function ($alias) {
-            return class_exists($alias);
-        });
+        return array_filter(
+            $facades,
+            function ($alias) {
+                return class_exists($alias);
+            },
+            ARRAY_FILTER_USE_KEY
+        );
     }
 
     /**


### PR DESCRIPTION
`Barryvdh\LaravelIdeHelper\Generator::getAliases()` has its own logic for Lumen which does not have an `AliasLoader` class.

There is processing to check the existence of alias class. In the `$facades` array the key is alias class name and value is original class name so` array_filter` makes a judgment on whether there is an original class, not an alias class.

This patch is to correct this problem.

Fixes #698
