### PR TITLE
Do not add instances of an anonymous class to the phpstorm_meta file

### DIFF
--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -87,8 +87,9 @@ class MetaCommand extends Command
             }
 
             try {
-                $concrete = $this->laravel->make($abstract);
-                if (is_object($concrete)) {
+				$concrete = $this->laravel->make($abstract);
+				$reflectionClass = new \ReflectionClass($concrete);
+                if (is_object($concrete) && !$reflectionClass->isAnonymous()) {
                     $bindings[$abstract] = get_class($concrete);
                 }
             } catch (\Throwable $e) {


### PR DESCRIPTION
When running `php artisan ide-helper:meta` in a Laravel project where [Lighthouse](https://lighthouse-php.com/) is installed, the `.phpstorm.meta.php` file contains syntax errors because it tries to add the classname of an anonymous class.

This line is what is added to the file:
```php
'Nuwave\Lighthouse\Support\Contracts\ProvidesSubscriptionResolver' => \class@anonymous /var/www/html/scorecardapi/vendor/nuwave/lighthouse/src/LighthouseServiceProvider.php0x7f67abf68775::class,
```

In this pull request, anonymous classes are not added to the `.phpstorm.meta.php` file