### PR TITLE
Add support for factory()->create() return types

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -1,6 +1,6 @@
 <?php
 
-return array(
+return [
 
     /*
     |--------------------------------------------------------------------------
@@ -11,9 +11,9 @@ return array(
     |
     */
 
-    'filename'  => '_ide_helper',
-    'format'    => 'php',
-    
+    'filename' => '_ide_helper',
+    'format'   => 'php',
+
     'meta_filename' => '.phpstorm.meta.php',
 
     /*
@@ -26,6 +26,18 @@ return array(
     */
 
     'include_fluent' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Factory Builders
+    |--------------------------------------------------------------------------
+    |
+    | Set to true to generate factory generators for better factory()
+    | method auto-completion.
+    |
+    */
+
+    'include_factory_builders' => false,
 
     /*
     |--------------------------------------------------------------------------
@@ -65,9 +77,9 @@ return array(
 
     'include_helpers' => false,
 
-    'helper_files' => array(
+    'helper_files' => [
         base_path().'/vendor/laravel/framework/src/Illuminate/Support/helpers.php',
-    ),
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -79,10 +91,9 @@ return array(
     |
     */
 
-    'model_locations' => array(
+    'model_locations' => [
         'app',
-    ),
-
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -93,13 +104,13 @@ return array(
     |
     */
 
-    'extra' => array(
-        'Eloquent' => array('Illuminate\Database\Eloquent\Builder', 'Illuminate\Database\Query\Builder'),
-        'Session' => array('Illuminate\Session\Store'),
-    ),
+    'extra' => [
+        'Eloquent' => [ 'Illuminate\Database\Eloquent\Builder', 'Illuminate\Database\Query\Builder' ],
+        'Session'  => [ 'Illuminate\Session\Store' ],
+    ],
 
-    'magic' => array(
-        'Log' => array(
+    'magic' => [
+        'Log' => [
             'debug'     => 'Monolog\Logger::addDebug',
             'info'      => 'Monolog\Logger::addInfo',
             'notice'    => 'Monolog\Logger::addNotice',
@@ -108,8 +119,8 @@ return array(
             'critical'  => 'Monolog\Logger::addCritical',
             'alert'     => 'Monolog\Logger::addAlert',
             'emergency' => 'Monolog\Logger::addEmergency',
-        )
-    ),
+        ],
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -121,9 +132,9 @@ return array(
     |
     */
 
-    'interfaces' => array(
+    'interfaces'                  => [
 
-    ),
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -151,9 +162,9 @@ return array(
     |  ),
     |
     */
-    'custom_db_types' => array(
+    'custom_db_types'             => [
 
-    ),
+    ],
 
     /*
      |--------------------------------------------------------------------------
@@ -189,8 +200,8 @@ return array(
     | Cast the given "real type" to the given "type".
     |
     */
-   'type_overrides' => array(
+    'type_overrides'              => [
         'integer' => 'int',
         'boolean' => 'bool',
-   ),
-);
+    ],
+];

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -13,7 +13,7 @@ return array(
 
     'filename'  => '_ide_helper',
     'format'    => 'php',
-
+    
     'meta_filename' => '.phpstorm.meta.php',
 
     /*

--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,18 @@ After publishing vendor, simply change the `include_fluent` line your `config/id
 And then run `php artisan ide-helper:generate` , you will now see all of the Fluent methods are recognized by your IDE.
 
 
+### Auto-completion for factory builders
+
+If you would like the `factory()->create()` and `factory()->make()` methods to return the correct model class,
+you can enable custom factory builders with the `include_factory_builders` line your `config/ide-helper.php` file.
+
+```php
+'include_factory_builders' => true,
+```
+
+For this to work, you must also publish the PhpStorm Meta file (see below). 
+
+
 ## PhpStorm Meta for Container instances
 
 It's possible to generate a PhpStorm meta file to [add support for factory design pattern](https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata). For Laravel, this means we can make PhpStorm understand what kind of object we are resolving from the IoC Container. For example, `events` will return an `Illuminate\Events\Dispatcher` object, so with the meta file you can call `app('events')` and it will autocomplete the Dispatcher methods.

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -20,16 +20,16 @@
  * @see https://github.com/barryvdh/laravel-ide-helper
  */
 
-<?php foreach($namespaces_by_extends_ns as $namespace => $aliases): ?>
+<?php foreach ($namespaces_by_extends_ns as $namespace => $aliases): ?>
 <?php if ($namespace == '\Illuminate\Database\Eloquent'): continue; endif; ?>
-namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
-<?php foreach($aliases as $alias): ?>
+namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
+<?php foreach ($aliases as $alias): ?>
 
-    <?= trim($alias->getDocComment('    ')) ?> 
+    <?= trim($alias->getDocComment('    ')) ?>
     <?= $alias->getClassType() ?> <?= $alias->getExtendsClass() ?> {
         <?php foreach($alias->getMethods() as $method): ?>
 
-        <?= trim($method->getDocComment('        ')) ?> 
+        <?= trim($method->getDocComment('        ')) ?>
         public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
         {<?php if($method->getDeclaringClass() !== $method->getRoot()): ?>
 
@@ -41,23 +41,23 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
             <?php endif?>
             <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRootMethodCall() ?>;
         }
-        <?php endforeach; ?> 
+        <?php endforeach; ?>
     }
-<?php endforeach; ?> 
+<?php endforeach; ?>
 }
 
 <?php endforeach; ?>
 
 <?php foreach($namespaces_by_alias_ns as $namespace => $aliases): ?>
-namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
+namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
 <?php foreach($aliases as $alias): ?>
 
     <?= $alias->getClassType() ?> <?= $alias->getShortName() ?> extends <?= $alias->getExtends() ?> {<?php if ($alias->getExtendsNamespace() == '\Illuminate\Database\Eloquent'): ?>
-        <?php foreach($alias->getMethods() as $method): ?> 
-            <?= trim($method->getDocComment('            ')) ?> 
+        <?php foreach($alias->getMethods() as $method): ?>
+            <?= trim($method->getDocComment('            ')) ?>
             public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
             {<?php if($method->getDeclaringClass() !== $method->getRoot()): ?>
-    
+
                 //Method inherited from <?= $method->getDeclaringClass() ?>
                 <?php endif; ?>
 
@@ -68,14 +68,14 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
             }
         <?php endforeach; ?>
 <?php endif; ?>}
-<?php endforeach; ?> 
+<?php endforeach; ?>
 }
 
 <?php endforeach; ?>
 
 <?php if($helpers): ?>
 namespace {
-<?= $helpers ?> 
+<?= $helpers ?>
 }
 <?php endif; ?>
 
@@ -105,3 +105,13 @@ namespace Illuminate\Support {
     class Fluent {}
 }
 <?php endif ?>
+
+<?php foreach ($factories as $factory): ?>
+namespace <?=$factory->getNamespaceName()?> {
+    /**
+    * @method \Illuminate\Database\Eloquent\Collection|<?=$factory->getShortName()?>[]|<?=$factory->getShortName()?> create($attributes = [])
+    * @method \Illuminate\Database\Eloquent\Collection|<?=$factory->getShortName()?>[]|<?=$factory->getShortName()?> make($attributes = [])
+    */
+    class <?=$factory->getShortName()?>FactoryBuilder extends \Illuminate\Database\Eloquent\FactoryBuilder {}
+}
+<?php endforeach; ?>

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -20,10 +20,10 @@
  * @see https://github.com/barryvdh/laravel-ide-helper
  */
 
-<?php foreach ($namespaces_by_extends_ns as $namespace => $aliases): ?>
+<?php foreach($namespaces_by_extends_ns as $namespace => $aliases): ?>
 <?php if ($namespace == '\Illuminate\Database\Eloquent'): continue; endif; ?>
 namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
-<?php foreach ($aliases as $alias): ?>
+<?php foreach($aliases as $alias): ?>
 
     <?= trim($alias->getDocComment('    ')) ?>
     <?= $alias->getClassType() ?> <?= $alias->getExtendsClass() ?> {

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -22,14 +22,14 @@
 
 <?php foreach($namespaces_by_extends_ns as $namespace => $aliases): ?>
 <?php if ($namespace == '\Illuminate\Database\Eloquent'): continue; endif; ?>
-namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
+namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
 <?php foreach($aliases as $alias): ?>
 
-    <?= trim($alias->getDocComment('    ')) ?>
+    <?= trim($alias->getDocComment('    ')) ?> 
     <?= $alias->getClassType() ?> <?= $alias->getExtendsClass() ?> {
         <?php foreach($alias->getMethods() as $method): ?>
 
-        <?= trim($method->getDocComment('        ')) ?>
+        <?= trim($method->getDocComment('        ')) ?> 
         public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
         {<?php if($method->getDeclaringClass() !== $method->getRoot()): ?>
 
@@ -41,23 +41,23 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
             <?php endif?>
             <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRootMethodCall() ?>;
         }
-        <?php endforeach; ?>
+        <?php endforeach; ?> 
     }
-<?php endforeach; ?>
+<?php endforeach; ?> 
 }
 
 <?php endforeach; ?>
 
 <?php foreach($namespaces_by_alias_ns as $namespace => $aliases): ?>
-namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
+namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
 <?php foreach($aliases as $alias): ?>
 
     <?= $alias->getClassType() ?> <?= $alias->getShortName() ?> extends <?= $alias->getExtends() ?> {<?php if ($alias->getExtendsNamespace() == '\Illuminate\Database\Eloquent'): ?>
-        <?php foreach($alias->getMethods() as $method): ?>
-            <?= trim($method->getDocComment('            ')) ?>
+        <?php foreach($alias->getMethods() as $method): ?> 
+            <?= trim($method->getDocComment('            ')) ?> 
             public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
             {<?php if($method->getDeclaringClass() !== $method->getRoot()): ?>
-
+    
                 //Method inherited from <?= $method->getDeclaringClass() ?>
                 <?php endif; ?>
 
@@ -68,14 +68,14 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
             }
         <?php endforeach; ?>
 <?php endif; ?>}
-<?php endforeach; ?>
+<?php endforeach; ?> 
 }
 
 <?php endforeach; ?>
 
 <?php if($helpers): ?>
 namespace {
-<?= $helpers ?>
+<?= $helpers ?> 
 }
 <?php endif; ?>
 

--- a/resources/views/meta.php
+++ b/resources/views/meta.php
@@ -20,6 +20,15 @@ namespace PHPSTORM_META {
     ]));
 <?php endforeach; ?>
 
+<?php if (count($factories)): ?>
+	override(\factory(0), map([
+        '' => '@FactoryBuilder',
+<?php foreach($factories as $factory): ?>
+        '<?= $factory->getName() ?>' => \<?= $factory->getName() ?>FactoryBuilder::class,
+<?php endforeach; ?>
+	]));
+<?php endif; ?>
+
     override(\Illuminate\Support\Arr::add(0), type(0));
     override(\Illuminate\Support\Arr::except(0), type(0));
     override(\Illuminate\Support\Arr::first(0), elementType(0));

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -67,6 +67,7 @@ class Alias
         }
 
         $this->addClass($this->root);
+        $this->detectFake();
         $this->detectNamespace();
         $this->detectClassType();
         $this->detectExtendsNamespace();
@@ -189,6 +190,30 @@ class Alias
         $this->addMagicMethods();
         $this->detectMethods();
         return $this->methods;
+    }
+
+    /**
+     * Detect class returned by ::fake()
+     */
+    protected function detectFake()
+    {
+        $facade = $this->facade;
+
+        if (!method_exists($facade, 'fake')) {
+            return;
+        }
+
+        $real = $facade::getFacadeRoot();
+
+        try {
+            $facade::fake();
+            $fake = $facade::getFacadeRoot();
+            if ($fake !== $real) {
+                $this->addClass(get_class($fake));
+            }
+        } finally {
+            $facade::swap($real);
+        }
     }
 
     /**

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -198,13 +198,13 @@ class Alias
     protected function detectFake()
     {
         $facade = $this->facade;
-
+        
         if (!method_exists($facade, 'fake')) {
             return;
         }
 
         $real = $facade::getFacadeRoot();
-
+        
         try {
             $facade::fake();
             $fake = $facade::getFacadeRoot();

--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -10,6 +10,7 @@
 
 namespace Barryvdh\LaravelIdeHelper\Console;
 
+use Barryvdh\LaravelIdeHelper\Factories;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -76,6 +77,9 @@ class MetaCommand extends Command
      */
     public function handle()
     {
+        // Needs to run before exception handler is registered
+        $factories = $this->config->get('ide-helper.include_factory_builders') ? Factories::all() : [];
+
         $this->registerClassAutoloadExceptions();
 
         $bindings = array();
@@ -97,9 +101,12 @@ class MetaCommand extends Command
             }
         }
 
