### PR TITLE
bugfix - Prevent redeclaring methods inside Aliases

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -176,6 +176,10 @@ class Alias
      */
     public function getMethods()
     {
+        if (count($this->methods) > 0) {
+            return $this->methods;
+        }
+
         $this->addMagicMethods();
         $this->detectMethods();
         return $this->methods;
@@ -411,10 +415,9 @@ class Alias
      */
     protected function removeDuplicateMethodsFromPhpDoc()
     {
-        $methods = count($this->methods) > 0 ? $this->methods : $this->getMethods();
         $methodNames = array_map(function (Method $method) {
             return $method->getName();
-        }, $methods);
+        }, $this->getMethods());
 
         foreach ($this->phpdoc->getTags() as $tag) {
             if ($tag instanceof MethodTag && in_array($tag->getMethodName(), $methodNames)) {


### PR DESCRIPTION
This pull request fixes issue https://github.com/barryvdh/laravel-ide-helper/issues/739.

The getMethods function gets called both in the removeDuplicateMethodsFromPhpDoc
function and in helper.php, which causes the method detection to be performed twice.

Parts of the method detection includes a check for duplicate methods, but Macro
methods for example, aren't checked for duplicates.

Instead of checking everywhere if we're not adding duplicates, I've included a
check in the getMethods call to just use the already generated methods
if they have been generated already.