### PR TITLE
Drop support for PHP < 7.2 and improve test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,34 +12,53 @@ env:
 matrix:
   include:
     - php: '7.2'
-      env: LARAVEL='5.5.*'
+      env: LARAVEL='5.5.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: '7.2'
-      env: LARAVEL='5.8.*'
+      env: LARAVEL='5.5.*' COMPOSER_FLAGS='--prefer-stable'
     - php: '7.2'
-      env: LARAVEL='^6.0'
+      env: LARAVEL='5.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: '7.2'
+      env: LARAVEL='5.8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: '7.2'
+      env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-lowest'
+    - php: '7.2'
+      env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-stable'
     - php: '7.3'
-      env: LARAVEL='5.5.*'
+      env: LARAVEL='5.5.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: '7.3'
-      env: LARAVEL='5.8.*'
+      env: LARAVEL='5.5.*' COMPOSER_FLAGS='--prefer-stable'
     - php: '7.3'
-      env: LARAVEL='^6.0'
+      env: LARAVEL='5.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: '7.3'
+      env: LARAVEL='5.8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: '7.3'
+      env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-lowest'
+    - php: '7.3'
+      env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-stable'
     - php: '7.4'
-      env: LARAVEL='5.5.*'
+      env: LARAVEL='5.5.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: '7.4'
-      env: LARAVEL='5.8.*'
+      env: LARAVEL='5.5.*' COMPOSER_FLAGS='--prefer-stable'
     - php: '7.4'
-      env: LARAVEL='^6.0' RUN_PHPCS=1
+      env: LARAVEL='5.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: '7.4'
+      env: LARAVEL='5.8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: '7.4'
+      env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-lowest'
+    - php: '7.4'
+      env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-stable' RUN_PHPCS=1
 
 before_script:
   - phpenv config-rm xdebug.ini || true
 
 install:
+  - travis_retry composer remove phpro/grumphp --no-interaction --no-update --dev
   - composer require "illuminate/support:${LARAVEL}" --no-interaction --no-update
   - composer require "illuminate/console:${LARAVEL}" --no-interaction --no-update
   - composer require "illuminate/filesystem:${LARAVEL}" --no-interaction --no-update
   - composer require --dev "illuminate/config:${LARAVEL}" --no-interaction --no-update
   - composer require --dev "illuminate/view:${LARAVEL}" --no-interaction --no-update
-  - composer update --no-interaction --prefer-dist
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist --no-suggest
 
 script:
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ install:
   - composer require "illuminate/filesystem:${LARAVEL}" --no-interaction --no-update
   - composer require --dev "illuminate/config:${LARAVEL}" --no-interaction --no-update
   - composer require --dev "illuminate/view:${LARAVEL}" --no-interaction --no-update
-  - if [[ $LARAVEL = '5.5.*' ]]; then composer require --dev mockery/mockery --no-interaction --no-update; fi
   - composer update --no-interaction --prefer-dist
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,33 +7,40 @@ cache:
 
 env:
   global:
-    - RUN_PHPUNIT=1
     - RUN_PHPCS=0
 
 matrix:
   include:
-    - php: 7.0
-      env: RUN_PHPUNIT=0
-    - php: 7.0
-      env: RUN_PHPUNIT=0 COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
-    - php: 7.1
-      env: RUN_PHPUNIT=0
-    - php: 7.2
-    - php: 7.3
-    - php: 7.4
-      env: RUN_PHPCS=1
+    - php: '7.2'
+      env: LARAVEL='5.5.*'
+    - php: '7.2'
+      env: LARAVEL='5.8.*'
+    - php: '7.2'
+      env: LARAVEL='^6.0'
+    - php: '7.3'
+      env: LARAVEL='5.5.*'
+    - php: '7.3'
+      env: LARAVEL='5.8.*'
+    - php: '7.3'
+      env: LARAVEL='^6.0'
+    - php: '7.4'
+      env: LARAVEL='5.5.*'
+    - php: '7.4'
+      env: LARAVEL='5.8.*'
+    - php: '7.4'
+      env: LARAVEL='^6.0' RUN_PHPCS=1
 
 before_script:
   - phpenv config-rm xdebug.ini || true
 
 install:
-  - |
-    if [[ $RUN_PHPUNIT = 0 ]]; then
-      # We assume the older PHP/Laravel versions and thus restore a working dependency system for them
-      composer remove --dev orchestra/testbench --no-interaction --no-update
-    fi
-  - travis_wait 20 travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist
+  - composer require "illuminate/support:${LARAVEL}" --no-interaction --no-update
+  - composer require "illuminate/console:${LARAVEL}" --no-interaction --no-update
+  - composer require "illuminate/filesystem:${LARAVEL}" --no-interaction --no-update
+  - composer require --dev "illuminate/config:${LARAVEL}" --no-interaction --no-update
+  - composer require --dev "illuminate/view:${LARAVEL}" --no-interaction --no-update
+  - composer update --no-interaction --prefer-dist
 
 script:
+  - vendor/bin/phpunit
   - if [[ $RUN_PHPCS = 1 ]]; then vendor/bin/phpcs --standard=psr2 src/; fi
