### PR TITLE
if aliases not Redis, don't skip

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -198,7 +198,7 @@ class Generator
         // Get all aliases
         foreach ($this->getAliases() as $name => $facade) {
             // Skip the Redis facade, if not available (otherwise Fatal PHP Error)
-            if ($facade == 'Illuminate\Support\Facades\Redis' && !class_exists('Predis\Client')) {
+            if ($facade == 'Illuminate\Support\Facades\Redis' && $name == 'Redis' && !class_exists('Predis\Client')) {
                 continue;
             }
 


### PR DESCRIPTION
"laravel/framework": "5.7.*"

config/database.php

```php
    'redis' => [

        'client' => 'phpredis',

        'default' => [
            'host' => env('REDIS_HOST', '127.0.0.1'),
            'port' => 6379,
            'database' => 0,
        ],

    ],
```

config/app.php

```php
'aliases' => [
    // ....
    'RedisServer'  => Illuminate\Support\Facades\Redis::class,
]

```