### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,13 +91,6 @@ The `Illuminate/Support/helpers.php` is already set up, but you can add/remove y
 
 ### Automatic phpDocs for models
 
-> For version < 2.6.5, you need to add `doctrine/dbal: ~2.3` to require-dev in your own composer.json to get database columns.
-
-
-```bash
-composer require --dev doctrine/dbal
-```
-
 If you don't want to write your properties yourself, you can use the command `php artisan ide-helper:models` to generate
 phpDocs, based on table columns, relations and getters/setters. You can write the comments directly to your Model file, using the `--write (-W)` option. By default, you are asked to overwrite or write to a separate file (`_ide_helper_models.php`). You can force No with `--nowrite (-N)`.
 Please make sure to backup your models, before writing the info.

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ The `Illuminate/Support/helpers.php` is already set up, but you can add/remove y
 
 ### Automatic phpDocs for models
 
-> You need to add `doctrine/dbal: ~2.3` to require-dev in your own composer.json to get database columns.
+> For version < 2.6.5, you need to add `doctrine/dbal: ~2.3` to require-dev in your own composer.json to get database columns.
 
 
 ```bash


### PR DESCRIPTION
In version 2.6.5, this commit https://github.com/barryvdh/laravel-ide-helper/commit/f8a8cb18e0a42ae4131b7ed865fe792f9b34630c made it so library's consumer no longer need to pull in `doctrine/dbal` manually. I think we should mention that in the readme file as well. Although I'm not sure if it adds any value to the file itself or not.