-  - if [[ $RUN_PHPUNIT = 1 ]]; then vendor/bin/phpunit; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
   - composer require "illuminate/filesystem:${LARAVEL}" --no-interaction --no-update
   - composer require --dev "illuminate/config:${LARAVEL}" --no-interaction --no-update
   - composer require --dev "illuminate/view:${LARAVEL}" --no-interaction --no-update
+  - if [[ $LARAVEL = '5.5.*' ]]; then composer require --dev mockery/mockery --no-interaction --no-update; fi
   - composer update --no-interaction --prefer-dist
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "phpro/grumphp": "^0.14",
         "scrutinizer/ocular": "~1.1",
         "squizlabs/php_codesniffer": "^3",
-        "orchestra/testbench": "^3|^4"
+        "orchestra/testbench": "^3|^4",
+        "mockery/mockery": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7",
+        "php": ">=7.2",
         "illuminate/support": "^5.5|^6",
         "illuminate/console": "^5.5|^6",
         "illuminate/filesystem": "^5.5|^6",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phpro/grumphp": "^0.14",
         "scrutinizer/ocular": "~1.1",
         "squizlabs/php_codesniffer": "^3",
-        "orchestra/testbench": "^4.4"
+        "orchestra/testbench": "^3|^4"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Console/EloquentCommandTest.php
+++ b/tests/Console/EloquentCommandTest.php
@@ -14,12 +14,11 @@ class EloquentCommandTest extends TestCase
     public function testCommand()
     {
         $modelFilename = $this->getVendorModelFilename();
-
-        // Ensure the mixins are not present
         $modelSource = file_get_contents($modelFilename);
-        $this->assertStringNotContainsString('* @mixin \\Eloquent', $modelSource);
-        $this->assertStringNotContainsString('* @mixin \\Illuminate\\Database\\Eloquent\\Builder', $modelSource);
-        $this->assertStringNotContainsString('* @mixin \\Illuminate\\Database\\Query\\Builder', $modelSource);
+        if (false !== strpos($modelSource, '* @mixin')) {
+            $msg = sprintf('Class %s already contains the @mixin markers', Model::class);
+            $this->markTestSkipped($msg);
+        }
 
         $actualContent = null;
         $mockFilesystem = Mockery::mock(Filesystem::class);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests;
 
 use Illuminate\Console\Command;
 use Orchestra\Testbench\TestCase as BaseTestCase;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\Console\Tester\CommandTester;
 
 abstract class TestCase extends BaseTestCase
@@ -33,22 +32,5 @@ abstract class TestCase extends BaseTestCase
         $tester->execute($arguments);
 
         return $tester;
-    }
-
-    /**
-     * @todo if support for Laravel 5.5 is dropped, this shim can be replaced with actual parent call
-     *
-     * @param string $needle
-     * @param string $haystack
-     * @param string $message
-     */
-    public static function assertStringNotContainsString(string $needle, string $haystack, string $message = ''): void
-    {
-        if (!method_exists(Assert::class, 'assertStringContainsString')) {
-            parent::assertNotContains($needle, $haystack, $message);
-            return;
-        }
-
-        parent::assertStringNotContainsString($needle, $haystack, $message);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests;
 
 use Illuminate\Console\Command;
 use Orchestra\Testbench\TestCase as BaseTestCase;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\Console\Tester\CommandTester;
 
 abstract class TestCase extends BaseTestCase
@@ -32,5 +33,22 @@ abstract class TestCase extends BaseTestCase
         $tester->execute($arguments);
 
         return $tester;
+    }
+
+    /**
+     * @todo if support for Laravel 5.5 is dropped, this shim can be replaced with actual parent call
+     *
+     * @param string $needle
+     * @param string $haystack
+     * @param string $message
+     */
+    public static function assertStringNotContainsString(string $needle, string $haystack, string $message = ''): void
+    {
+        if (!method_exists(Assert::class, 'assertStringContainsString')) {
+            parent::assertNotContains($needle, $haystack, $message);
+            return;
+        }
+
+        parent::assertStringNotContainsString($needle, $haystack, $message);
     }
 }


### PR DESCRIPTION
Based on the feedback in https://github.com/barryvdh/laravel-ide-helper/pull/865#issuecomment-570085281 I _tried_ to come up with a possible solution here:

This is mostly driven by two factors:
- Everything < PHP 7.2 is **not** supported anymore => https://www.php.net/supported-versions.php
- In light of expanding the test suite, many recent versions of tools have 7.2 as minimum requirement

As such, the changes summarized here are:
- drop support for < 7.1 and explicitly bump php verison in `composer.json `
- rework the travis test matrix **to be explicit**
  - Previously it was unclear what was really tested because only the PHP version was specified and all the dependencies aligned itself, but that didn't express what Laravel version was actually tested => this is now explicit
  - as such was we now can run phpunit for all supported versions 🎉
- this requires relaxing the version constraint for orchestra/testbench so composer can chose the best supported version
- ~still some special work was needed for Laravel 5.5:~
  - ~a shim for `assertNotStringContainsString`~
  - ~explicitly install mockery/mockery, as older orchestra/testbanch versions didn't require it~
  => **was removed**
- added mockery as root dependency
- added `--prefer-lowest` to test matrix

Does not approach make sense to everyone?