### PR TITLE
Model relation properties being overwritten

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -483,7 +483,7 @@ class ModelsCommand extends Command
                                'morphedByMany' => '\Illuminate\Database\Eloquent\Relations\MorphToMany'
                              ) as $relation => $impl) {
                         $search = '$this->' . $relation . '(';
-                        if (stripos($code, $search) || stripos($impl, (string)$type) !== false) {
+                        if (stripos($code, $search) || $impl === (string)$type) {
                             //Resolve the relation's model to a Relation object.
                             $methodReflection = new \ReflectionMethod($model, $method);
                             if ($methodReflection->getNumberOfParameters()) {


### PR DESCRIPTION
There was a bug introduced in the ModelsCommand here: https://github.com/barryvdh/laravel-ide-helper/commit/bcb881b20d57c3408bead36f1a836bb8137a13b7 in `src/Console/ModelsCommand.php:483`.

The loose string comparison of `stripos($impl, $type) !== false` means that several relation declarations are being overwritten with an incorrectly matched relation based on relation type.

**All `morphTo` relations will be overwritten using the `morphToMany` relation type, and then overwritten again using the `morphedByMany` relation type.** 

This results in PHPDoc block for those relations showing as (for example): 
```
@property-read \Illuminate\Database\Eloquent\Collection|\App\Models\Comms\MessageRecipient[] $owner
```
Instead of: 
```
@property-read \Illuminate\Database\Eloquent\Model|\Eloquent $owner
```


**All `hasMany` relations will be overwritten using the `hasManyThrough` relation type (looks like the logic for handling the two is the same, so no immediate harm here)**
