### PR TITLE
Fix missed autocomplete in helper view

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -1,4 +1,10 @@
 <?= '<?php' ?>
+<?php
+/** @var \Barryvdh\LaravelIdeHelper\Alias[][] $namespaces_by_alias_ns */
+/** @var \Barryvdh\LaravelIdeHelper\Alias[][] $namespaces_by_extends_ns */
+/** @var bool $include_fluent */
+/** @var string $helpers */
+?>
 
 // @formatter:off
 

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -1,9 +1,11 @@
 <?= '<?php' ?>
 <?php
-/** @var \Barryvdh\LaravelIdeHelper\Alias[][] $namespaces_by_alias_ns */
-/** @var \Barryvdh\LaravelIdeHelper\Alias[][] $namespaces_by_extends_ns */
-/** @var bool $include_fluent */
-/** @var string $helpers */
+/**
+ * @var \Barryvdh\LaravelIdeHelper\Alias[][] $namespaces_by_alias_ns
+ * @var \Barryvdh\LaravelIdeHelper\Alias[][] $namespaces_by_extends_ns
+ * @var bool $include_fluent
+ * @var string $helpers
+ */
 ?>
 
 // @formatter:off

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -171,7 +171,7 @@ class Alias
     /**
      * Get the methods found by this Alias
      *
-     * @return array
+     * @return array|Method[]
      */
     public function getMethods()
     {


### PR DESCRIPTION
I noticed that there is missed autocomplete for variables in **helpers** view.

![image](https://user-images.githubusercontent.com/13823215/46263075-26c07e00-c513-11e8-8e2b-1fd61cd00fac.png)

For me, as a new guy in this project, it was unclear what vars in view are and which methods are called.

So I added type binding and now it's much easier for new contributors to figure out what's going on here.

![image](https://user-images.githubusercontent.com/13823215/46263097-61c2b180-c513-11e8-83f6-92de043bc199.png)