### PR TITLE
Fix non-facade classes will result in no autocomplete

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -21,15 +21,12 @@
  */
 
 <?php foreach ($namespaces_by_extends_ns as $namespace => $aliases) : ?>
-    <?php if ($namespace == '\Illuminate\Database\Eloquent') :
-        continue;
-    endif; ?>
-namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
+namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
     <?php foreach ($aliases as $alias) : ?>
-        <?= trim($alias->getDocComment('    ')) ?> 
+        <?= trim($alias->getDocComment('    ')) ?>
         <?= $alias->getClassType() ?> <?= $alias->getExtendsClass() ?> {
         <?php foreach ($alias->getMethods() as $method) : ?>
-            <?= trim($method->getDocComment('        ')) ?> 
+            <?= trim($method->getDocComment('        ')) ?>
         public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
         {<?php if ($method->getDeclaringClass() !== $method->getRoot()) : ?>
             //Method inherited from <?= $method->getDeclaringClass() ?>
@@ -40,19 +37,19 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
             <?php endif?>
             <?= $method->shouldReturn() ? 'return ' : '' ?><?= $method->getRootMethodCall() ?>;
         }
-        <?php endforeach; ?> 
+        <?php endforeach; ?>
     }
-    <?php endforeach; ?> 
+    <?php endforeach; ?>
 }
 
 <?php endforeach; ?>
 
 <?php foreach ($namespaces_by_alias_ns as $namespace => $aliases) : ?>
-namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
+namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
     <?php foreach ($aliases as $alias) : ?>
         <?= $alias->getClassType() ?> <?= $alias->getShortName() ?> extends <?= $alias->getExtends() ?> {<?php if ($alias->getExtendsNamespace() == '\Illuminate\Database\Eloquent') : ?>
-            <?php foreach ($alias->getMethods() as $method) : ?> 
-                <?= trim($method->getDocComment('            ')) ?> 
+            <?php foreach ($alias->getMethods() as $method) : ?>
+                <?= trim($method->getDocComment('            ')) ?>
             public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
             {<?php if ($method->getDeclaringClass() !== $method->getRoot()) : ?>
                 //Method inherited from <?= $method->getDeclaringClass() ?>
@@ -65,14 +62,14 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
             }
             <?php endforeach; ?>
         <?php endif; ?>}
-    <?php endforeach; ?> 
+    <?php endforeach; ?>
 }
 
 <?php endforeach; ?>
 
 <?php if ($helpers) : ?>
 namespace {
-    <?= $helpers ?> 
+    <?= $helpers ?>
 }
 <?php endif; ?>
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -13,6 +13,7 @@ namespace Barryvdh\LaravelIdeHelper;
 
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use ReflectionClass;
@@ -184,7 +185,9 @@ class Generator
      */
     protected function getAliasesByExtendsNamespace()
     {
-        $aliases = $this->getValidAliases();
+        $aliases = $this->getValidAliases()->filter(static function (Alias $alias) {
+            return is_subclass_of($alias->getExtends(), Facade::class);
+        });
 
         $this->addMacroableClasses($aliases);
 


### PR DESCRIPTION
Currently non-facade classes are resulting non functioning autocomplete. The reason of this that an empty class will be defined in the ide helper class, which will be used for the auto-completion. This pull request prevents this behavior by only handling facades in the namespaced part of the helper file.

Unlike #802  this pull request will keep the alias registration.

Fixes #784