### PR TITLE
Update ReflectionDocBlock to v2.0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/support": "^5.5,<5.8",
         "illuminate/console": "^5.5,<5.8",
         "illuminate/filesystem": "^5.5,<5.8",
-        "barryvdh/reflection-docblock": "^2.0.5",
+        "barryvdh/reflection-docblock": "^2.0.6",
         "composer/composer": "^1.6"
     },
     "require-dev": {


### PR DESCRIPTION
This PR should solve the second part of #739.

This update improves the parsing of return types, allowing array return
types to be recognized.

This was needed to properly recognize the files and allFiles methods as
duplicates (the function filtering duplicate definitions - `removeDuplicateMethodsFromPhpDoc` in `Alias.php` - didn't recognise them as duplicates, because the return type was seen as part
of the name).