+
+
         $content = $this->view->make('meta', [
           'bindings' => $bindings,
           'methods' => $this->methods,
+          'factories' => $factories,
         ])->render();
 
         $filename = $this->option('filename');

--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -103,8 +103,6 @@ class MetaCommand extends Command
             }
         }
 
-
-
         $content = $this->view->make('meta', [
           'bindings' => $bindings,
           'methods' => $this->methods,

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -457,7 +457,9 @@ class ModelsCommand extends Command
                     $reflection = new \ReflectionMethod($model, $method);
 
                     if ($returnType = $reflection->getReturnType()) {
-                        $type = $returnType instanceof \ReflectionNamedType ? $returnType->getName() : (string)$returnType;
+                        $type = $returnType instanceof \ReflectionNamedType
+                            ? $returnType->getName()
+                            : (string)$returnType;
                     } else {
                         // php 7.x type or fallback to docblock
                         $type = (string)$this->getReturnTypeFromDocBlock($reflection);

--- a/src/Factories.php
+++ b/src/Factories.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper;
+
+use Exception;
+use Illuminate\Database\Eloquent\Factory;
+use ReflectionClass;
+
+class Factories
+{
+
+    public static function all()
+    {
+        $factories = [];
+
+        $factory = app(Factory::class);
+
+        $definitions = (new ReflectionClass(Factory::class))->getProperty('definitions');
+        $definitions->setAccessible(true);
+
+        foreach ($definitions->getValue($factory) as $factory_target => $config) {
+            try {
+                $factories[] = new ReflectionClass($factory_target);
+            } catch (Exception $exception) {
+            }
+        }
+
+        return $factories;
+    }
+}

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -86,6 +86,7 @@ class Generator
             ->with('helpers', $this->helpers)
             ->with('version', $app->version())
             ->with('include_fluent', $this->config->get('ide-helper.include_fluent', true))
+	        ->with('factories', $this->config->get('ide-helper.include_factory_builders') ? Factories::all() : [])
             ->render();
     }
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -86,7 +86,7 @@ class Generator
             ->with('helpers', $this->helpers)
             ->with('version', $app->version())
             ->with('include_fluent', $this->config->get('ide-helper.include_fluent', true))
-	        ->with('factories', $this->config->get('ide-helper.include_factory_builders') ? Factories::all() : [])
+            ->with('factories', $this->config->get('ide-helper.include_factory_builders') ? Factories::all() : [])
             ->render();
     }
 


### PR DESCRIPTION
Right now, PhpStorm does not know what the return type of `factory(\App\User::class)->create()` is. To solve this, this PR adds two generators (when `include_factory_builders` is set to `true`):

First, the `generate` command will create "faux" FactoryBuilder classes, like:

```php
namespace App {
    /**
     * @method \Illuminate\Database\Eloquent\Collection|User[]|User create($attributes = [])
     * @method \Illuminate\Database\Eloquent\Collection|User[]|User make($attributes = [])
     */
    class UserFactoryBuilder extends \Illuminate\Database\Eloquent\FactoryBuilder {}
}
```

Second, the `meta` command will override the `factory()` method to return the associated builder class:

```php
override(\factory(0), map([
    '' => '@FactoryBuilder',
    'App\User' => \App\UserFactoryBuilder::class,
]));
```

Now, PhpStorm will think that the return type of `factory(\App\User::class)` is  `\App\UserFactoryBuilder`. Calls to `create()` or `make()` will correctly autocomplete all the methods/properties on the `\App\User` class.