### PR TITLE
[CHORE] Bump grumphp version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "illuminate/config": "^5.5|^6",
         "illuminate/view": "^5.5|^6",
-        "phpro/grumphp": "^0.14",
+        "phpro/grumphp": "^0.17.1",
         "squizlabs/php_codesniffer": "^3",
         "orchestra/testbench": "^3|^4",
         "mockery/mockery": "^1.3"


### PR DESCRIPTION
The current version emits the following:
```
Deprecated: strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior in laravel-ide-helper/vendor/phpro/grumphp/src/Locator/ConfigurationFile.php on line 75

Deprecated: strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior in laravel-ide-helper/vendor/phpro/grumphp/src/Locator/ConfigurationFile.php on line 75
```

Manually tested it locally, worked as expected.