### PR TITLE
Fix: Parametrized relationships prevent generation of metadata

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -482,7 +482,7 @@ class ModelsCommand extends Command
                             //Resolve the relation's model to a Relation object.
                             $methodReflection = new \ReflectionMethod($model, $method);
                             if ($methodReflection->getNumberOfParameters()) {
-                                return;
+                                continue;
                             }
 
                             $relationObj = $model->$method();


### PR DESCRIPTION
This change fixes a bug where when there is a parameter taken by a relationship 
`getPropertiesFromMethods` function will return instead of going to next method on the list.