### PR TITLE
Support for custom builder classes

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -446,7 +446,10 @@ class ModelsCommand extends Command
                     }
                 } elseif (in_array($method, ['query', 'newQuery', 'newModelQuery'])) {
                     $reflection = new \ReflectionClass($model);
-                    $this->setMethod($method, '\Illuminate\Database\Eloquent\Builder|\\' . $reflection->getName());
+
+                    $builder = get_class($model->newModelQuery());
+
+                    $this->setMethod($method, "\\{$builder}|\\" . $reflection->getName());
                 } elseif (!method_exists('Illuminate\Database\Eloquent\Model', $method)
                     && !Str::startsWith($method, 'get')
                 ) {


### PR DESCRIPTION
You can override the builder class used on a per model basis. This wasn't supported yet.

For reference: https://mobile.twitter.com/timacdonald87/status/1109964446766497793