### PR TITLE
fix: warning when call the instance method

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -36,7 +36,10 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
             //Method inherited from <?= $method->getDeclaringClass() ?>
             <?php endif; ?>
 
-            <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRoot() ?>::<?= $method->getRealName() ?>(<?= $method->getParams() ?>);
+            <?php if($method->isInstanceCall()):?>
+            /** @var <?=$method->getRoot()?> $instance */
+            <?php endif?>
+            <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRootMethodCall() ?>;
         }
         <?php endforeach; ?> 
     }
@@ -57,8 +60,11 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
     
                 //Method inherited from <?= $method->getDeclaringClass() ?>
                 <?php endif; ?>
-    
-                <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRoot() ?>::<?= $method->getRealName() ?>(<?= $method->getParams() ?>);
+
+                <?php if($method->isInstanceCall()):?>
+                /** @var <?=$method->getRoot()?> $instance */
+                <?php endif?>
+                <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRootMethodCall() ?>;
             }
         <?php endforeach; ?>
 <?php endif; ?>}

--- a/src/Method.php
+++ b/src/Method.php
@@ -34,6 +34,7 @@ class Method
     protected $interfaces = array();
     protected $real_name;
     protected $return = null;
+    protected $root;
 
     /**
      * @param \ReflectionMethod|\ReflectionFunctionAbstract $method
@@ -49,6 +50,9 @@ class Method
         $this->name = $methodName ?: $method->name;
         $this->real_name = $method->name;
         $this->initClassDefinedProperties($method, $class);
+
+        //Reference the 'real' function in the declaring class
+        $this->root = '\\' . ltrim($class->getName(), '\\');
 
         //Create a DocBlock and serializer instance
         $this->initPhpDoc($method);
@@ -66,9 +70,6 @@ class Method
 
         //Make the method static
         $this->phpdoc->appendTag(Tag::createInstance('@static', $this->phpdoc));
-
-        //Reference the 'real' function in the declaring class
-        $this->root = '\\' . ltrim($class->getName(), '\\');
     }
 
     /**
@@ -108,6 +109,26 @@ class Method
     public function getRoot()
     {
         return $this->root;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isInstanceCall()
+    {
+        return ! ($this->method->isClosure() || $this->method->isStatic());
+    }
+
+    /**
+     * @return string
+     */
+    public function getRootMethodCall()
+    {
+        if ($this->isInstanceCall()) {
+            return "\$instance->{$this->getRealName()}({$this->getParams()})";
+        } else {
+            return "{$this->getRoot()}::{$this->getRealName()}({$this->getParams()})";
+        }
     }
 
     /**
@@ -243,6 +264,10 @@ class Method
             // Set the changed content
             $tag->setContent($returnValue . ' ' . $tag->getDescription());
             $this->return = $returnValue;
+
+            if ($tag->getType() === '$this') {
+                $tag->setType($this->root);
+            }
         } else {
             $this->return = null;
         }


### PR DESCRIPTION
When calling the original method, I would like to use static call or instance method call, as appropriate.
Also, want to resolve the return type when it was $this.

current:
("Non-static method 'withGlobalScope' should not be called statically" warning in PHPStorm)
("Return value is expected to be 'Eloquent', 'Illuminate\Database\Eloquent\Builder' returned" warning in PHPStorm)
```php
/**
 * Register a new global scope.
 *
 * @param string $identifier
 * @param \Illuminate\Database\Eloquent\Scope|\Closure $scope
 * @return $this
 * @static 
 */ 
public static function withGlobalScope($identifier, $scope)
{
    return \Illuminate\Database\Eloquent\Builder::withGlobalScope($identifier, $scope);
}
```

Idea
```php
/**
 * Register a new global scope.
 *
 * @param string $identifier
 * @param \Illuminate\Database\Eloquent\Scope|\Closure $scope
 * @return \Illuminate\Database\Eloquent\Builder 
 * @static 
 */ 
public static function withGlobalScope($identifier, $scope)
{
    /** @var \Illuminate\Database\Eloquent\Builder $instance */
    return $instance->withGlobalScope($identifier, $scope);
}
```