### PR TITLE
Fix regression introduced in #765

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -10,6 +10,7 @@
 
 namespace Barryvdh\LaravelIdeHelper;
 
+use Closure;
 use ReflectionClass;
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Context;
@@ -395,7 +396,7 @@ class Alias
             return new \ReflectionMethod($macro_func[0], $macro_func[1]);
         }
 
-        if (is_object($macro_func) && is_callable($macro_func)) {
+        if (is_object($macro_func) && is_callable($macro_func) && !$macro_func instanceof Closure) {
             return new \ReflectionMethod($macro_func, '__invoke');
         }
 


### PR DESCRIPTION
See my comment https://github.com/barryvdh/laravel-ide-helper/pull/765#issuecomment-471014271:

The change in #765 made anonymous functions get reflected with `ReflectionMethod` instead of `ReflectionFunction`, which makes it lose the doc comment. This means that the generated helpers are missing their return types. This is because Closure is also an object and callable.

To fix it, Closure should be excluded from that new condition.

Edit: More specifically, I think it's because `ReflectionMethod` tries to grab doc comments from `__invoke`, but the comment is actually at the location of the function, not in the Closure instance.