### PR TITLE
Add support for custom cast classes

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -290,7 +290,7 @@ class ModelsCommand extends Command
                     $realType = '\Illuminate\Support\Collection';
                     break;
                 default:
-                    $realType = 'mixed';
+                    $realType = class_exists($type) ? ('\\' . $type) : 'mixed';
                     break;
             }
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -456,7 +456,7 @@ class ModelsCommand extends Command
                     //Use reflection to inspect the code, based on Illuminate/Support/SerializableClosure.php
                     $reflection = new \ReflectionMethod($model, $method);
                     // php 7.x type or fallback to docblock
-                    $type = (string) $reflection->getReturnType() ?: (string)$this->getReturnTypeFromDocBlock($reflection);
+                    $type = (string)($reflection->getReturnType() ?: $this->getReturnTypeFromDocBlock($reflection));
 
                     $file = new \SplFileObject($reflection->getFileName());
                     $file->seek($reflection->getStartLine() - 1);


### PR DESCRIPTION
Some packages such as https://github.com/mad-web/laravel-enum allow using a class name as the cast type instead of setting up an accessor. 

If this is the case, the overrides will allow a call to `->castedProperty` to return an instance of whatever the class was e.g.

```php
class MyModel extends Model
{

   use EnumCastable;

    protected $casts = [
        'status' => \App\Enums\MyModelStatusEnum::class
    ];
}
```

Calling `$model->status` will return an instance of `MyModelStatusEnum`.

This small patch means that if the provided cast type is a valid class name then rather than returning 
```php
@property mixed $status
```
We will assume it will return an instance of that class and so instead we output 
```php
@property \App\Enums\MyModelStatusEnum $status
```

In the event that the developer actually doesn't want the class name (very unlikely) the developer can always use the `ide-helper.type_overrides` option to set it back to mixed.

## ⚠️ Failing Code Style check is not related to this PR ⚠️
The second PR to this file is just a fix to an unrelated code style issue.