### PR TITLE
Resolve how to call the original methods.

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -36,7 +36,7 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
             //Method inherited from <?= $method->getDeclaringClass() ?>
             <?php endif; ?>
 
-            <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRoot() ?>::<?= $method->getRealName() ?>(<?= $method->getParams() ?>);
+            <?= $method->getRootMethodCall('            ') ?>;
         }
         <?php endforeach; ?> 
     }
@@ -58,7 +58,7 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
                 //Method inherited from <?= $method->getDeclaringClass() ?>
                 <?php endif; ?>
     
-                <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRoot() ?>::<?= $method->getRealName() ?>(<?= $method->getParams() ?>);
+                <?= $method->getRootMethodCall('                ') ?>;
             }
         <?php endforeach; ?>
 <?php endif; ?>}


### PR DESCRIPTION
Thanks for the useful package and maintenance.

When calling the original method, I would like to use static call or instance method call, as appropriate.
Also, want to resolve the return type when it was $this.

current:
("Non-static method 'withGlobalScope' should not be called statically" warning in PHPStorm)
("Return value is expected to be 'Eloquent', 'Illuminate\Database\Eloquent\Builder' returned" warning in PHPStorm)
```php
/**
 * Register a new global scope.
 *
 * @param string $identifier
 * @param \Illuminate\Database\Eloquent\Scope|\Closure $scope
 * @return $this
 * @static 
 */ 
public static function withGlobalScope($identifier, $scope)
{
    return \Illuminate\Database\Eloquent\Builder::withGlobalScope($identifier, $scope);
}
```

Idea
```php
/**
 * Register a new global scope.
 *
 * @param string $identifier
 * @param \Illuminate\Database\Eloquent\Scope|\Closure $scope
 * @return \Illuminate\Database\Eloquent\Builder 
 * @static 
 */ 
public static function withGlobalScope($identifier, $scope)
{
    /** @var \Illuminate\Database\Eloquent\Builder $instance */
    return $instance->withGlobalScope($identifier, $scope);
}
```