### PR TITLE
Include DocBloc’s from classes to allow deeper code inspection

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -193,4 +193,16 @@ return array(
         'integer' => 'int',
         'boolean' => 'bool',
    ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Include DocBlocks from classes
+    |--------------------------------------------------------------------------
+    |
+    | Include DocBlocks from classes to allow additional code inspection for
+    | magic methods and properties.
+    |
+    */
+    'include_class_docblocks' => false,
+
 );

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -10,11 +10,12 @@
 
 namespace Barryvdh\LaravelIdeHelper;
 
+use ReflectionClass;
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Context;
-use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
 use Barryvdh\Reflection\DocBlock\Tag\MethodTag;
-use ReflectionClass;
+use Illuminate\Config\Repository as ConfigRepository;
+use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
 
 class Alias
 {
@@ -35,17 +36,22 @@ class Alias
     protected $interfaces = array();
     protected $phpdoc = null;
 
+    /** @var ConfigRepository  */
+    protected $config;
+
     /**
      * @param string $alias
      * @param string $facade
      * @param array $magicMethods
      * @param array $interfaces
+     * @param ConfigRepository $config
      */
-    public function __construct($alias, $facade, $magicMethods = array(), $interfaces = array())
+    public function __construct($alias, $facade, $magicMethods = array(), $interfaces = array(), ConfigRepository $config)
     {
         $this->alias = $alias;
         $this->magicMethods = $magicMethods;
         $this->interfaces = $interfaces;
+        $this->config = $config;
 
         // Make the class absolute
         $facade = '\\' . ltrim($facade, '\\');
@@ -403,6 +409,16 @@ class Alias
         $serializer = new DocBlockSerializer(1, $prefix);
 
         if ($this->phpdoc) {
+            if ($this->config->get('ide-helper.include_class_docblocks')) {
+                // if a class doesn't expose any DocBlock tags
+                // we can perform reflection on the class and
+                // add in the original class DocBlock
+                if (count($this->phpdoc->getTags()) === 0) {
+                    $class = new ReflectionClass($this->root);
+                    $this->phpdoc = new DocBlock($class->getDocComment());
+                }
+            }
+
             $this->removeDuplicateMethodsFromPhpDoc();
             return $serializer->getDocComment($this->phpdoc);
         }

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -46,7 +46,7 @@ class Alias
      * @param array            $magicMethods
      * @param array            $interfaces
      */
-    public function __construct(ConfigRepository $config, $alias, $facade, $magicMethods = array(), $interfaces = array())
+    public function __construct($config, $alias, $facade, $magicMethods = array(), $interfaces = array())
     {
         $this->alias = $alias;
         $this->magicMethods = $magicMethods;

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -40,13 +40,13 @@ class Alias
     protected $config;
 
     /**
-     * @param string $alias
-     * @param string $facade
-     * @param array $magicMethods
-     * @param array $interfaces
      * @param ConfigRepository $config
+     * @param string           $alias
+     * @param string           $facade
+     * @param array            $magicMethods
+     * @param array            $interfaces
      */
-    public function __construct($alias, $facade, $magicMethods = array(), $interfaces = array(), ConfigRepository $config)
+    public function __construct(ConfigRepository $config, $alias, $facade, $magicMethods = array(), $interfaces = array())
     {
         $this->alias = $alias;
         $this->magicMethods = $magicMethods;
@@ -422,7 +422,7 @@ class Alias
             $this->removeDuplicateMethodsFromPhpDoc();
             return $serializer->getDocComment($this->phpdoc);
         }
-        
+
         return '';
     }
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -203,7 +203,7 @@ class Generator
             }
 
             $magicMethods = array_key_exists($name, $this->magic) ? $this->magic[$name] : array();
-            $alias = new Alias($name, $facade, $magicMethods, $this->interfaces, $this->config);
+            $alias = new Alias($this->config, $name, $facade, $magicMethods, $this->interfaces);
             if ($alias->isValid()) {
                 //Add extra methods, from other classes (magic static calls)
                 if (array_key_exists($name, $this->extra)) {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -203,7 +203,7 @@ class Generator
             }
 
             $magicMethods = array_key_exists($name, $this->magic) ? $this->magic[$name] : array();
-            $alias = new Alias($name, $facade, $magicMethods, $this->interfaces);
+            $alias = new Alias($name, $facade, $magicMethods, $this->interfaces, $this->config);
             if ($alias->isValid()) {
                 //Add extra methods, from other classes (magic static calls)
                 if (array_key_exists($name, $this->extra)) {


### PR DESCRIPTION
Currently if a class has magic methods and the class include type hints they aren't resolved by the ide-helper package.

For example before:

<img width="528" alt="screenshot_258" src="https://user-images.githubusercontent.com/1677419/50330896-c49b7600-0561-11e9-9225-17261a267a27.png">

and after:

<img width="534" alt="screenshot_259" src="https://user-images.githubusercontent.com/1677419/50330909-cebd7480-0561-11e9-970f-b13ce39608b5.png">

My proposed PR simply inspects classes, includes their DocBlocks to add in any comments and PhpDoc including @method's to allow type hinting.
