### PR TITLE
Automatically generate helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
         "scrutinizer/ocular": "~1.1",
         "squizlabs/php_codesniffer": "^3"
     },
+    "suggest": {
+        "illuminate/events": "Required for automatic helper generation (^5.5|^6)."
+    },
     "autoload": {
         "psr-4": {
             "Barryvdh\\LaravelIdeHelper\\": "src"

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -217,4 +217,30 @@ return array(
     */
     'listen_on_commands' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Automatic helper generation parameters
+    |--------------------------------------------------------------------------
+    |
+    | The command line parameters to be passed for the ide-helper:generate
+    | command.
+    |
+    */
+    'listen_generate_parameters' => array(
+
+    ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Automatic model helper generation parameters
+    |--------------------------------------------------------------------------
+    |
+    | The command line parameters to be passed for the ide-helper:models
+    | command.
+    |
+    */
+    'listen_models_parameters' => array(
+        '--no-write',
+    ),
+
 );

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -232,6 +232,19 @@ return array(
 
     /*
     |--------------------------------------------------------------------------
+    | Automatic metadata generation parameters
+    |--------------------------------------------------------------------------
+    |
+    | The command line parameters to be passed for the ide-helper:meta command.
+    | Set this variable to false to disable running this command.
+    |
+    */
+    'listen_meta_parameters' => array(
+
+    ),
+
+    /*
+    |--------------------------------------------------------------------------
     | Automatic model helper generation parameters
     |--------------------------------------------------------------------------
     |

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -223,7 +223,7 @@ return array(
     |--------------------------------------------------------------------------
     |
     | The command line parameters to be passed for the ide-helper:generate
-    | command.
+    | command. Set this variable to false to disable running this command.
     |
     */
     'listen_generate_parameters' => array(
@@ -236,7 +236,7 @@ return array(
     |--------------------------------------------------------------------------
     |
     | The command line parameters to be passed for the ide-helper:models
-    | command.
+    | command. Set this variable to false to disable running this command.
     |
     */
     'listen_models_parameters' => array(

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -13,7 +13,7 @@ return array(
 
     'filename'  => '_ide_helper',
     'format'    => 'php',
-    
+
     'meta_filename' => '.phpstorm.meta.php',
 
     /*
@@ -205,5 +205,16 @@ return array(
     |
     */
     'include_class_docblocks' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Generate helper files automatically
+    |--------------------------------------------------------------------------
+    |
+    | Automatically generate facade helpers on package:discover command and
+    | model helpers on migrate and migrate:rollback commands.
+    |
+    */
+    'listen_on_commands' => false,
 
 );

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -240,7 +240,7 @@ return array(
     |
     */
     'listen_models_parameters' => array(
-        '--no-write',
+        '--nowrite' => true,
     ),
 
 );

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -14,6 +14,8 @@ use Barryvdh\LaravelIdeHelper\Console\EloquentCommand;
 use Barryvdh\LaravelIdeHelper\Console\GeneratorCommand;
 use Barryvdh\LaravelIdeHelper\Console\MetaCommand;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Listeners\GenerateHelpers;
+use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Engines\PhpEngine;
@@ -37,6 +39,10 @@ class IdeHelperServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if ($this->app['config']->get('ide-helper.listen_on_commands')) {
+            $this->app['events']->listen(CommandFinished::class, GenerateHelpers::class);
+        }
+
         if ($this->app->has('view')) {
             $viewPath = __DIR__ . '/../resources/views';
             $this->loadViewsFrom($viewPath, 'ide-helper');

--- a/src/Listeners/GenerateHelpers.php
+++ b/src/Listeners/GenerateHelpers.php
@@ -34,6 +34,7 @@ class GenerateHelpers
         switch ($event->command) {
             case "package:discover":
                 $this->generate('generate', $event->output);
+                $this->generate('meta', $event->output);
                 break;
             case "migrate":
             case "migrate:rollback":
@@ -51,7 +52,7 @@ class GenerateHelpers
     {
         $parameters = $this->config->get(
             'ide-helper.listen_'.$command.'_parameters',
-                array()
+            array()
         );
 
         if ($parameters === false) {

--- a/src/Listeners/GenerateHelpers.php
+++ b/src/Listeners/GenerateHelpers.php
@@ -36,7 +36,10 @@ class GenerateHelpers
             case "package:discover":
                 $this->artisan->call(
                     'ide-helper:generate',
-                    $this->config->get('ide-helper.listen_generate_parameters', []),
+                    $this->config->get(
+                        'ide-helper.listen_generate_parameters',
+                        array()
+                    ),
                     $event->output
                 );
                 break;
@@ -44,7 +47,10 @@ class GenerateHelpers
             case "migrate:rollback":
                 $this->artisan->call(
                     'ide-helper:models',
-                    $this->config->get('ide-helper.listen_model_parameters', []),
+                    $this->config->get(
+                        'ide-helper.listen_model_parameters',
+                        array()
+                    ),
                     $event->output
                 );
                 break;

--- a/src/Listeners/GenerateHelpers.php
+++ b/src/Listeners/GenerateHelpers.php
@@ -48,7 +48,7 @@ class GenerateHelpers
                 $this->artisan->call(
                     'ide-helper:models',
                     $this->config->get(
-                        'ide-helper.listen_model_parameters',
+                        'ide-helper.listen_models_parameters',
                         array()
                     ),
                     $event->output

--- a/src/Listeners/GenerateHelpers.php
+++ b/src/Listeners/GenerateHelpers.php
@@ -8,9 +8,16 @@ use Illuminate\Contracts\Console\Kernel as Artisan;
 
 class GenerateHelpers
 {
+    /** @var \Illuminate\Contracts\Console\Kernel */
     protected $artisan;
+
+    /** @var \Illuminate\Config\Repository */
     protected $config;
 
+    /**
+     * @param \Illuminate\Contracts\Console\Kernel $artisan
+     * @param \Illuminate\Config\Repository $config
+     */
     public function __construct(Artisan $artisan, Config $config)
     {
         $this->artisan = $artisan;

--- a/src/Listeners/GenerateHelpers.php
+++ b/src/Listeners/GenerateHelpers.php
@@ -3,10 +3,20 @@
 namespace Barryvdh\LaravelIdeHelper\Listeners;
 
 use Illuminate\Console\Events\CommandFinished;
-use Illuminate\Support\Facades\Artisan;
+use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Contracts\Console\Kernel as Artisan;
 
 class GenerateHelpers
 {
+    protected $artisan;
+    protected $config;
+
+    public function __construct(Artisan $artisan, Config $config)
+    {
+        $this->artisan = $artisan;
+        $this->config = $config;
+    }
+
     /**
      * Handle the event.
      *
@@ -17,11 +27,19 @@ class GenerateHelpers
     {
         switch ($event->command) {
             case "package:discover":
-                Artisan::call('ide-helper:generate', [], $event->output);
+                $this->artisan->call(
+                    'ide-helper:generate',
+                    $this->config->get('ide-helper.listen_generate_parameters', []),
+                    $event->output
+                );
                 break;
             case "migrate":
             case "migrate:rollback":
-                Artisan::call('ide-helper:models', ['--no-write'], $event->output);
+                $this->artisan->call(
+                    'ide-helper:models',
+                    $this->config->get('ide-helper.listen_model_parameters', []),
+                    $event->output
+                );
                 break;
         }
     }

--- a/src/Listeners/GenerateHelpers.php
+++ b/src/Listeners/GenerateHelpers.php
@@ -28,32 +28,51 @@ class GenerateHelpers
      * Handle the event.
      *
      * @param  CommandFinished  $event
-     * @return void
      */
     public function handle(CommandFinished $event)
     {
         switch ($event->command) {
             case "package:discover":
-                $this->artisan->call(
-                    'ide-helper:generate',
-                    $this->config->get(
-                        'ide-helper.listen_generate_parameters',
-                        array()
-                    ),
-                    $event->output
-                );
+                $this->generateHelper($event->output);
                 break;
             case "migrate":
             case "migrate:rollback":
-                $this->artisan->call(
-                    'ide-helper:models',
-                    $this->config->get(
-                        'ide-helper.listen_models_parameters',
-                        array()
-                    ),
-                    $event->output
-                );
+                $this->generateModels($event->output);
                 break;
         }
+    }
+
+    /**
+     * Run "ide-helper:generate" command.
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface
+     */
+    protected function generateHelper($output)
+    {
+        $this->artisan->call(
+            'ide-helper:generate',
+            $this->config->get(
+                'ide-helper.listen_generate_parameters',
+                array()
+            ),
+            $output
+        );
+    }
+
+    /**
+     * Run "ide-helper:models" command.
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface
+     */
+    protected function generateModels($output)
+    {
+        $this->artisan->call(
+            'ide-helper:models',
+            $this->config->get(
+                'ide-helper.listen_models_parameters',
+                array()
+            ),
+            $output
+        );
     }
 }

--- a/src/Listeners/GenerateHelpers.php
+++ b/src/Listeners/GenerateHelpers.php
@@ -54,6 +54,10 @@ class GenerateHelpers
                 array()
         );
 
+        if ($parameters === false) {
+            return;
+        }
+
         $this->artisan->call('ide-helper:'.$command, $parameters, $output);
     }
 }

--- a/src/Listeners/GenerateHelpers.php
+++ b/src/Listeners/GenerateHelpers.php
@@ -33,46 +33,27 @@ class GenerateHelpers
     {
         switch ($event->command) {
             case "package:discover":
-                $this->generateHelper($event->output);
+                $this->generate('generate', $event->output);
                 break;
             case "migrate":
             case "migrate:rollback":
-                $this->generateModels($event->output);
+                $this->generate('models', $event->output);
                 break;
         }
     }
 
     /**
-     * Run "ide-helper:generate" command.
+     * Run an "ide-helper:..." command.
      *
      * @param \Symfony\Component\Console\Output\OutputInterface
      */
-    protected function generateHelper($output)
+    protected function generate($command, $output)
     {
-        $this->artisan->call(
-            'ide-helper:generate',
-            $this->config->get(
-                'ide-helper.listen_generate_parameters',
+        $parameters = $this->config->get(
+            'ide-helper.listen_'.$command.'_parameters',
                 array()
-            ),
-            $output
         );
-    }
 
-    /**
-     * Run "ide-helper:models" command.
-     *
-     * @param \Symfony\Component\Console\Output\OutputInterface
-     */
-    protected function generateModels($output)
-    {
-        $this->artisan->call(
-            'ide-helper:models',
-            $this->config->get(
-                'ide-helper.listen_models_parameters',
-                array()
-            ),
-            $output
-        );
+        $this->artisan->call('ide-helper:'.$command, $parameters, $output);
     }
 }

--- a/src/Listeners/GenerateHelpers.php
+++ b/src/Listeners/GenerateHelpers.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper\Listeners;
+
+use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Support\Facades\Artisan;
+
+class GenerateHelpers
+{
+    /**
+     * Handle the event.
+     *
+     * @param  CommandFinished  $event
+     * @return void
+     */
+    public function handle(CommandFinished $event)
+    {
+        switch ($event->command) {
+            case "package:discover":
+                Artisan::call('ide-helper:generate', [], $event->output);
+                break;
+            case "migrate":
+            case "migrate:rollback":
+                Artisan::call('ide-helper:models', ['--no-write'], $event->output);
+                break;
+        }
+    }
+}


### PR DESCRIPTION
This pull request allows automatic helper generation. This is achieved by listening on the command finished event of `migrate`, `migrate:rollback` and `package:discover` commands.

I added this feature disabled by default, but it could be default on in the next major version.

Feel free to rename the config variable, this was my first idea.