### PR TITLE
Allow Laravel 5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
     ],
     "require": {
         "php": ">=7",
-        "illuminate/support": "^5.5,<5.8",
-        "illuminate/console": "^5.5,<5.8",
-        "illuminate/filesystem": "^5.5,<5.8",
+        "illuminate/support": "^5.5,<5.9",
+        "illuminate/console": "^5.5,<5.9",
+        "illuminate/filesystem": "^5.5,<5.9",
         "barryvdh/reflection-docblock": "^2.0.6",
         "composer/composer": "^1.6"
     },
     "require-dev": {
-        "illuminate/config": "^5.1,<5.8",
-        "illuminate/view": "^5.1,<5.8",
+        "illuminate/config": "^5.1,<5.9",
+        "illuminate/view": "^5.1,<5.9",
         "phpro/grumphp": "^0.14",
         "phpunit/phpunit" : "4.*",
         "scrutinizer/ocular": "~1.1",


### PR DESCRIPTION
I use "laravel/framework": "dev-master as 5.7.999" (alias because of the <5.8 of laravel-ide-helper) and it works perfectly so I assume, there is no real reason to lock this project compatibility to <5.8