### PR TITLE
Add support for custom date class via Date::use()

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -64,6 +64,14 @@ class ModelsCommand extends Command
     protected $nullableColumns = [];
 
     /**
+     * During initializtion we use Laravels Date Facade to
+     * determine the actual date class and store it here.
+     *
+     * @var string
+     */
+    protected $dateClass;
+
+    /**
      * @param Filesystem $files
      */
     public function __construct(Filesystem $files)
@@ -102,6 +110,10 @@ class ModelsCommand extends Command
                 $this->write = true;
             }
         }
+
+        $this->dateClass = class_exists(\Illuminate\Support\Facades\Date::class)
+            ? '\\' . get_class(\Illuminate\Support\Facades\Date::now())
+            : '\Illuminate\Support\Carbon';
 
         $content = $this->generateDocs($model, $ignore);
 
@@ -284,7 +296,7 @@ class ModelsCommand extends Command
                     break;
                 case 'date':
                 case 'datetime':
-                    $realType = '\Illuminate\Support\Carbon';
+                    $realType = $this->dateClass;
                     break;
                 case 'collection':
                     $realType = '\Illuminate\Support\Collection';
@@ -348,7 +360,7 @@ class ModelsCommand extends Command
             foreach ($columns as $column) {
                 $name = $column->getName();
                 if (in_array($name, $model->getDates())) {
-                    $type = '\Illuminate\Support\Carbon';
+                    $type = $this->dateClass;
                 } else {
                     $type = $column->getType()->getName();
                     switch ($type) {


### PR DESCRIPTION
Laravel 5.8 introduced a feature to support a custom date class via
`Date::use()`, see https://github.com/laravel/framework/pull/25320

When e.g. using `Date::use(CarbonImmutable)` in a project, it means
all date casts are not returning `\Illuminate\Support\Carbon` anymore
but `\Carbon\CarbonImmutable`, which means all the generated type hints
for dates are now wrong.

This change tries to be still backwards compatible with Laravel < 5.8
which do not have the Date facade.