### PR TITLE
[PSR-12] Update param type array to use short array syntax

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -730,7 +730,7 @@ class ModelsCommand extends Command
                 if (is_bool($default)) {
                     $default = $default ? 'true' : 'false';
                 } elseif (is_array($default)) {
-                    $default = 'array()';
+                    $default = '[]';
                 } elseif (is_null($default)) {
                     $default = 'null';
                 } elseif (is_int($default)) {

--- a/src/Method.php
+++ b/src/Method.php
@@ -321,7 +321,7 @@ class Method
                 if (is_bool($default)) {
                     $default = $default ? 'true' : 'false';
                 } elseif (is_array($default)) {
-                    $default = 'array()';
+                    $default = '[]';
                 } elseif (is_null($default)) {
                     $default = 'null';
                 } elseif (is_int($default)) {


### PR DESCRIPTION
This update changes the param type in methods to `[]` rather than `array()` as part of PSR-12 as enabling the new inspections in PHPstorm highlights this as an issue.

e.g.
```php
* @method static \Illuminate\Database\Eloquent\Builder|\App\Something whereHasTags($tags = array())
```
becomes
```php
 * @method static \Illuminate\Database\Eloquent\Builder|\App\Something whereHasTags($tags = [])
```