### PR TITLE
Chages to x2Many relationships detection & adds $relationship_countt

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -503,13 +503,19 @@ class ModelsCommand extends Command
                                     'morphToMany',
                                     'morphedByMany',
                                 ];
-                                if (in_array($relation, $relations)) {
+                                if (strpos(get_class($relationObj), 'Many') !== false) {
                                     //Collection or array of models (because Collection is Arrayable)
                                     $this->setProperty(
                                         $method,
                                         $this->getCollectionClass($relatedModel) . '|' . $relatedModel . '[]',
                                         true,
                                         null
+                                    );
+                                    $this->setProperty(
+                                        Str::snake($method) . '_count',
+                                        'int|null',
+                                        true,
+                                        false
                                     );
                                 } elseif ($relation === "morphTo") {
                                     // Model isn't specified because relation is polymorphic


### PR DESCRIPTION

 * x to Many relationships are detected via a `Many` keyword in the relationship object class name
   * reason: example: `belongsTo` was incorrectly recognized as `belongsToMany`
 * adds `@property-read int|null $x2Many_relationship_method_name_count` model class docBlock comment
   * when model makes use of `withCount` or `loadCount` there is a property on the resource `$instance->relationship_method_count` that states the count of related models
   * can be `NULL` when `withCount` or `loadCount` aren't used