### PR TITLE
Fix missed methods with same name

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -28,7 +28,7 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
             //Method inherited from <?= $method->getDeclaringClass() ?>
             <?php endif; ?>
 
-            <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRoot() ?>::<?= $method->getName() ?>(<?= $method->getParams() ?>);
+            <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRoot() ?>::<?= $method->getRealName() ?>(<?= $method->getParams() ?>);
         }
         <?php endforeach; ?> 
     }

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -50,7 +50,7 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
                 //Method inherited from <?= $method->getDeclaringClass() ?>
                 <?php endif; ?>
     
-                <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRoot() ?>::<?= $method->getName() ?>(<?= $method->getParams() ?>);
+                <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRoot() ?>::<?= $method->getRealName() ?>(<?= $method->getParams() ?>);
             }
         <?php endforeach; ?>
 <?php endif; ?>}

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -310,7 +310,7 @@ class Alias
             $method = new \ReflectionMethod($className, $name);
             $class = new \ReflectionClass($className);
 
-            if (!in_array($method->name, $this->usedMethods)) {
+            if (!in_array($magic, $this->usedMethods)) {
                 if ($class !== $this->root) {
                     $this->methods[] = new Method($method, $this->alias, $class, $magic, $this->interfaces);
                 }

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -26,6 +26,7 @@ class Macro extends Method
         $this->method = $method;
         $this->interfaces = $interfaces;
         $this->name = $methodName ?: $method->name;
+        $this->real_name = $method->name;
         $this->namespace = $class->getNamespaceName();
 
         //Create a DocBlock and serializer instance

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -17,37 +17,30 @@ class Macro extends Method
      * @param array               $interfaces
      */
     public function __construct(
-        \ReflectionFunctionAbstract $method,
+        $method,
         $alias,
         $class,
         $methodName = null,
         $interfaces = array()
     ) {
-        $this->method = $method;
-        $this->interfaces = $interfaces;
-        $this->name = $methodName ?: $method->name;
-        $this->real_name = $method->name;
-        $this->namespace = $class->getNamespaceName();
+        parent::__construct($method, $alias, $class, $methodName, $interfaces);
+    }
 
-        //Create a DocBlock and serializer instance
+    /**
+     * @param \ReflectionFunctionAbstract $method
+     */
+    protected function initPhpDoc($method)
+    {
         $this->phpdoc = new DocBlock($method);
+    }
 
-        //Normalize the description and inherit the docs from parents/interfaces
-        try {
-            $this->normalizeParams($this->phpdoc);
-            $this->normalizeReturn($this->phpdoc);
-            $this->normalizeDescription($this->phpdoc);
-        } catch (\Exception $e) {
-        }
-
-        //Get the parameters, including formatted default values
-        $this->getParameters($method);
-
-        //Make the method static
-        $this->phpdoc->appendTag(Tag::createInstance('@static', $this->phpdoc));
-
-        //Reference the 'real' function in the declaringclass
+    /**
+     * @param \ReflectionFunctionAbstract $method
+     * @param \ReflectionClass $class
+     */
+    protected function initClassDefinedProperties($method, \ReflectionClass $class)
+    {
+        $this->namespace = $class->getNamespaceName();
         $this->declaringClassName = '\\' . ltrim($class->name, '\\');
-        $this->root = '\\' . ltrim($class->getName(), '\\');
     }
 }

--- a/src/Method.php
+++ b/src/Method.php
@@ -31,6 +31,7 @@ class Method
     protected $params = array();
     protected $params_with_default = array();
     protected $interfaces = array();
+    protected $real_name;
     protected $return = null;
 
     /**
@@ -45,6 +46,7 @@ class Method
         $this->method = $method;
         $this->interfaces = $interfaces;
         $this->name = $methodName ?: $method->name;
+        $this->real_name = $method->name;
         $this->namespace = $method->getDeclaringClass()->getNamespaceName();
 
         //Create a DocBlock and serializer instance
@@ -110,6 +112,16 @@ class Method
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * Get the real method name
+     *
+     * @return string
+     */
+    public function getRealName()
+    {
+        return $this->real_name;
     }
 
     /**


### PR DESCRIPTION
This PR fixes problem, described in #712 

Also, there is avoided code duplication in Macro constructor which makes me confusing why it is different if there nearly all code is the same.