### PR TITLE
Add hasOneThrough to ide-helper:models

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -473,6 +473,7 @@ class ModelsCommand extends Command
                     foreach (array(
                                'hasMany' => '\Illuminate\Database\Eloquent\Relations\HasMany',
                                'hasManyThrough' => '\Illuminate\Database\Eloquent\Relations\HasManyThrough',
+                               'hasOneThrough' => '\Illuminate\Database\Eloquent\Relations\HasOneThrough',
                                'belongsToMany' => '\Illuminate\Database\Eloquent\Relations\BelongsToMany',
                                'hasOne' => '\Illuminate\Database\Eloquent\Relations\HasOne',
                                'belongsTo' => '\Illuminate\Database\Eloquent\Relations\BelongsTo',


### PR DESCRIPTION
Added missing relation type.
Currently no doc line generated from hasOneThrough relation.

```
    public function company()
    {
        return $this->hasOneThrough(
            Company::class,
            CompanyUser::class,
        );
    }
```


Expected result:
```
 * @property-read \App\Models\Company $company
```