### PR TITLE
Removed confusing README installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Note: You do need CodeComplice for Sublime Text: https://github.com/spectacles/C
 Require this package with composer using the following command:
 
 ```bash
-composer require barryvdh/laravel-ide-helper
+composer require --dev barryvdh/laravel-ide-helper
 ```
 
 After updating composer, add the service provider to the `providers` array in `config/app.php`
@@ -38,12 +38,6 @@ After updating composer, add the service provider to the `providers` array in `c
 Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class,
 ```
 **Laravel 5.5** uses Package Auto-Discovery, so doesn't require you to manually add the ServiceProvider.
-
-To install this package on only development systems, add the `--dev` flag to your composer command:
-
-```bash
-composer require --dev barryvdh/laravel-ide-helper
-```
 
 In Laravel, instead of adding the service provider in the `config/app.php` file, you can add the following code to your `app/Providers/AppServiceProvider.php` file, within the `register()` method:
 


### PR DESCRIPTION
While installing this for my project, I didn't see the `--dev` instructions until I was literally editing this README for a pull request.

Since laravel-ide-helper is only designed for development purposes, let's just remove the superfluous entry altogether. Smart devs who for some crazy reason need it on prod will know to remove the `--dev`, while less knowledgeable devs won't shoot themselves in the foot accidentally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/barryvdh/laravel-ide-helper/786)
<!-- Reviewable:end -->
