### PR TITLE
Fix php 7.3 bug

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -453,7 +453,7 @@ class ModelsCommand extends Command
                     //Use reflection to inspect the code, based on Illuminate/Support/SerializableClosure.php
                     $reflection = new \ReflectionMethod($model, $method);
                     // php 7.x type or fallback to docblock
-                    $type = (string) $reflection->getReturnType() ?: $this->getReturnTypeFromDocBlock($reflection);
+                    $type = (string) $reflection->getReturnType() ?: (string)$this->getReturnTypeFromDocBlock($reflection);
 
                     $file = new \SplFileObject($reflection->getFileName());
                     $file->seek($reflection->getStartLine() - 1);


### PR DESCRIPTION
fix error on line l 483: 
Exception: stripos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior
Could not analyze class App\Models\Client.