### PR TITLE
Add support for invokable classes as macro function

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -395,6 +395,10 @@ class Alias
             return new \ReflectionMethod($macro_func[0], $macro_func[1]);
         }
 
+        if (is_object($macro_func) && is_callable($macro_func)) {
+            return new \ReflectionMethod($macro_func, '__invoke');
+        }
+
         return new \ReflectionFunction($macro_func);
     }
 


### PR DESCRIPTION
Macros can be used with invokable classes, like so.

```php
<?php

namespace App\Providers;

use Illuminate\Support\ServiceProvider;
use Illuminate\Support\Facades\Response;

class ResponseMacroServiceProvider extends ServiceProvider
{
    public function boot()
    {
        Response::macro('foo', new Foo());
    }
}

class Foo
{
    public function __invoke()
    {
        return 'foobar';
    }
}
```

When running `ide-helper:generate` the following fatal error was thrown.

>Symfony\Component\Debug\Exception\FatalThrowableError  : ReflectionFunction::__construct() expects parameter 1 to be string, object given

This commit fixes this error.