### PR TITLE
bugfix - Do not use the real_name for closures

### DIFF
--- a/src/Method.php
+++ b/src/Method.php
@@ -47,7 +47,7 @@ class Method
         $this->method = $method;
         $this->interfaces = $interfaces;
         $this->name = $methodName ?: $method->name;
-        $this->real_name = $method->name;
+        $this->real_name = $method->isClosure() ? $this->name : $method->name;
         $this->initClassDefinedProperties($method, $class);
 
         //Create a DocBlock and serializer instance


### PR DESCRIPTION
In https://github.com/barryvdh/laravel-ide-helper/commit/5d8d93273f67797f61b92cc32690d058b6c6b4d9, an issue was introduced causing syntax errors to appear for methods defined in Macro's.

See issues: https://github.com/barryvdh/laravel-ide-helper/issues/726, https://github.com/barryvdh/laravel-ide-helper/issues/734

This is caused by trying to retrieve the real method name of an anonymous function (a closure).  Closures do not have a method name that makes sense to use in the ide_helper
file. e.g. `Illuminate\Foundation\Providers\{closure}` would be the real_name instead of
just `validate`. So for the closure methods, we should just use the provided
methodName instead.