### PR TITLE
fix: Helper has syntax error when real method is closure.

### DIFF
--- a/src/Method.php
+++ b/src/Method.php
@@ -48,6 +48,10 @@ class Method
         $this->interfaces = $interfaces;
         $this->name = $methodName ?: $method->name;
         $this->real_name = $method->name;
+        if (preg_match('/\{(.+)}/', $this->real_name, $matches)) {
+            // 'FQCN::NAMESPACE\{closure}()' -> 'FQCN::closure()'
+            list(, $this->real_name) = $matches;
+        }
         $this->initClassDefinedProperties($method, $class);
 
         //Create a DocBlock and serializer instance


### PR DESCRIPTION
Thanks for the helpful package!

I'd like to fix syntax errors that occur in _ide_helper when real method is closure.

current: (syntax error)
```php
return \Illuminate\Http\Request::Illuminate\Foundation\Providers\{closure}($rules, $params);
```

want this: (undefined method warning)
```php
return \Illuminate\Http\Request::closure($rules, $params);
```