### PR TITLE
Form request helpers

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -83,6 +83,20 @@ return array(
         'app',
     ),
 
+    /*
+    |--------------------------------------------------------------------------
+    | FormRequest locations to include
+    |--------------------------------------------------------------------------
+    |
+    | Define in which directories the ide-helper:form-requests command should look
+    | for form request classes.
+    |
+    */
+
+    'form_request_locations' => array(
+        'app/Http/Requests',
+    ),
+
 
     /*
     |--------------------------------------------------------------------------

--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,59 @@ After publishing vendor, simply change the `include_fluent` line your `config/id
 ```
 And then run `php artisan ide-helper:generate` , you will now see all of the Fluent methods are recognized by your IDE.
 
+### Automatic phpDocs generation for Laravel FormRequests
+You can generate phpDocs support for Laravel's FormRequests. To do so run the following command:
+```php
+php artisan ide:form-requests
+```
+By default, this will create a new file called `_ide_helper_form_requests.php` in the root of your project and populate this file with FormRequest classes and phpDocs.
+If you want to change the name of the file generated you may pass the `--filename` argument to the command.
+```php
+php artisan ide:form-requests --filename="form_request_ide_helpers.php"
+```
+You can also generate phpDocs inline, inside the actual files where your FormRequest declarations are you, by passing the `--internal` option
+```php
+php artisan ide:form-requests --internal
+``` 
+The defauld FormRequest directory `app/Http/Requests` will be scanned for FormRequests by default. If you want to add more directories where you keep your FormRequests
+you can do that in the `config/ide-helper.php` configuration file under the `form_request_location` key. 
+```php
+/*
+    |--------------------------------------------------------------------------
+    | FormRequest locations to include
+    |--------------------------------------------------------------------------
+    |
+    | Define in which directories the ide-helper:form-requests command should look
+    | for form request classes.
+    |
+    */
+
+    'form_request_locations' => array(
+        'app/Http/Requests',
+        'app/Http/OtherFormRequests',
+    ),
+```
+Please note that subdirectories __ARE__ included included in the parsing and needn't be listed explicitly.
+
+If you want to provide additional directories when running the command without editing the configuration file, you can do that by passing the `--dir` argument.
+You may pass this argument more than once
+```php
+php artisan ide:form-requests --dir="app/Http/SomeMoreFormRequests" --dir="app/Http/EvenMoreFormRequests"
+```
+Please note that running the command this way __WILL__ include both the directories specified in the command and the ones in the configuration file.
+
+Furthermore, it is possible to generate phpDocs for a single file by passing the `request` argument. 
+Please note that the value of the `request` argument has to be a fully qualified class name of the request to create the phpDocs for.
+``php
+php artisan ide:form-requests request="App\Http\Requests\CreateArticleFormRequest"
+``
+Invoking the command this way will create phpDocs __ONLY__ for the provided request.
+
+The last option that you may pass is `--ignore`. This option allows you to ignore one or more form requests when generating phpDocs.
+The values of the `--ignore` options have to be fully qualified class names of the requests you want to ignore
+```php
+php artisan ide:form-requests --ignore="App\Http\Requests\FirstIgnoredRequest" --ignore="App\Http\Requests\SecondIgnoredRequest"
+```
 
 ## PhpStorm Meta for Container instances
 

--- a/src/Console/FormRequestsCommand.php
+++ b/src/Console/FormRequestsCommand.php
@@ -1,0 +1,468 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper\Console;
+
+use Barryvdh\Reflection\DocBlock\Context;
+use Barryvdh\Reflection\DocBlock as DocBlock;
+use Barryvdh\Reflection\DocBlock\Serializer;
+use Barryvdh\Reflection\DocBlock\Tag;
+use Composer\Autoload\ClassMapGenerator;
+use Illuminate\Auth\Passwords\PasswordBroker;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Factory;
+
+class FormRequestsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ide-helper:form-requests 
+                                {request?}                                  : Fully qualified class name of the FormRequest to generate the helper for.
+                                {--dir=*}                                   : An array of the directories in which to search for form requests. The default directory is automatically injected.
+                                {--internal}                                : Force the command to write all the docblocks inside class files. 
+                                {--filename=_ide_helper_forms_requests.php} : Override the name of the helper file. This has no effect when --internal is used. 
+                                {--ignore=*}                                : Ignore form requests. You can use this option multiple times.';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate autocompletion for form requests.';
+
+    /**
+     * Name of the request to generate the helper for.
+     *
+     * @var null
+     */
+    protected $formRequest = null;
+
+    /**
+     * The name of the file to which to write the helper.
+     *
+     * @var string
+     */
+    protected $filename = null;
+
+    /**
+     * Array of FQCN's that should be skipped by this command.
+     *
+     * @var array
+     */
+    protected $blacklist = [];
+
+    /**
+     * A flag determining whether docblocks should be written internally or externally.
+     *
+     * @var bool
+     */
+    protected $writeToExternal = true;
+
+    /**
+     * A flag determining whether original docblock data should be retained in the case of writing internally.
+     *
+     * @var bool
+     */
+    protected $reset = false;
+
+    /**
+     * An array of directories in which to search for form requests.
+     *
+     * @var array
+     */
+    protected $dirs = [];
+
+    /** @var \Illuminate\Filesystem\Filesystem */
+    protected $filesystem;
+
+    /** @var \Barryvdh\Reflection\DocBlock\Serializer  */
+    protected $serializer;
+
+    /**
+     * A map of all the rules and the types they enforce.
+     */
+    const RULE_MAP = [
+        'accepted' => 'boolean|string',
+        'boolean' => 'boolean',
+
+        'array' => 'array',
+        'json' => 'array',
+
+        'integer' => 'integer',
+
+        'numeric' => 'integer|float',
+        'digits' => 'integer|float',
+        'digits_between' => 'integer|float',
+
+        'active_url' => 'string',
+        'after' => 'string',
+        'after_or_equal' => 'string',
+        'alpha' => 'string',
+        'alpha_dash' => 'string',
+        'alpha_numeric' => 'string',
+        'before' => 'string',
+        'before_or_equal' => 'string',
+        'date' => 'string',
+        'date_equals' => 'string',
+        'date_format' => 'string',
+        'ip_address' => 'string',
+        'string' => 'string',
+        'timezone' => 'string',
+        'url' => 'string',
+        'uuid' => 'string',
+
+        'dimensions' => UploadedFile::class,
+        'file' => UploadedFile::class,
+        'image' => UploadedFile::class,
+        'mimetypes' => UploadedFile::class,
+        'mimes' => UploadedFile::class,
+    ];
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct(Filesystem $filesystem, Serializer $serializer)
+    {
+        parent::__construct();
+
+        $this->filesystem = $filesystem;
+
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->parseOptionsAndArguments();
+        
+        $requests = ($this->formRequest !== null)
+            ? $this->extractRelevantRequestReflections([$this->formRequest])
+            : $this->getRequestReflections();
+
+        if (empty($requests)) {
+            return $this->error("No requests were found for the current configuration.");
+        }
+
+        return $this->createHelpersForRequests($requests);
+    }
+
+    /**
+     * @param array<\ReflectionClass> $requests
+     */
+    protected function createHelpersForRequests($requests)
+    {
+        $output = '';
+        
+        /** @var \ReflectionClass $request */
+        foreach ($requests as $request) {
+            $instance = $request->newInstance();
+            $values = $this->parseValidation($instance->rules());
+            
+            ($this->writeToExternal)
+                ? $this->appendToOutput($output, $request, $values)
+                : $this->writeToFile($request, $values) && $this->info("Written new phpDocBlock to" . $request->getFileName());
+        }
+
+        if ($this->writeToExternal) {
+            $output = $this->initializeExternalOutput() . $output;
+            $this->filesystem->put($this->filename, $output);
+            return $this->info("Fresh helper comments have been written to {$this->filename}");
+        }
+
+        $this->info("\nWritten a total of " . count($requests) . " phpDocBlocks");
+    }
+
+    /** Create and return the header for an external output file. */
+    protected function initializeExternalOutput()
+    {
+        return
+"<?php
+
+// @formatter off
+
+/**
+* This is a helper file for your form requests. 
+* It provides you with autocompletion for validated form request data.
+* 
+* @author Misa Kovic <misa95kovic@gmail.com>
+**/
+
+
+";
+    }
+
+    /**
+     * Append the parsed values for the specified class to an existing (external) output.
+     *
+     * @param DocBlock $output
+     * @param \ReflectionClass $request
+     * @param array $values
+     * @return DocBlock
+     */
+    protected function appendToOutput(&$output, $request, $values)
+    {
+        $docBlock = $this->createDocBlockForRequest($request, $values);
+        $docBlockComment = $this->serializer->getDocComment($docBlock);
+
+        $classDeclaration = $this->createClassDeclarationForRequest($request, $values);
+
+        $namespace = $request->getNamespaceName();
+
+        $output .= "namespace {$namespace} {\n{$docBlockComment}\n{$classDeclaration}\n}\n\n";
+    }
+
+    /**
+     * Create a DocBlock instance for a form request.
+     *
+     * @param \ReflectionClass $request
+     * @param array $rules
+     * @return \Barryvdh\Reflection\DocBlock
+     */
+    protected function createDocBlockForRequest(\ReflectionClass $request, array $rules)
+    {
+        $context = new Context($request->getNamespaceName());
+        $docBlock = new DocBlock('', $context);
+        $docBlock->setText($request->name);
+
+        $docBlock->setText($request->name);
+
+        foreach ($rules as $rule) {
+            $docBlock->appendTag($this->parameterTag($rule));
+        }
+        
+        return $docBlock;
+    }
+
+    /**
+     * Create a Mock class declaration for a request.
+     *
+     * @param \ReflectionClass $request
+     * @param array $rules
+     * @return string
+     */
+    public function createClassDeclarationForRequest(\ReflectionClass $request, array $rules)
+    {
+        $class = $request->getShortName();
+        $parent = $request->getParentClass()->name;
+
+        return "class {$class} extends {$parent} {}";
+    }
+
+    /**
+     * Write a docblock with the parsed values to the request file (internally).
+     *
+     * @param \ReflectionClass $request
+     * @param array $values
+     */
+    protected function writeToFile($request, $values)
+    {
+        $filePath = $request->getFileName();
+        $newDocBlockComment = $this->serializer->getDocComment($this->createDocBlockForRequest($request, $values));
+        $oldDocBlockComment = $request->getDocComment();
+        $fileContents = $this->filesystem->get($filePath);
+        
+        if ($oldDocBlockComment) {
+            $fileContents = str_replace($oldDocBlockComment, $newDocBlockComment, $fileContents);
+        } else {
+            $className = $request->getShortName();
+            $toBeReplaced = "class {$className}";
+            if (!Str::contains($fileContents, $toBeReplaced)) {
+                return false;
+            }
+
+            $newDocBlockComment .= "\nclass {$className}";
+            
+            $fileContents = str_replace($toBeReplaced, $newDocBlockComment, $fileContents);
+        }
+        
+        return $this->filesystem->put($filePath, $fileContents);
+    }
+    
+    protected function parameterTag(array $rule)
+    {
+        return new Tag(
+            'property',
+            "{$rule['type']} {$rule['name']}"
+        );
+    }
+
+    /**
+     * Parse the validation rules to extract the names and types of values.
+     *
+     * @param array $rules
+     */
+    protected function parseValidation($rules)
+    {
+        $parsed = [];
+
+        foreach ($rules as $name => $constrains) {
+            $parsed[] = [
+                'name' => $name,
+                'type' => $this->parseValidationType($constrains),
+            ];
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * Parse the type of a value from its validation rules.
+     *
+     * @param $constraints
+     * @return string
+     */
+    protected function parseValidationType($constraints)
+    {
+        $constraints = $this->parseValidationRules($constraints);
+        $parsedType = 'mixed';
+
+        foreach (static::RULE_MAP as $rule => $types) {
+            if (in_array($rule, $constraints)) {
+                $parsedType = $types;
+            }
+        }
+
+        if (in_array('nullable', $constraints)) {
+            $parsedType .= '|null';
+        }
+
+        return $parsedType;
+    }
+
+    /**
+     * Parse individual rules from a validation rules string.
+     *
+     * @param $constraints
+     */
+    protected function parseValidationRules($constraints)
+    {
+        $constraints = explode('|', $constraints);
+
+        $constraints = array_map(function ($constraint) {
+            if (strpos($constraint, ':') > -1) {
+                $constraint = explode(':', $constraint)[0];
+            }
+
+            return $constraint;
+        }, $constraints);
+
+        return $constraints;
+    }
+
+    /**
+     * Parse all the options and store them as object attributes.
+     *
+     * @return void
+     */
+    protected function parseOptionsAndArguments()
+    {
+        $this->filename = $this->option('filename');
+
+        $this->writeToExternal = ! $this->option('internal');
+
+        $this->blacklist = $this->option('ignore');
+
+        $this->formRequest = $this->argument('request');
+    }
+
+    /**
+     * Prepare an array of all the requests that should have helpers generated.
+     *
+     * @return array<\ReflectionClass>
+     */
+    protected function getRequestReflections()
+    {
+        $defaultRequests = $this->getClassesInConfigSpecification();
+
+        $specifiedRequests = $this->getClassesInArgumentDirs();
+
+        return $this->extractRelevantRequestReflections(array_merge($defaultRequests, $specifiedRequests));
+    }
+
+    /**
+     * Extract all the relevant FormRequest classess from an array of all the classes and return ReflectionClass objects for them.
+     *
+     * @param array<string> $allClasses
+     * @return array<\ReflectionClass>
+     */
+    protected function extractRelevantRequestReflections($allClasses)
+    {
+        $relevant = [];
+
+        foreach ($allClasses as $class) {
+            if (in_array($class, $this->blacklist) || !class_exists($class)) {
+                continue;
+            }
+
+            $reflected = new \ReflectionClass($class);
+
+            if (!$reflected->isSubclassOf(FormRequest::class)) {
+                continue;
+            }
+
+            $relevant[] = $reflected;
+        }
+
+        return $relevant;
+    }
+
+    /**
+     * Read the config file and load all the requests from the paths specified in it.
+     *
+     * @return array<string>
+     */
+    protected function getClassesInConfigSpecification()
+    {
+        $configPaths = $this->laravel['config']->get('ide-helper.form_request_locations');
+        $allClasses = [];
+
+        foreach ($configPaths as $dir) {
+            $dir = base_path($dir);
+            $allClasses = array_merge($allClasses, $this->getClassesFromDirectory($dir));
+        }
+
+        return $allClasses;
+    }
+
+    /**
+     * Go through all the directories specified in the options and return the classes from them.
+     *
+     * @return array<string>
+     */
+    protected function getClassesInArgumentDirs()
+    {
+        $allClasses = [];
+
+        foreach ($this->dirs as $dir) {
+            $allClasses = array_merge($allClasses, $this->getClassesFromDirectory($dir));
+        }
+
+        return array_unique($allClasses);
+    }
+
+    /**
+     * Parse a directory and extract all the classes in it.
+     *
+     * @param string $dir
+     * @return array<string>
+     */
+    protected function getClassesFromDirectory($dir)
+    {
+        if (!is_dir($dir)) {
+            return [];
+        }
+
+        return array_keys(ClassMapGenerator::createMap($dir));
+    }
+}

--- a/src/Console/FormRequestsCommand.php
+++ b/src/Console/FormRequestsCommand.php
@@ -22,11 +22,16 @@ class FormRequestsCommand extends Command
      * @var string
      */
     protected $signature = 'ide-helper:form-requests 
-                                {request?}                                  : Fully qualified class name of the FormRequest to generate the helper for.
-                                {--dir=*}                                   : An array of the directories in which to search for form requests. The default directory is automatically injected.
-                                {--internal}                                : Force the command to write all the docblocks inside class files. 
-                                {--filename=_ide_helper_forms_requests.php} : Override the name of the helper file. This has no effect when --internal is used. 
-                                {--ignore=*}                                : Ignore form requests. You can use this option multiple times.';
+        {request?}                                  
+            : Fully qualified class name of the FormRequest to generate the helper for.
+        {--dir=*}                                   
+            : An array of the directories to search for form requests. The default directory is automatically injected.
+        {--internal}                                
+            : Force the command to write all the docblocks inside class files. 
+        {--filename=_ide_helper_forms_requests.php} 
+            : Override the name of the helper file. This has no effect when --internal is used. 
+        {--ignore=*}                                
+            : Ignore form requests. You can use this option multiple times.';
 
     /**
      * The console command description.
@@ -171,7 +176,8 @@ class FormRequestsCommand extends Command
             
             ($this->writeToExternal)
                 ? $this->appendToOutput($output, $request, $values)
-                : $this->writeToFile($request, $values) && $this->info("Written new phpDocBlock to" . $request->getFileName());
+                : $this->writeToFile($request, $values) &&
+                  $this->info("Written new phpDocBlock to" . $request->getFileName());
         }
 
         if ($this->writeToExternal) {
@@ -187,7 +193,7 @@ class FormRequestsCommand extends Command
     protected function initializeExternalOutput()
     {
         return
-"<?php
+            "<?php
 
 // @formatter off
 
@@ -391,7 +397,8 @@ class FormRequestsCommand extends Command
     }
 
     /**
-     * Extract all the relevant FormRequest classess from an array of all the classes and return ReflectionClass objects for them.
+     * Extract all the relevant FormRequest classess
+     * from an array of all the classes and return ReflectionClass objects for them.
      *
      * @param array<string> $allClasses
      * @return array<\ReflectionClass>

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -11,9 +11,11 @@
 namespace Barryvdh\LaravelIdeHelper;
 
 use Barryvdh\LaravelIdeHelper\Console\EloquentCommand;
+use Barryvdh\LaravelIdeHelper\Console\FormRequestsCommand;
 use Barryvdh\LaravelIdeHelper\Console\GeneratorCommand;
 use Barryvdh\LaravelIdeHelper\Console\MetaCommand;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\Reflection\DocBlock\Serializer;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Engines\PhpEngine;
@@ -90,11 +92,22 @@ class IdeHelperServiceProvider extends ServiceProvider
             }
         );
 
+        $this->app->singleton(
+            'command.ide-helper.requests',
+            function ($app) use ($localViewFactory) {
+                return new FormRequestsCommand(
+                    $app['files'],
+                    new Serializer(),
+                );
+            }
+        );
+
         $this->commands(
             'command.ide-helper.generate',
             'command.ide-helper.models',
             'command.ide-helper.meta',
-            'command.ide-helper.eloquent'
+            'command.ide-helper.eloquent',
+            'command.ide-helper.requests'
         );
     }
 


### PR DESCRIPTION
This pull request exposes a command for generating phpDocs for Laravel's FormRequests. 
The command supports generating docBlocks both inline, in the same files where class declarations are, and inline. 
It also supports parsing FormRequests from custom locations, not just the default one, as well as skipping specified form requests when generating phpDocs.