### PR TITLE
[CODESTYLE] Replace phpcs with php-cs-fixer and use pre-defined / Laravel compatible config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  code-style-checker:
+    name: Code Style checker
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Setup PHP
+        run: sudo phpdismod xdebug
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/.composer/cache/files
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: composer install
+        run: composer install --prefer-dist --no-interaction --no-suggest --no-progress
+
+      - name: Run php-cs
+        run: composer check-style

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ vendor
 composer.lock
 .idea
 .phpunit.result.cache
+.php_cs.cache
+.php_cs

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,18 @@
+<?php
+require __DIR__ . '/vendor/autoload.php';
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__);
+return (new MattAllan\LaravelCodeStyle\Config())
+        ->setFinder($finder)
+        ->setRules([
+            '@Laravel' => true,
+            '@Laravel:risky' => true,
+            // Project specific
+            'array_indentation' => true,
+            'is_null' => true,
+            'modernize_types_casting' => true,
+            'method_argument_space' => [
+                'on_multiline' => 'ensure_fully_multiline',
+            ],
+        ])
+        ->setRiskyAllowed(true);

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-env:
-  global:
-    - RUN_PHPCS=0
-
 matrix:
   include:
     - php: '7.2'
@@ -46,13 +42,14 @@ matrix:
     - php: '7.4'
       env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-lowest'
     - php: '7.4'
-      env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-stable' RUN_PHPCS=1
+      env: LARAVEL='^6.0' COMPOSER_FLAGS='--prefer-stable'
 
 before_script:
   - phpenv config-rm xdebug.ini || true
 
 install:
   - travis_retry composer remove phpro/grumphp --no-interaction --no-update --dev
+  - composer remove matt-allan/laravel-code-style --no-interaction --no-update --dev
   - composer require "illuminate/support:${LARAVEL}" --no-interaction --no-update
   - composer require "illuminate/console:${LARAVEL}" --no-interaction --no-update
   - composer require "illuminate/filesystem:${LARAVEL}" --no-interaction --no-update
@@ -62,4 +59,3 @@ install:
 
 script:
   - vendor/bin/phpunit
-  - if [[ $RUN_PHPCS = 1 ]]; then vendor/bin/phpcs --standard=psr2 src/; fi

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,8 @@
     },
     "scripts": {
         "test": "phpunit",
-        "check-style": "phpcs -p --standard=PSR2 src/",
-        "fix-style": "phpcbf -p --standard=PSR2 src/"
+        "check-style": "php-cs-fixer fix --diff --diff-format=udiff --dry-run",
+        "fix-style": "php-cs-fixer fix"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "illuminate/config": "^5.5|^6",
         "illuminate/view": "^5.5|^6",
         "phpro/grumphp": "^0.17.1",
-        "squizlabs/php_codesniffer": "^3",
         "orchestra/testbench": "^3|^4",
         "mockery/mockery": "^1.3",
         "matt-allan/laravel-code-style": "^0.5.0"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "phpro/grumphp": "^0.17.1",
         "squizlabs/php_codesniffer": "^3",
         "orchestra/testbench": "^3|^4",
-        "mockery/mockery": "^1.3"
+        "mockery/mockery": "^1.3",
+        "matt-allan/laravel-code-style": "^0.5.0"
     },
     "autoload": {
         "psr-4": {

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -1,6 +1,6 @@
 <?php
 
-return array(
+return [
 
     /*
     |--------------------------------------------------------------------------
@@ -13,7 +13,7 @@ return array(
 
     'filename'  => '_ide_helper',
     'format'    => 'php',
-    
+
     'meta_filename' => '.phpstorm.meta.php',
 
     /*
@@ -77,9 +77,9 @@ return array(
 
     'include_helpers' => false,
 
-    'helper_files' => array(
+    'helper_files' => [
         base_path().'/vendor/laravel/framework/src/Illuminate/Support/helpers.php',
-    ),
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -91,10 +91,9 @@ return array(
     |
     */
 
-    'model_locations' => array(
+    'model_locations' => [
         'app',
-    ),
-
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -105,12 +104,12 @@ return array(
     |
     */
 
-    'extra' => array(
-        'Eloquent' => array('Illuminate\Database\Eloquent\Builder', 'Illuminate\Database\Query\Builder'),
-        'Session' => array('Illuminate\Session\Store'),
-    ),
+    'extra' => [
+        'Eloquent' => ['Illuminate\Database\Eloquent\Builder', 'Illuminate\Database\Query\Builder'],
+        'Session' => ['Illuminate\Session\Store'],
+    ],
 
-    'magic' => array(),
+    'magic' => [],
 
     /*
     |--------------------------------------------------------------------------
@@ -122,9 +121,9 @@ return array(
     |
     */
 
-    'interfaces' => array(
+    'interfaces' => [
 
-    ),
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -152,9 +151,9 @@ return array(
     |  ),
     |
     */
-    'custom_db_types' => array(
+    'custom_db_types' => [
 
-    ),
+    ],
 
     /*
      |--------------------------------------------------------------------------
@@ -190,10 +189,10 @@ return array(
     | Cast the given "real type" to the given "type".
     |
     */
-    'type_overrides' => array(
+    'type_overrides' => [
         'integer' => 'int',
         'boolean' => 'bool',
-    ),
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -206,4 +205,4 @@ return array(
     */
     'include_class_docblocks' => false,
 
-);
+];

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -7,12 +7,4 @@ parameters:
             testsuite: ~
             group: []
             always_execute: false
-        phpcs:
-            standard: PSR2
-            warning_severity: ~
-            ignore_patterns:
-                - tests/
-            triggered_by: [php]
-            whitelist_patterns:
-                - /^src\/.*/
-                - /^config\/.*/
+        phpcsfixer2:

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -1,7 +1,7 @@
 <?= '<?php' ?>
 <?php
 /**
- * @var \Barryvdh\LaravelIdeHelper\Alias[][] $namespaces_by_alias_ns
+ * @var \Barryvdh\LaravelIdeHelper\Alias[][]
  * @var \Barryvdh\LaravelIdeHelper\Alias[][] $namespaces_by_extends_ns
  * @var bool $include_fluent
  * @var string $helpers
@@ -12,7 +12,7 @@
 
 /**
  * A helper file for Laravel 5, to provide autocomplete information to your IDE
- * Generated for Laravel <?= $version ?> on <?= date("Y-m-d H:i:s") ?>.
+ * Generated for Laravel <?= $version ?> on <?= date('Y-m-d H:i:s') ?>.
  *
  * This file should not be included in your code, only analyzed by your IDE!
  *
@@ -20,26 +20,26 @@
  * @see https://github.com/barryvdh/laravel-ide-helper
  */
 
-<?php foreach($namespaces_by_extends_ns as $namespace => $aliases): ?>
+<?php foreach ($namespaces_by_extends_ns as $namespace => $aliases): ?>
 <?php if ($namespace == '\Illuminate\Database\Eloquent'): continue; endif; ?>
 namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
-<?php foreach($aliases as $alias): ?>
+<?php foreach ($aliases as $alias): ?>
 
     <?= trim($alias->getDocComment('    ')) ?> 
     <?= $alias->getClassType() ?> <?= $alias->getExtendsClass() ?> {
-        <?php foreach($alias->getMethods() as $method): ?>
+        <?php foreach ($alias->getMethods() as $method): ?>
 
         <?= trim($method->getDocComment('        ')) ?> 
         public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
-        {<?php if($method->getDeclaringClass() !== $method->getRoot()): ?>
+        {<?php if ($method->getDeclaringClass() !== $method->getRoot()): ?>
 
             //Method inherited from <?= $method->getDeclaringClass() ?>
             <?php endif; ?>
 
-            <?php if($method->isInstanceCall()):?>
+            <?php if ($method->isInstanceCall()):?>
             /** @var <?=$method->getRoot()?> $instance */
             <?php endif?>
-            <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRootMethodCall() ?>;
+            <?= $method->shouldReturn() ? 'return ' : '' ?><?= $method->getRootMethodCall() ?>;
         }
         <?php endforeach; ?> 
     }
@@ -48,23 +48,23 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
 
 <?php endforeach; ?>
 
-<?php foreach($namespaces_by_alias_ns as $namespace => $aliases): ?>
+<?php foreach ($namespaces_by_alias_ns as $namespace => $aliases): ?>
 namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
-<?php foreach($aliases as $alias): ?>
+<?php foreach ($aliases as $alias): ?>
 
     <?= $alias->getClassType() ?> <?= $alias->getShortName() ?> extends <?= $alias->getExtends() ?> {<?php if ($alias->getExtendsNamespace() == '\Illuminate\Database\Eloquent'): ?>
-        <?php foreach($alias->getMethods() as $method): ?> 
+        <?php foreach ($alias->getMethods() as $method): ?> 
             <?= trim($method->getDocComment('            ')) ?> 
             public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
-            {<?php if($method->getDeclaringClass() !== $method->getRoot()): ?>
+            {<?php if ($method->getDeclaringClass() !== $method->getRoot()): ?>
     
                 //Method inherited from <?= $method->getDeclaringClass() ?>
                 <?php endif; ?>
 
-                <?php if($method->isInstanceCall()):?>
+                <?php if ($method->isInstanceCall()):?>
                 /** @var <?=$method->getRoot()?> $instance */
                 <?php endif?>
-                <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRootMethodCall() ?>;
+                <?= $method->shouldReturn() ? 'return ' : '' ?><?= $method->getRootMethodCall() ?>;
             }
         <?php endforeach; ?>
 <?php endif; ?>}
@@ -73,13 +73,13 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
 
 <?php endforeach; ?>
 
-<?php if($helpers): ?>
+<?php if ($helpers): ?>
 namespace {
 <?= $helpers ?> 
 }
 <?php endif; ?>
 
-<?php if($include_fluent): ?>
+<?php if ($include_fluent): ?>
 namespace Illuminate\Support {
     /**
      * Methods commonly used in migrations

--- a/resources/views/meta.php
+++ b/resources/views/meta.php
@@ -6,7 +6,7 @@ namespace PHPSTORM_META {
 
    /**
     * PhpStorm Meta file, to provide autocomplete information for PhpStorm
-    * Generated on <?= date("Y-m-d H:i:s") ?>.
+    * Generated on <?= date('Y-m-d H:i:s') ?>.
     *
     * @author Barry vd. Heuvel <barryvdh@gmail.com>
     * @see https://github.com/barryvdh/laravel-ide-helper
@@ -14,7 +14,7 @@ namespace PHPSTORM_META {
 <?php foreach ($methods as $method): ?>
     override(<?= $method ?>, map([
         '' => '@',
-<?php foreach($bindings as $abstract => $class): ?>
+<?php foreach ($bindings as $abstract => $class): ?>
         '<?= $abstract ?>' => \<?= $class ?>::class,
 <?php endforeach; ?>
     ]));
@@ -23,7 +23,7 @@ namespace PHPSTORM_META {
 <?php if (count($factories)): ?>
 	override(\factory(0), map([
         '' => '@FactoryBuilder',
-<?php foreach($factories as $factory): ?>
+<?php foreach ($factories as $factory): ?>
         '<?= $factory->getName() ?>' => \<?= $factory->getName() ?>FactoryBuilder::class,
 <?php endforeach; ?>
 	]));

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Laravel IDE Helper Generator
+ * Laravel IDE Helper Generator.
  *
  * @author    Barry vd. Heuvel <barryvdh@gmail.com>
  * @copyright 2014 Barry vd. Heuvel / Fruitcake Studio (http://www.fruitcakestudio.nl)
@@ -10,13 +10,13 @@
 
 namespace Barryvdh\LaravelIdeHelper;
 
-use Closure;
-use ReflectionClass;
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Context;
-use Barryvdh\Reflection\DocBlock\Tag\MethodTag;
-use Illuminate\Config\Repository as ConfigRepository;
 use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
+use Barryvdh\Reflection\DocBlock\Tag\MethodTag;
+use Closure;
+use Illuminate\Config\Repository as ConfigRepository;
+use ReflectionClass;
 
 class Alias
 {
@@ -29,15 +29,15 @@ class Alias
     protected $short;
     protected $namespace = '__root';
     protected $root = null;
-    protected $classes = array();
-    protected $methods = array();
-    protected $usedMethods = array();
+    protected $classes = [];
+    protected $methods = [];
+    protected $usedMethods = [];
     protected $valid = false;
-    protected $magicMethods = array();
-    protected $interfaces = array();
+    protected $magicMethods = [];
+    protected $interfaces = [];
     protected $phpdoc = null;
 
-    /** @var ConfigRepository  */
+    /** @var ConfigRepository */
     protected $config;
 
     /**
@@ -47,7 +47,7 @@ class Alias
      * @param array            $magicMethods
      * @param array            $interfaces
      */
-    public function __construct($config, $alias, $facade, $magicMethods = array(), $interfaces = array())
+    public function __construct($config, $alias, $facade, $magicMethods = [], $interfaces = [])
     {
         $this->alias = $alias;
         $this->magicMethods = $magicMethods;
@@ -55,12 +55,12 @@ class Alias
         $this->config = $config;
 
         // Make the class absolute
-        $facade = '\\' . ltrim($facade, '\\');
+        $facade = '\\'.ltrim($facade, '\\');
         $this->facade = $facade;
 
         $this->detectRoot();
 
-        if ((!$this->isTrait() && $this->root)) {
+        if ((! $this->isTrait() && $this->root)) {
             $this->valid = true;
         } else {
             return;
@@ -72,25 +72,24 @@ class Alias
         $this->detectClassType();
         $this->detectExtendsNamespace();
 
-        if (!empty($this->namespace)) {
+        if (! empty($this->namespace)) {
             //Create a DocBlock and serializer instance
             $this->phpdoc = new DocBlock(new ReflectionClass($alias), new Context($this->namespace));
         }
 
-
         if ($facade === '\Illuminate\Database\Eloquent\Model') {
-            $this->usedMethods = array('decrement', 'increment');
+            $this->usedMethods = ['decrement', 'increment'];
         }
     }
 
     /**
-     * Add one or more classes to analyze
+     * Add one or more classes to analyze.
      *
      * @param array|string $classes
      */
     public function addClass($classes)
     {
-        $classes = (array)$classes;
+        $classes = (array) $classes;
         foreach ($classes as $class) {
             if (class_exists($class) || interface_exists($class)) {
                 $this->classes[] = $class;
@@ -110,7 +109,7 @@ class Alias
     }
 
     /**
-     * Get the classtype, 'interface' or 'class'
+     * Get the classtype, 'interface' or 'class'.
      *
      * @return string
      */
@@ -120,7 +119,7 @@ class Alias
     }
 
     /**
-     * Get the class which this alias extends
+     * Get the class which this alias extends.
      *
      * @return null|string
      */
@@ -130,7 +129,7 @@ class Alias
     }
 
     /**
-     * Get the class short name which this alias extends
+     * Get the class short name which this alias extends.
      *
      * @return null|string
      */
@@ -140,7 +139,7 @@ class Alias
     }
 
     /**
-     * Get the namespace of the class which this alias extends
+     * Get the namespace of the class which this alias extends.
      *
      * @return null|string
      */
@@ -150,7 +149,7 @@ class Alias
     }
 
     /**
-     * Get the Alias by which this class is called
+     * Get the Alias by which this class is called.
      *
      * @return string
      */
@@ -160,14 +159,15 @@ class Alias
     }
 
     /**
-     * Return the short name (without namespace)
+     * Return the short name (without namespace).
      */
     public function getShortName()
     {
         return $this->short;
     }
+
     /**
-     * Get the namespace from the alias
+     * Get the namespace from the alias.
      *
      * @return string
      */
@@ -177,7 +177,7 @@ class Alias
     }
 
     /**
-     * Get the methods found by this Alias
+     * Get the methods found by this Alias.
      *
      * @return array|Method[]
      */
@@ -189,22 +189,23 @@ class Alias
 
         $this->addMagicMethods();
         $this->detectMethods();
+
         return $this->methods;
     }
 
     /**
-     * Detect class returned by ::fake()
+     * Detect class returned by ::fake().
      */
     protected function detectFake()
     {
         $facade = $this->facade;
-        
-        if (!method_exists($facade, 'fake')) {
+
+        if (! method_exists($facade, 'fake')) {
             return;
         }
 
         $real = $facade::getFacadeRoot();
-        
+
         try {
             $facade::fake();
             $fake = $facade::getFacadeRoot();
@@ -217,7 +218,7 @@ class Alias
     }
 
     /**
-     * Detect the namespace
+     * Detect the namespace.
      */
     protected function detectNamespace()
     {
@@ -231,7 +232,7 @@ class Alias
     }
 
     /**
-     * Detect the extends namespace
+     * Detect the extends namespace.
      */
     protected function detectExtendsNamespace()
     {
@@ -243,7 +244,7 @@ class Alias
     }
 
     /**
-     * Detect the class type
+     * Detect the class type.
      */
     protected function detectClassType()
     {
@@ -260,7 +261,7 @@ class Alias
     }
 
     /**
-     * Get the real root of a facade
+     * Get the real root of a facade.
      *
      * @return bool|string
      */
@@ -277,7 +278,7 @@ class Alias
             }
 
             //If it doesn't exist, skip it
-            if (!class_exists($root) && !interface_exists($root)) {
+            if (! class_exists($root) && ! interface_exists($root)) {
                 return;
             }
 
@@ -286,12 +287,12 @@ class Alias
             //When the database connection is not set, some classes will be skipped
         } catch (\PDOException $e) {
             $this->error(
-                "PDOException: " . $e->getMessage() .
-                "\nPlease configure your database connection correctly, or use the sqlite memory driver (-M)." .
+                'PDOException: '.$e->getMessage().
+                "\nPlease configure your database connection correctly, or use the sqlite memory driver (-M).".
                 " Skipping $facade."
             );
         } catch (\Exception $e) {
-            $this->error("Exception: " . $e->getMessage() . "\nSkipping $facade.");
+            $this->error('Exception: '.$e->getMessage()."\nSkipping $facade.");
         }
     }
 
@@ -306,23 +307,24 @@ class Alias
         if (function_exists('trait_exists') && trait_exists($this->facade)) {
             return true;
         }
+
         return false;
     }
 
     /**
-     * Add magic methods, as defined in the configuration files
+     * Add magic methods, as defined in the configuration files.
      */
     protected function addMagicMethods()
     {
         foreach ($this->magicMethods as $magic => $real) {
-            list($className, $name) = explode('::', $real);
-            if ((!class_exists($className) && !interface_exists($className)) || !method_exists($className, $name)) {
+            [$className, $name] = explode('::', $real);
+            if ((! class_exists($className) && ! interface_exists($className)) || ! method_exists($className, $name)) {
                 continue;
             }
             $method = new \ReflectionMethod($className, $name);
             $class = new \ReflectionClass($className);
 
-            if (!in_array($magic, $this->usedMethods)) {
+            if (! in_array($magic, $this->usedMethods)) {
                 if ($class !== $this->root) {
                     $this->methods[] = new Method($method, $this->alias, $class, $magic, $this->interfaces);
                 }
@@ -338,14 +340,13 @@ class Alias
      */
     protected function detectMethods()
     {
-
         foreach ($this->classes as $class) {
             $reflection = new \ReflectionClass($class);
 
             $methods = $reflection->getMethods(\ReflectionMethod::IS_PUBLIC);
             if ($methods) {
                 foreach ($methods as $method) {
-                    if (!in_array($method->name, $this->usedMethods)) {
+                    if (! in_array($method->name, $this->usedMethods)) {
                         // Only add the methods to the output when the root is not the same as the class.
                         // And don't add the __*() methods
                         if ($this->extends !== $class && substr($method->name, 0, 2) !== '__') {
@@ -368,7 +369,7 @@ class Alias
                 $properties = $reflection->getStaticProperties();
                 $macros = isset($properties['macros']) ? $properties['macros'] : [];
                 foreach ($macros as $macro_name => $macro_func) {
-                    if (!in_array($macro_name, $this->usedMethods)) {
+                    if (! in_array($macro_name, $this->usedMethods)) {
                         // Add macros
                         $this->methods[] = new Macro(
                             $this->getMacroFunction($macro_func),
@@ -396,7 +397,7 @@ class Alias
             return new \ReflectionMethod($macro_func[0], $macro_func[1]);
         }
 
-        if (is_object($macro_func) && is_callable($macro_func) && !$macro_func instanceof Closure) {
+        if (is_object($macro_func) && is_callable($macro_func) && ! $macro_func instanceof Closure) {
             return new \ReflectionMethod($macro_func, '__invoke');
         }
 
@@ -425,6 +426,7 @@ class Alias
             }
 
             $this->removeDuplicateMethodsFromPhpDoc();
+
             return $serializer->getDocComment($this->phpdoc);
         }
 
@@ -458,6 +460,6 @@ class Alias
      */
     protected function error($string)
     {
-        echo $string . "\r\n";
+        echo $string."\r\n";
     }
 }

--- a/src/Console/EloquentCommand.php
+++ b/src/Console/EloquentCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Laravel IDE Helper Generator - Eloquent Model Mixin
+ * Laravel IDE Helper Generator - Eloquent Model Mixin.
  *
  * @author    Charles A. Peterson <artistan@gmail.com>
  * @copyright 2017 Charles A. Peterson / Fruitcake Studio (http://www.fruitcakestudio.nl)
@@ -15,7 +15,7 @@ use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 
 /**
- * A command to add \Eloquent mixin to Eloquent\Model
+ * A command to add \Eloquent mixin to Eloquent\Model.
  *
  * @author Charles A. Peterson <artistan@gmail.com>
  */
@@ -29,7 +29,7 @@ class EloquentCommand extends Command
     protected $name = 'ide-helper:eloquent';
 
     /**
-     * @var Filesystem $files
+     * @var Filesystem
      */
     protected $files;
 

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Laravel IDE Helper Generator
+ * Laravel IDE Helper Generator.
  *
  * @author    Barry vd. Heuvel <barryvdh@gmail.com>
  * @copyright 2014 Barry vd. Heuvel / Fruitcake Studio (http://www.fruitcakestudio.nl)
@@ -14,17 +14,16 @@ use Barryvdh\LaravelIdeHelper\Eloquent;
 use Barryvdh\LaravelIdeHelper\Generator;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
- * A command to generate autocomplete information for your IDE
+ * A command to generate autocomplete information for your IDE.
  *
  * @author Barry vd. Heuvel <barryvdh@gmail.com>
  */
 class GeneratorCommand extends Command
 {
-
     /**
      * The console command name.
      *
@@ -50,15 +49,14 @@ class GeneratorCommand extends Command
 
     protected $onlyExtend;
 
-
     /**
-     *
      * @param \Illuminate\Config\Repository $config
      * @param \Illuminate\Filesystem\Filesystem $files
      * @param \Illuminate\View\Factory $view
      */
     public function __construct(
-        /*ConfigRepository */ $config,
+        /*ConfigRepository */ 
+        $config,
         Filesystem $files,
         /* Illuminate\View\Factory */
         $view
@@ -76,9 +74,9 @@ class GeneratorCommand extends Command
      */
     public function handle()
     {
-        if (file_exists(base_path() . '/vendor/compiled.php') ||
-            file_exists(base_path() . '/bootstrap/cache/compiled.php') ||
-            file_exists(base_path() . '/storage/framework/compiled.php')) {
+        if (file_exists(base_path().'/vendor/compiled.php') ||
+            file_exists(base_path().'/bootstrap/cache/compiled.php') ||
+            file_exists(base_path().'/storage/framework/compiled.php')) {
             $this->error(
                 'Error generating IDE Helper: first delete your compiled file (php artisan clear-compiled)'
             );
@@ -91,18 +89,17 @@ class GeneratorCommand extends Command
                 $filename = substr($filename, 0, -4);
             }
 
-            $filename .= '.' . $format;
+            $filename .= '.'.$format;
 
             if ($this->option('memory')) {
                 $this->useMemoryDriver();
             }
 
-
             $helpers = '';
             if ($this->option('helpers') || ($this->config->get('ide-helper.include_helpers'))) {
-                foreach ($this->config->get('ide-helper.helper_files', array()) as $helper) {
+                foreach ($this->config->get('ide-helper.helper_files', []) as $helper) {
                     if (file_exists($helper)) {
-                        $helpers .= str_replace(array('<?php', '?>'), '', $this->files->get($helper));
+                        $helpers .= str_replace(['<?php', '?>'], '', $this->files->get($helper));
                     }
                 }
             } else {
@@ -130,10 +127,10 @@ class GeneratorCommand extends Command
         //Use a sqlite database in memory, to avoid connection errors on Database facades
         $this->config->set(
             'database.connections.sqlite',
-            array(
+            [
                 'driver' => 'sqlite',
                 'database' => ':memory:',
-            )
+            ]
         );
         $this->config->set('database.default', 'sqlite');
     }
@@ -147,11 +144,11 @@ class GeneratorCommand extends Command
     {
         $filename = $this->config->get('ide-helper.filename');
 
-        return array(
-            array(
-                'filename', InputArgument::OPTIONAL, 'The path to the helper file', $filename
-            ),
-        );
+        return [
+            [
+                'filename', InputArgument::OPTIONAL, 'The path to the helper file', $filename,
+            ],
+        ];
     }
 
     /**
@@ -164,12 +161,12 @@ class GeneratorCommand extends Command
         $format = $this->config->get('ide-helper.format');
         $writeMixins = $this->config->get('ide-helper.write_eloquent_model_mixins');
 
-        return array(
-            array('format', "F", InputOption::VALUE_OPTIONAL, 'The format for the IDE Helper', $format),
-            array('write_mixins', "W", InputOption::VALUE_OPTIONAL, 'Write mixins to Laravel Model?', $writeMixins),
-            array('helpers', "H", InputOption::VALUE_NONE, 'Include the helper files'),
-            array('memory', "M", InputOption::VALUE_NONE, 'Use sqlite memory driver'),
-            array('sublime', "S", InputOption::VALUE_NONE, 'DEPRECATED: Use different style for SublimeText CodeIntel'),
-        );
+        return [
+            ['format', 'F', InputOption::VALUE_OPTIONAL, 'The format for the IDE Helper', $format],
+            ['write_mixins', 'W', InputOption::VALUE_OPTIONAL, 'Write mixins to Laravel Model?', $writeMixins],
+            ['helpers', 'H', InputOption::VALUE_NONE, 'Include the helper files'],
+            ['memory', 'M', InputOption::VALUE_NONE, 'Use sqlite memory driver'],
+            ['sublime', 'S', InputOption::VALUE_NONE, 'DEPRECATED: Use different style for SublimeText CodeIntel'],
+        ];
     }
 }

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -55,10 +55,8 @@ class GeneratorCommand extends Command
      * @param \Illuminate\View\Factory $view
      */
     public function __construct(
-        /*ConfigRepository */ 
         $config,
         Filesystem $files,
-        /* Illuminate\View\Factory */
         $view
     ) {
         $this->config = $config;

--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Laravel IDE Helper Generator
+ * Laravel IDE Helper Generator.
  *
  * @author    Barry vd. Heuvel <barryvdh@gmail.com>
  * @copyright 2015 Barry vd. Heuvel / Fruitcake Studio (http://www.fruitcakestudio.nl)
@@ -16,13 +16,12 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * A command to generate phpstorm meta data
+ * A command to generate phpstorm meta data.
  *
  * @author Barry vd. Heuvel <barryvdh@gmail.com>
  */
 class MetaCommand extends Command
 {
-
     /**
      * The console command name.
      *
@@ -47,18 +46,17 @@ class MetaCommand extends Command
     protected $config;
 
     protected $methods = [
-      'new \Illuminate\Contracts\Container\Container',
-      '\Illuminate\Container\Container::makeWith(0)',
-      '\Illuminate\Contracts\Container\Container::make(0)',
-      '\Illuminate\Contracts\Container\Container::makeWith(0)',
-      '\App::make(0)',
-      '\App::makeWith(0)',
-      '\app(0)',
-      '\resolve(0)',
+        'new \Illuminate\Contracts\Container\Container',
+        '\Illuminate\Container\Container::makeWith(0)',
+        '\Illuminate\Contracts\Container\Container::make(0)',
+        '\Illuminate\Contracts\Container\Container::makeWith(0)',
+        '\App::make(0)',
+        '\App::makeWith(0)',
+        '\app(0)',
+        '\resolve(0)',
     ];
 
     /**
-     *
      * @param \Illuminate\Contracts\Filesystem\Filesystem $files
      * @param \Illuminate\Contracts\View\Factory $view
      * @param \Illuminate\Contracts\Config $config
@@ -83,7 +81,7 @@ class MetaCommand extends Command
 
         $this->registerClassAutoloadExceptions();
 
-        $bindings = array();
+        $bindings = [];
         foreach ($this->getAbstracts() as $abstract) {
             // Validator and seeder cause problems
             if (in_array($abstract, ['validator', 'seeder'])) {
@@ -93,7 +91,7 @@ class MetaCommand extends Command
             try {
                 $concrete = $this->laravel->make($abstract);
                 $reflectionClass = new \ReflectionClass($concrete);
-                if (is_object($concrete) && !$reflectionClass->isAnonymous()) {
+                if (is_object($concrete) && ! $reflectionClass->isAnonymous()) {
                     $bindings[$abstract] = get_class($concrete);
                 }
             } catch (\Throwable $e) {
@@ -104,9 +102,9 @@ class MetaCommand extends Command
         }
 
         $content = $this->view->make('meta', [
-          'bindings' => $bindings,
-          'methods' => $this->methods,
-          'factories' => $factories,
+            'bindings' => $bindings,
+            'methods' => $this->methods,
+            'factories' => $factories,
         ])->render();
 
         $filename = $this->option('filename');
@@ -155,8 +153,8 @@ class MetaCommand extends Command
     {
         $filename = $this->config->get('ide-helper.meta_filename');
 
-        return array(
-            array('filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the meta file', $filename),
-        );
+        return [
+            ['filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the meta file', $filename],
+        ];
     }
 }

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Laravel IDE Helper Generator
+ * Laravel IDE Helper Generator.
  *
  * @author    Barry vd. Heuvel <barryvdh@gmail.com>
  * @copyright 2014 Barry vd. Heuvel / Fruitcake Studio (http://www.fruitcakestudio.nl)
@@ -10,29 +10,29 @@
 
 namespace Barryvdh\LaravelIdeHelper\Console;
 
+use Barryvdh\Reflection\DocBlock;
+use Barryvdh\Reflection\DocBlock\Context;
+use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
+use Barryvdh\Reflection\DocBlock\Tag;
 use Composer\Autoload\ClassMapGenerator;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Str;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 use ReflectionClass;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Barryvdh\Reflection\DocBlock;
-use Barryvdh\Reflection\DocBlock\Context;
-use Barryvdh\Reflection\DocBlock\Tag;
-use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
 
 /**
- * A command to generate autocomplete information for your IDE
+ * A command to generate autocomplete information for your IDE.
  *
  * @author Barry vd. Heuvel <barryvdh@gmail.com>
  */
 class ModelsCommand extends Command
 {
     /**
-     * @var Filesystem $files
+     * @var Filesystem
      */
     protected $files;
 
@@ -52,10 +52,10 @@ class ModelsCommand extends Command
     protected $description = 'Generate autocompletion for models';
 
     protected $write_model_magic_where;
-    protected $properties = array();
-    protected $methods = array();
+    protected $properties = [];
+    protected $methods = [];
     protected $write = false;
-    protected $dirs = array();
+    protected $dirs = [];
     protected $reset;
     protected $keep_text;
     /**
@@ -102,7 +102,7 @@ class ModelsCommand extends Command
         $this->write_model_magic_where = $this->laravel['config']->get('ide-helper.write_model_magic_where', true);
 
         //If filename is default and Write is not specified, ask what to do
-        if (!$this->write && $filename === $this->filename && !$this->option('nowrite')) {
+        if (! $this->write && $filename === $this->filename && ! $this->option('nowrite')) {
             if ($this->confirm(
                 "Do you want to overwrite the existing model files? Choose no to write to $filename instead"
             )
@@ -112,12 +112,12 @@ class ModelsCommand extends Command
         }
 
         $this->dateClass = class_exists(\Illuminate\Support\Facades\Date::class)
-            ? '\\' . get_class(\Illuminate\Support\Facades\Date::now())
+            ? '\\'.get_class(\Illuminate\Support\Facades\Date::now())
             : '\Illuminate\Support\Carbon';
 
         $content = $this->generateDocs($model, $ignore);
 
-        if (!$this->write) {
+        if (! $this->write) {
             $written = $this->files->put($filename, $content);
             if ($written !== false) {
                 $this->info("Model information was written to $filename");
@@ -127,7 +127,6 @@ class ModelsCommand extends Command
         }
     }
 
-
     /**
      * Get the console command arguments.
      *
@@ -135,9 +134,9 @@ class ModelsCommand extends Command
      */
     protected function getArguments()
     {
-        return array(
-          array('model', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Which models to include', array()),
-        );
+        return [
+            ['model', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Which models to include', []],
+        ];
     }
 
     /**
@@ -147,21 +146,19 @@ class ModelsCommand extends Command
      */
     protected function getOptions()
     {
-        return array(
-          array('filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the helper file', $this->filename),
-          array('dir', 'D', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The model dir', array()),
-          array('write', 'W', InputOption::VALUE_NONE, 'Write to Model file'),
-          array('nowrite', 'N', InputOption::VALUE_NONE, 'Don\'t write to Model file'),
-          array('reset', 'R', InputOption::VALUE_NONE, 'Remove the original phpdocs instead of appending'),
-          array('smart-reset', 'r', InputOption::VALUE_NONE, 'Refresh the properties/methods list, but keep the text'),
-          array('ignore', 'I', InputOption::VALUE_OPTIONAL, 'Which models to ignore', ''),
-        );
+        return [
+            ['filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the helper file', $this->filename],
+            ['dir', 'D', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The model dir', []],
+            ['write', 'W', InputOption::VALUE_NONE, 'Write to Model file'],
+            ['nowrite', 'N', InputOption::VALUE_NONE, 'Don\'t write to Model file'],
+            ['reset', 'R', InputOption::VALUE_NONE, 'Remove the original phpdocs instead of appending'],
+            ['smart-reset', 'r', InputOption::VALUE_NONE, 'Refresh the properties/methods list, but keep the text'],
+            ['ignore', 'I', InputOption::VALUE_OPTIONAL, 'Which models to ignore', ''],
+        ];
     }
 
     protected function generateDocs($loadModels, $ignore = '')
     {
-
-
         $output = "<?php
 
 // @formatter:off
@@ -179,7 +176,7 @@ class ModelsCommand extends Command
         if (empty($loadModels)) {
             $models = $this->loadModels();
         } else {
-            $models = array();
+            $models = [];
             foreach ($loadModels as $model) {
                 $models = array_merge($models, explode(',', $model));
             }
@@ -194,14 +191,14 @@ class ModelsCommand extends Command
                 }
                 continue;
             }
-            $this->properties = array();
-            $this->methods = array();
+            $this->properties = [];
+            $this->methods = [];
             if (class_exists($name)) {
                 try {
                     // handle abstract classes, interfaces, ...
                     $reflectionClass = new ReflectionClass($name);
 
-                    if (!$reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Model')) {
+                    if (! $reflectionClass->isSubclassOf('Illuminate\Database\Eloquent\Model')) {
                         continue;
                     }
 
@@ -209,7 +206,7 @@ class ModelsCommand extends Command
                         $this->comment("Loading model '$name'");
                     }
 
-                    if (!$reflectionClass->IsInstantiable()) {
+                    if (! $reflectionClass->IsInstantiable()) {
                         // ignore abstract class or interface
                         continue;
                     }
@@ -226,18 +223,16 @@ class ModelsCommand extends Command
 
                     $this->getPropertiesFromMethods($model);
                     $this->getSoftDeleteMethods($model);
-                    $output                .= $this->createPhpDocs($name);
-                    $ignore[]              = $name;
+                    $output .= $this->createPhpDocs($name);
+                    $ignore[] = $name;
                     $this->nullableColumns = [];
                 } catch (\Throwable $e) {
-                    $this->error("Exception: " . $e->getMessage() .
-                        "\nCould not analyze class $name.\n\nTrace:\n" .
-                        $e->getTraceAsString());
+                    $this->error('Exception: '.$e->getMessage()."\nCould not analyze class $name.\n\nTrace:\n".$e->getTraceAsString());
                 }
             }
         }
 
-        if (!$hasDoctrine) {
+        if (! $hasDoctrine) {
             $this->error(
                 'Warning: `"doctrine/dbal": "~2.3"` is required to load database information. '.
                 'Please require that in your composer.json and run `composer update`.'
@@ -247,18 +242,18 @@ class ModelsCommand extends Command
         return $output;
     }
 
-
     protected function loadModels()
     {
-        $models = array();
+        $models = [];
         foreach ($this->dirs as $dir) {
-            $dir = base_path() . '/' . $dir;
+            $dir = base_path().'/'.$dir;
             if (file_exists($dir)) {
                 foreach (ClassMapGenerator::createMap($dir) as $model => $path) {
                     $models[] = $model;
                 }
             }
         }
+
         return $models;
     }
 
@@ -304,11 +299,11 @@ class ModelsCommand extends Command
                     $realType = '\Illuminate\Support\Collection';
                     break;
                 default:
-                    $realType = class_exists($type) ? ('\\' . $type) : 'mixed';
+                    $realType = class_exists($type) ? ('\\'.$type) : 'mixed';
                     break;
             }
 
-            if (!isset($this->properties[$name])) {
+            if (! isset($this->properties[$name])) {
                 continue;
             } else {
                 $this->properties[$name]['type'] = $this->getTypeOverride($realType);
@@ -328,7 +323,7 @@ class ModelsCommand extends Command
      */
     protected function getTypeOverride($type)
     {
-        $typeOverrides = $this->laravel['config']->get('ide-helper.type_overrides', array());
+        $typeOverrides = $this->laravel['config']->get('ide-helper.type_overrides', []);
 
         return isset($typeOverrides[$type]) ? $typeOverrides[$type] : $type;
     }
@@ -340,20 +335,20 @@ class ModelsCommand extends Command
      */
     protected function getPropertiesFromTable($model)
     {
-        $table = $model->getConnection()->getTablePrefix() . $model->getTable();
+        $table = $model->getConnection()->getTablePrefix().$model->getTable();
         $schema = $model->getConnection()->getDoctrineSchemaManager($table);
         $databasePlatform = $schema->getDatabasePlatform();
         $databasePlatform->registerDoctrineTypeMapping('enum', 'string');
 
         $platformName = $databasePlatform->getName();
-        $customTypes = $this->laravel['config']->get("ide-helper.custom_db_types.{$platformName}", array());
+        $customTypes = $this->laravel['config']->get("ide-helper.custom_db_types.{$platformName}", []);
         foreach ($customTypes as $yourTypeName => $doctrineTypeName) {
             $databasePlatform->registerDoctrineTypeMapping($yourTypeName, $doctrineTypeName);
         }
 
         $database = null;
         if (strpos($table, '.')) {
-            list($database, $table) = explode('.', $table);
+            [$database, $table] = explode('.', $table);
         }
 
         $columns = $schema->listTableColumns($table, $database);
@@ -402,15 +397,15 @@ class ModelsCommand extends Command
                 }
 
                 $comment = $column->getComment();
-                if (!$column->getNotnull()) {
+                if (! $column->getNotnull()) {
                     $this->nullableColumns[$name] = true;
                 }
-                $this->setProperty($name, $type, true, true, $comment, !$column->getNotnull());
+                $this->setProperty($name, $type, true, true, $comment, ! $column->getNotnull());
                 if ($this->write_model_magic_where) {
                     $this->setMethod(
-                        Str::camel("where_" . $name),
-                        '\Illuminate\Database\Eloquent\Builder|\\' . get_class($model),
-                        array('$value')
+                        Str::camel('where_'.$name),
+                        '\Illuminate\Database\Eloquent\Builder|\\'.get_class($model),
+                        ['$value']
                     );
                 }
             }
@@ -433,7 +428,7 @@ class ModelsCommand extends Command
                 ) {
                     //Magic get<name>Attribute
                     $name = Str::snake(substr($method, 3, -9));
-                    if (!empty($name)) {
+                    if (! empty($name)) {
                         $reflection = new \ReflectionMethod($model, $method);
                         $type = $this->getReturnTypeFromDocBlock($reflection);
                         $this->setProperty($name, $type, true, null);
@@ -445,27 +440,27 @@ class ModelsCommand extends Command
                 ) {
                     //Magic set<name>Attribute
                     $name = Str::snake(substr($method, 3, -9));
-                    if (!empty($name)) {
+                    if (! empty($name)) {
                         $this->setProperty($name, null, null, true);
                     }
                 } elseif (Str::startsWith($method, 'scope') && $method !== 'scopeQuery') {
                     //Magic set<name>Attribute
                     $name = Str::camel(substr($method, 5));
-                    if (!empty($name)) {
+                    if (! empty($name)) {
                         $reflection = new \ReflectionMethod($model, $method);
                         $args = $this->getParameters($reflection);
                         //Remove the first ($query) argument
                         array_shift($args);
-                        $this->setMethod($name, '\Illuminate\Database\Eloquent\Builder|\\' . $reflection->class, $args);
+                        $this->setMethod($name, '\Illuminate\Database\Eloquent\Builder|\\'.$reflection->class, $args);
                     }
                 } elseif (in_array($method, ['query', 'newQuery', 'newModelQuery'])) {
                     $reflection = new \ReflectionClass($model);
 
                     $builder = get_class($model->newModelQuery());
 
-                    $this->setMethod($method, "\\{$builder}|\\" . $reflection->getName());
-                } elseif (!method_exists('Illuminate\Database\Eloquent\Model', $method)
-                    && !Str::startsWith($method, 'get')
+                    $this->setMethod($method, "\\{$builder}|\\".$reflection->getName());
+                } elseif (! method_exists('Illuminate\Database\Eloquent\Model', $method)
+                    && ! Str::startsWith($method, 'get')
                 ) {
                     //Use reflection to inspect the code, based on Illuminate/Support/SerializableClosure.php
                     $reflection = new \ReflectionMethod($model, $method);
@@ -473,10 +468,10 @@ class ModelsCommand extends Command
                     if ($returnType = $reflection->getReturnType()) {
                         $type = $returnType instanceof \ReflectionNamedType
                             ? $returnType->getName()
-                            : (string)$returnType;
+                            : (string) $returnType;
                     } else {
                         // php 7.x type or fallback to docblock
-                        $type = (string)$this->getReturnTypeFromDocBlock($reflection);
+                        $type = (string) $this->getReturnTypeFromDocBlock($reflection);
                     }
 
                     $file = new \SplFileObject($reflection->getFileName());
@@ -491,21 +486,21 @@ class ModelsCommand extends Command
                     $begin = strpos($code, 'function(');
                     $code = substr($code, $begin, strrpos($code, '}') - $begin + 1);
 
-                    foreach (array(
-                               'hasMany' => '\Illuminate\Database\Eloquent\Relations\HasMany',
-                               'hasManyThrough' => '\Illuminate\Database\Eloquent\Relations\HasManyThrough',
-                               'hasOneThrough' => '\Illuminate\Database\Eloquent\Relations\HasOneThrough',
-                               'belongsToMany' => '\Illuminate\Database\Eloquent\Relations\BelongsToMany',
-                               'hasOne' => '\Illuminate\Database\Eloquent\Relations\HasOne',
-                               'belongsTo' => '\Illuminate\Database\Eloquent\Relations\BelongsTo',
-                               'morphOne' => '\Illuminate\Database\Eloquent\Relations\MorphOne',
-                               'morphTo' => '\Illuminate\Database\Eloquent\Relations\MorphTo',
-                               'morphMany' => '\Illuminate\Database\Eloquent\Relations\MorphMany',
-                               'morphToMany' => '\Illuminate\Database\Eloquent\Relations\MorphToMany',
-                               'morphedByMany' => '\Illuminate\Database\Eloquent\Relations\MorphToMany'
-                             ) as $relation => $impl) {
-                        $search = '$this->' . $relation . '(';
-                        if (stripos($code, $search) || $impl === (string)$type) {
+                    foreach ([
+                        'hasMany' => '\Illuminate\Database\Eloquent\Relations\HasMany',
+                        'hasManyThrough' => '\Illuminate\Database\Eloquent\Relations\HasManyThrough',
+                        'hasOneThrough' => '\Illuminate\Database\Eloquent\Relations\HasOneThrough',
+                        'belongsToMany' => '\Illuminate\Database\Eloquent\Relations\BelongsToMany',
+                        'hasOne' => '\Illuminate\Database\Eloquent\Relations\HasOne',
+                        'belongsTo' => '\Illuminate\Database\Eloquent\Relations\BelongsTo',
+                        'morphOne' => '\Illuminate\Database\Eloquent\Relations\MorphOne',
+                        'morphTo' => '\Illuminate\Database\Eloquent\Relations\MorphTo',
+                        'morphMany' => '\Illuminate\Database\Eloquent\Relations\MorphMany',
+                        'morphToMany' => '\Illuminate\Database\Eloquent\Relations\MorphToMany',
+                        'morphedByMany' => '\Illuminate\Database\Eloquent\Relations\MorphToMany',
+                    ] as $relation => $impl) {
+                        $search = '$this->'.$relation.'(';
+                        if (stripos($code, $search) || $impl === (string) $type) {
                             //Resolve the relation's model to a Relation object.
                             $methodReflection = new \ReflectionMethod($model, $method);
                             if ($methodReflection->getNumberOfParameters()) {
@@ -520,7 +515,7 @@ class ModelsCommand extends Command
                             });
 
                             if ($relationObj instanceof Relation) {
-                                $relatedModel = '\\' . get_class($relationObj->getRelated());
+                                $relatedModel = '\\'.get_class($relationObj->getRelated());
 
                                 $relations = [
                                     'hasManyThrough',
@@ -534,17 +529,17 @@ class ModelsCommand extends Command
                                     //Collection or array of models (because Collection is Arrayable)
                                     $this->setProperty(
                                         $method,
-                                        $this->getCollectionClass($relatedModel) . '|' . $relatedModel . '[]',
+                                        $this->getCollectionClass($relatedModel).'|'.$relatedModel.'[]',
                                         true,
                                         null
                                     );
                                     $this->setProperty(
-                                        Str::snake($method) . '_count',
+                                        Str::snake($method).'_count',
                                         'int|null',
                                         true,
                                         false
                                     );
-                                } elseif ($relation === "morphTo") {
+                                } elseif ($relation === 'morphTo') {
                                     // Model isn't specified because relation is polymorphic
                                     $this->setProperty(
                                         $method,
@@ -572,7 +567,7 @@ class ModelsCommand extends Command
     }
 
     /**
-     * Check if the foreign key of the relation is nullable
+     * Check if the foreign key of the relation is nullable.
      *
      * @param Relation $relation
      *
@@ -581,7 +576,7 @@ class ModelsCommand extends Command
     private function isRelationForeignKeyNullable(Relation $relation)
     {
         $reflectionObj = new \ReflectionObject($relation);
-        if (!$reflectionObj->hasProperty('foreignKey')) {
+        if (! $reflectionObj->hasProperty('foreignKey')) {
             return false;
         }
         $fkProp = $reflectionObj->getProperty('foreignKey');
@@ -600,8 +595,8 @@ class ModelsCommand extends Command
      */
     protected function setProperty($name, $type = null, $read = null, $write = null, $comment = '', $nullable = false)
     {
-        if (!isset($this->properties[$name])) {
-            $this->properties[$name] = array();
+        if (! isset($this->properties[$name])) {
+            $this->properties[$name] = [];
             $this->properties[$name]['type'] = 'mixed';
             $this->properties[$name]['read'] = false;
             $this->properties[$name]['write'] = false;
@@ -610,7 +605,7 @@ class ModelsCommand extends Command
         if ($type !== null) {
             $newType = $this->getTypeOverride($type);
             if ($nullable) {
-                $newType .='|null';
+                $newType .= '|null';
             }
             $this->properties[$name]['type'] = $newType;
         }
@@ -622,12 +617,12 @@ class ModelsCommand extends Command
         }
     }
 
-    protected function setMethod($name, $type = '', $arguments = array())
+    protected function setMethod($name, $type = '', $arguments = [])
     {
         $methods = array_change_key_case($this->methods, CASE_LOWER);
 
-        if (!isset($methods[strtolower($name)])) {
-            $this->methods[$name] = array();
+        if (! isset($methods[strtolower($name)])) {
+            $this->methods[$name] = [];
             $this->methods[$name]['type'] = $type;
             $this->methods[$name]['arguments'] = $arguments;
         }
@@ -639,7 +634,6 @@ class ModelsCommand extends Command
      */
     protected function createPhpDocs($class)
     {
-
         $reflection = new ReflectionClass($class);
         $namespace = $reflection->getNamespaceName();
         $classname = $reflection->getShortName();
@@ -657,17 +651,17 @@ class ModelsCommand extends Command
             $phpdoc = new DocBlock($reflection, new Context($namespace));
         }
 
-        if (!$phpdoc->getText()) {
+        if (! $phpdoc->getText()) {
             $phpdoc->setText($class);
         }
 
-        $properties = array();
-        $methods = array();
+        $properties = [];
+        $methods = [];
         foreach ($phpdoc->getTags() as $tag) {
             $name = $tag->getName();
-            if ($name == "property" || $name == "property-read" || $name == "property-write") {
+            if ($name == 'property' || $name == 'property-read' || $name == 'property-write') {
                 $properties[] = $tag->getVariableName();
-            } elseif ($name == "method") {
+            } elseif ($name == 'method') {
                 $methods[] = $tag->getMethodName();
             }
         }
@@ -706,13 +700,12 @@ class ModelsCommand extends Command
         }
 
         if ($this->write && ! $phpdoc->getTagsByName('mixin')) {
-            $phpdoc->appendTag(Tag::createInstance("@mixin \\Eloquent", $phpdoc));
+            $phpdoc->appendTag(Tag::createInstance('@mixin \\Eloquent', $phpdoc));
         }
 
         $serializer = new DocBlockSerializer();
         $serializer->getDocComment($phpdoc);
         $docComment = $serializer->getDocComment($phpdoc);
-
 
         if ($this->write) {
             $filename = $reflection->getFileName();
@@ -728,16 +721,17 @@ class ModelsCommand extends Command
                 }
             }
             if ($this->files->put($filename, $contents)) {
-                $this->info('Written new phpDocBlock to ' . $filename);
+                $this->info('Written new phpDocBlock to '.$filename);
             }
         }
 
         $output = "namespace {$namespace}{\n{$docComment}\n\t{$keyword}class {$classname} extends \Eloquent {}\n}\n\n";
+
         return $output;
     }
 
     /**
-     * Get the parameters and format them correctly
+     * Get the parameters and format them correctly.
      *
      * @param $method
      * @return array
@@ -745,12 +739,12 @@ class ModelsCommand extends Command
     public function getParameters($method)
     {
         //Loop through the default values for paremeters, and make the correct output string
-        $params = array();
-        $paramsWithDefault = array();
+        $params = [];
+        $paramsWithDefault = [];
         /** @var \ReflectionParameter $param */
         foreach ($method->getParameters() as $param) {
             $paramClass = $param->getClass();
-            $paramStr = (!is_null($paramClass) ? '\\' . $paramClass->getName() . ' ' : '') . '$' . $param->getName();
+            $paramStr = (null !== $paramClass ? '\\'.$paramClass->getName().' ' : '').'$'.$param->getName();
             $params[] = $paramStr;
             if ($param->isOptional() && $param->isDefaultValueAvailable()) {
                 $default = $param->getDefaultValue();
@@ -758,17 +752,18 @@ class ModelsCommand extends Command
                     $default = $default ? 'true' : 'false';
                 } elseif (is_array($default)) {
                     $default = '[]';
-                } elseif (is_null($default)) {
+                } elseif (null === $default) {
                     $default = 'null';
                 } elseif (is_int($default)) {
                     //$default = $default;
                 } else {
-                    $default = "'" . trim($default) . "'";
+                    $default = "'".trim($default)."'";
                 }
                 $paramStr .= " = $default";
             }
             $paramsWithDefault[] = $paramStr;
         }
+
         return $paramsWithDefault;
     }
 
@@ -783,13 +778,14 @@ class ModelsCommand extends Command
     {
         // Return something in the very very unlikely scenario the model doesn't
         // have a newCollection() method.
-        if (!method_exists($className, 'newCollection')) {
+        if (! method_exists($className, 'newCollection')) {
             return '\Illuminate\Database\Eloquent\Collection';
         }
 
         /** @var \Illuminate\Database\Eloquent\Model $model */
         $model = new $className;
-        return '\\' . get_class($model->newCollection());
+
+        return '\\'.get_class($model->newCollection());
     }
 
     /**
@@ -801,7 +797,7 @@ class ModelsCommand extends Command
     }
 
     /**
-     * Get method return type based on it DocBlock comment
+     * Get method return type based on it DocBlock comment.
      *
      * @param \ReflectionMethod $reflection
      *
@@ -820,7 +816,7 @@ class ModelsCommand extends Command
     }
 
     /**
-     * Generates methods provided by the SoftDeletes trait
+     * Generates methods provided by the SoftDeletes trait.
      * @param \Illuminate\Database\Eloquent\Model $model
      */
     protected function getSoftDeleteMethods($model)
@@ -830,9 +826,9 @@ class ModelsCommand extends Command
             $this->setMethod('forceDelete', 'bool|null', []);
             $this->setMethod('restore', 'bool|null', []);
 
-            $this->setMethod('withTrashed', '\Illuminate\Database\Query\Builder|\\' . get_class($model), []);
-            $this->setMethod('withoutTrashed', '\Illuminate\Database\Query\Builder|\\' . get_class($model), []);
-            $this->setMethod('onlyTrashed', '\Illuminate\Database\Query\Builder|\\' . get_class($model), []);
+            $this->setMethod('withTrashed', '\Illuminate\Database\Query\Builder|\\'.get_class($model), []);
+            $this->setMethod('withoutTrashed', '\Illuminate\Database\Query\Builder|\\'.get_class($model), []);
+            $this->setMethod('onlyTrashed', '\Illuminate\Database\Query\Builder|\\'.get_class($model), []);
         }
     }
 

--- a/src/Eloquent.php
+++ b/src/Eloquent.php
@@ -1,24 +1,25 @@
 <?php
 
 /**
- * Laravel IDE Helper to add \Eloquent mixin to Eloquent\Model
+ * Laravel IDE Helper to add \Eloquent mixin to Eloquent\Model.
  *
  * @author Charles A. Peterson <artistan@gmail.com>
  */
+
 namespace Barryvdh\LaravelIdeHelper;
 
-use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Context;
 use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
 use Barryvdh\Reflection\DocBlock\Tag;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
 
 class Eloquent
 {
     /**
      * Write mixin helper to the Eloquent\Model
-     * This is needed since laravel/framework v5.4.29
+     * This is needed since laravel/framework v5.4.29.
      *
      * @param Command    $command
      * @param Filesystem $files
@@ -29,12 +30,12 @@ class Eloquent
     {
         $class = 'Illuminate\Database\Eloquent\Model';
 
-        $reflection  = new \ReflectionClass($class);
-        $namespace   = $reflection->getNamespaceName();
+        $reflection = new \ReflectionClass($class);
+        $namespace = $reflection->getNamespaceName();
         $originalDoc = $reflection->getDocComment();
 
-        if (!$originalDoc) {
-            $command->info('Unexpected no document on ' . $class);
+        if (! $originalDoc) {
+            $command->info('Unexpected no document on '.$class);
         }
         $phpdoc = new DocBlock($reflection, new Context($namespace));
 
@@ -49,7 +50,7 @@ class Eloquent
             $mixin = $m->getContent();
 
             if (isset($expectedMixins[$mixin])) {
-                $command->info('Tag Exists: @mixin ' . $mixin . ' in ' . $class);
+                $command->info('Tag Exists: @mixin '.$mixin.' in '.$class);
 
                 $expectedMixins[$mixin] = true;
             }
@@ -58,14 +59,14 @@ class Eloquent
         $changed = false;
         foreach ($expectedMixins as $expectedMixin => $present) {
             if ($present === false) {
-                $phpdoc->appendTag(Tag::createInstance('@mixin ' . $expectedMixin, $phpdoc));
+                $phpdoc->appendTag(Tag::createInstance('@mixin '.$expectedMixin, $phpdoc));
 
                 $changed = true;
             }
         }
 
         // If nothing's changed, stop here.
-        if (!$changed) {
+        if (! $changed) {
             return;
         }
 
@@ -77,7 +78,7 @@ class Eloquent
             The new DocBlock is appended to the beginning of the class declaration.
             Since there is no DocBlock, the declaration is used as a guide.
         */
-        if (!$originalDoc) {
+        if (! $originalDoc) {
             $originalDoc = 'abstract class Model implements';
 
             $docComment .= "\nabstract class Model implements";
@@ -87,22 +88,22 @@ class Eloquent
         if ($filename) {
             $contents = $files->get($filename);
             if ($contents) {
-                $count    = 0;
+                $count = 0;
                 $contents = str_replace($originalDoc, $docComment, $contents, $count);
                 if ($count > 0) {
                     if ($files->put($filename, $contents)) {
-                        $command->info('Wrote expected docblock to ' . $filename);
+                        $command->info('Wrote expected docblock to '.$filename);
                     } else {
-                        $command->error('File write failed to ' . $filename);
+                        $command->error('File write failed to '.$filename);
                     }
                 } else {
-                    $command->error('Content did not change ' . $contents);
+                    $command->error('Content did not change '.$contents);
                 }
             } else {
-                $command->error('No file contents found ' . $filename);
+                $command->error('No file contents found '.$filename);
             }
         } else {
-            $command->error('Filename not found ' . $class);
+            $command->error('Filename not found '.$class);
         }
     }
 }

--- a/src/Factories.php
+++ b/src/Factories.php
@@ -8,7 +8,6 @@ use ReflectionClass;
 
 class Factories
 {
-
     public static function all()
     {
         $factories = [];

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Laravel IDE Helper Generator
+ * Laravel IDE Helper Generator.
  *
  * @author    Barry vd. Heuvel <barryvdh@gmail.com>
  * @copyright 2014 Barry vd. Heuvel / Fruitcake Studio (http://www.fruitcakestudio.nl)
@@ -10,8 +10,8 @@
 
 namespace Barryvdh\LaravelIdeHelper;
 
-use Illuminate\Foundation\Application;
 use Illuminate\Foundation\AliasLoader;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Collection;
 use ReflectionClass;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -27,9 +27,9 @@ class Generator
     /** @var \Symfony\Component\Console\Output\OutputInterface */
     protected $output;
 
-    protected $extra = array();
-    protected $magic = array();
-    protected $interfaces = array();
+    protected $extra = [];
+    protected $magic = [];
+    protected $interfaces = [];
     protected $helpers;
 
     /**
@@ -39,8 +39,10 @@ class Generator
      * @param string $helpers
      */
     public function __construct(
-        /*ConfigRepository */ $config,
-        /* Illuminate\View\Factory */ $view,
+        /*ConfigRepository */ 
+        $config,
+        /* Illuminate\View\Factory */ 
+        $view,
         OutputInterface $output = null,
         $helpers = ''
     ) {
@@ -55,13 +57,13 @@ class Generator
         $this->interfaces = array_merge($this->interfaces, $this->config->get('ide-helper.interfaces'));
         // Make all interface classes absolute
         foreach ($this->interfaces as &$interface) {
-            $interface = '\\' . ltrim($interface, '\\');
+            $interface = '\\'.ltrim($interface, '\\');
         }
         $this->helpers = $helpers;
     }
 
     /**
-     * Generate the helper file contents;
+     * Generate the helper file contents;.
      *
      * @param  string  $format  The format to generate the helper in (php/json)
      * @return string;
@@ -80,6 +82,7 @@ class Generator
     public function generatePhpHelper()
     {
         $app = app();
+
         return $this->view->make('helper')
             ->with('namespaces_by_extends_ns', $this->getAliasesByExtendsNamespace())
             ->with('namespaces_by_alias_ns', $this->getAliasesByAliasNamespace())
@@ -92,16 +95,16 @@ class Generator
 
     public function generateJsonHelper()
     {
-        $classes = array();
+        $classes = [];
         foreach ($this->getValidAliases() as $aliases) {
             foreach ($aliases as $alias) {
-                $functions = array();
+                $functions = [];
                 foreach ($alias->getMethods() as $method) {
-                    $functions[$method->getName()] = '('. $method->getParamsWithDefault().')';
+                    $functions[$method->getName()] = '('.$method->getParamsWithDefault().')';
                 }
-                $classes[$alias->getAlias()] = array(
+                $classes[$alias->getAlias()] = [
                     'functions' => $functions,
-                );
+                ];
             }
         }
 
@@ -110,11 +113,11 @@ class Generator
             $flags |= JSON_PRETTY_PRINT;
         }
 
-        return json_encode(array(
-            'php' => array(
+        return json_encode([
+            'php' => [
                 'classes' => $classes,
-            ),
-        ), $flags);
+            ],
+        ], $flags);
     }
 
     protected function detectDrivers()
@@ -134,7 +137,7 @@ class Generator
                         (strpos($versionStr, 'Lumen (5.1') === 0 ? 'driver' : 'guard');
                 }
                 $class = get_class(\Auth::$authMethod());
-                $this->extra['Auth'] = array($class);
+                $this->extra['Auth'] = [$class];
                 $this->interfaces['\Illuminate\Auth\UserProviderInterface'] = $class;
             }
         } catch (\Exception $e) {
@@ -143,7 +146,7 @@ class Generator
         try {
             if (class_exists('DB') && is_a('DB', '\Illuminate\Support\Facades\DB', true)) {
                 $class = get_class(\DB::connection());
-                $this->extra['DB'] = array($class);
+                $this->extra['DB'] = [$class];
                 $this->interfaces['\Illuminate\Database\ConnectionInterface'] = $class;
             }
         } catch (\Exception $e) {
@@ -153,7 +156,7 @@ class Generator
             if (class_exists('Cache') && is_a('Cache', '\Illuminate\Support\Facades\Cache', true)) {
                 $driver = get_class(\Cache::driver());
                 $store = get_class(\Cache::getStore());
-                $this->extra['Cache'] = array($driver, $store);
+                $this->extra['Cache'] = [$driver, $store];
                 $this->interfaces['\Illuminate\Cache\StoreInterface'] = $store;
             }
         } catch (\Exception $e) {
@@ -162,7 +165,7 @@ class Generator
         try {
             if (class_exists('Queue') && is_a('Queue', '\Illuminate\Support\Facades\Queue', true)) {
                 $class = get_class(\Queue::connection());
-                $this->extra['Queue'] = array($class);
+                $this->extra['Queue'] = [$class];
                 $this->interfaces['\Illuminate\Queue\QueueInterface'] = $class;
             }
         } catch (\Exception $e) {
@@ -171,7 +174,7 @@ class Generator
         try {
             if (class_exists('SSH') && is_a('SSH', '\Illuminate\Support\Facades\SSH', true)) {
                 $class = get_class(\SSH::connection());
-                $this->extra['SSH'] = array($class);
+                $this->extra['SSH'] = [$class];
                 $this->interfaces['\Illuminate\Remote\ConnectionInterface'] = $class;
             }
         } catch (\Exception $e) {
@@ -180,7 +183,7 @@ class Generator
         try {
             if (class_exists('Storage') && is_a('Storage', '\Illuminate\Support\Facades\Storage', true)) {
                 $class = get_class(\Storage::disk());
-                $this->extra['Storage'] = array($class);
+                $this->extra['Storage'] = [$class];
                 $this->interfaces['\Illuminate\Contracts\Filesystem\Filesystem'] = $class;
             }
         } catch (\Exception $e) {
@@ -188,7 +191,7 @@ class Generator
     }
 
     /**
-     * Find all aliases that are valid for us to render
+     * Find all aliases that are valid for us to render.
      *
      * @return Collection
      */
@@ -199,11 +202,11 @@ class Generator
         // Get all aliases
         foreach ($this->getAliases() as $name => $facade) {
             // Skip the Redis facade, if not available (otherwise Fatal PHP Error)
-            if ($facade == 'Illuminate\Support\Facades\Redis' && $name == 'Redis' && !class_exists('Predis\Client')) {
+            if ($facade == 'Illuminate\Support\Facades\Redis' && $name == 'Redis' && ! class_exists('Predis\Client')) {
                 continue;
             }
 
-            $magicMethods = array_key_exists($name, $this->magic) ? $this->magic[$name] : array();
+            $magicMethods = array_key_exists($name, $this->magic) ? $this->magic[$name] : [];
             $alias = new Alias($this->config, $name, $facade, $magicMethods, $this->interfaces);
             if ($alias->isValid()) {
                 //Add extra methods, from other classes (magic static calls)
@@ -219,7 +222,7 @@ class Generator
     }
 
     /**
-     * Regroup aliases by namespace of extended classes
+     * Regroup aliases by namespace of extended classes.
      *
      * @return Collection
      */
@@ -231,7 +234,7 @@ class Generator
     }
 
     /**
-     * Regroup aliases by namespace of alias
+     * Regroup aliases by namespace of alias.
      *
      * @return Collection
      */
@@ -250,24 +253,24 @@ class Generator
         }
 
         $facades = [
-          'App' => 'Illuminate\Support\Facades\App',
-          'Auth' => 'Illuminate\Support\Facades\Auth',
-          'Bus' => 'Illuminate\Support\Facades\Bus',
-          'DB' => 'Illuminate\Support\Facades\DB',
-          'Cache' => 'Illuminate\Support\Facades\Cache',
-          'Cookie' => 'Illuminate\Support\Facades\Cookie',
-          'Crypt' => 'Illuminate\Support\Facades\Crypt',
-          'Event' => 'Illuminate\Support\Facades\Event',
-          'Hash' => 'Illuminate\Support\Facades\Hash',
-          'Log' => 'Illuminate\Support\Facades\Log',
-          'Mail' => 'Illuminate\Support\Facades\Mail',
-          'Queue' => 'Illuminate\Support\Facades\Queue',
-          'Request' => 'Illuminate\Support\Facades\Request',
-          'Schema' => 'Illuminate\Support\Facades\Schema',
-          'Session' => 'Illuminate\Support\Facades\Session',
-          'Storage' => 'Illuminate\Support\Facades\Storage',
-          'Validator' => 'Illuminate\Support\Facades\Validator',
-          'Gate' => 'Illuminate\Support\Facades\Gate',
+            'App' => 'Illuminate\Support\Facades\App',
+            'Auth' => 'Illuminate\Support\Facades\Auth',
+            'Bus' => 'Illuminate\Support\Facades\Bus',
+            'DB' => 'Illuminate\Support\Facades\DB',
+            'Cache' => 'Illuminate\Support\Facades\Cache',
+            'Cookie' => 'Illuminate\Support\Facades\Cookie',
+            'Crypt' => 'Illuminate\Support\Facades\Crypt',
+            'Event' => 'Illuminate\Support\Facades\Event',
+            'Hash' => 'Illuminate\Support\Facades\Hash',
+            'Log' => 'Illuminate\Support\Facades\Log',
+            'Mail' => 'Illuminate\Support\Facades\Mail',
+            'Queue' => 'Illuminate\Support\Facades\Queue',
+            'Request' => 'Illuminate\Support\Facades\Request',
+            'Schema' => 'Illuminate\Support\Facades\Schema',
+            'Session' => 'Illuminate\Support\Facades\Session',
+            'Storage' => 'Illuminate\Support\Facades\Storage',
+            'Validator' => 'Illuminate\Support\Facades\Validator',
+            'Gate' => 'Illuminate\Support\Facades\Gate',
         ];
 
         $facades = array_merge($facades, $this->config->get('app.aliases', []));
@@ -283,7 +286,7 @@ class Generator
     }
 
     /**
-     * Get the driver/connection/store from the managers
+     * Get the driver/connection/store from the managers.
      *
      * @param $alias
      * @return array|bool|string
@@ -291,15 +294,16 @@ class Generator
     public function getDriver($alias)
     {
         try {
-            if ($alias == "Auth") {
+            if ($alias == 'Auth') {
                 $driver = \Auth::driver();
-            } elseif ($alias == "DB") {
+            } elseif ($alias == 'DB') {
                 $driver = \DB::connection();
-            } elseif ($alias == "Cache") {
+            } elseif ($alias == 'Cache') {
                 $driver = get_class(\Cache::driver());
                 $store = get_class(\Cache::getStore());
-                return array($driver, $store);
-            } elseif ($alias == "Queue") {
+
+                return [$driver, $store];
+            } elseif ($alias == 'Queue') {
                 $driver = \Queue::connection();
             } else {
                 return false;
@@ -308,6 +312,7 @@ class Generator
             return get_class($driver);
         } catch (\Exception $e) {
             $this->error("Could not determine driver/connection for $alias.");
+
             return false;
         }
     }
@@ -323,7 +328,7 @@ class Generator
         if ($this->output) {
             $this->output->writeln("<error>$string</error>");
         } else {
-            echo $string . "\r\n";
+            echo $string."\r\n";
         }
     }
 }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -39,9 +39,7 @@ class Generator
      * @param string $helpers
      */
     public function __construct(
-        /*ConfigRepository */ 
         $config,
-        /* Illuminate\View\Factory */ 
         $view,
         OutputInterface $output = null,
         $helpers = ''

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Laravel IDE Helper Generator
+ * Laravel IDE Helper Generator.
  *
  * @author    Barry vd. Heuvel <barryvdh@gmail.com>
  * @copyright 2014 Barry vd. Heuvel / Fruitcake Studio (http://www.fruitcakestudio.nl)
@@ -22,7 +22,6 @@ use Illuminate\View\FileViewFinder;
 
 class IdeHelperServiceProvider extends ServiceProvider
 {
-
     /**
      * Indicates if loading of the provider is deferred.
      *
@@ -38,11 +37,11 @@ class IdeHelperServiceProvider extends ServiceProvider
     public function boot()
     {
         if ($this->app->has('view')) {
-            $viewPath = __DIR__ . '/../resources/views';
+            $viewPath = __DIR__.'/../resources/views';
             $this->loadViewsFrom($viewPath, 'ide-helper');
         }
 
-        $configPath = __DIR__ . '/../config/ide-helper.php';
+        $configPath = __DIR__.'/../config/ide-helper.php';
         if (function_exists('config_path')) {
             $publishPath = config_path('ide-helper.php');
         } else {
@@ -58,7 +57,7 @@ class IdeHelperServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $configPath = __DIR__ . '/../config/ide-helper.php';
+        $configPath = __DIR__.'/../config/ide-helper.php';
         $this->mergeConfigFrom($configPath, 'ide-helper');
         $localViewFactory = $this->createLocalViewFactory();
 
@@ -105,7 +104,7 @@ class IdeHelperServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return array('command.ide-helper.generate', 'command.ide-helper.models');
+        return ['command.ide-helper.generate', 'command.ide-helper.models'];
     }
 
     /**
@@ -117,7 +116,7 @@ class IdeHelperServiceProvider extends ServiceProvider
         $resolver->register('php', function () {
             return new PhpEngine();
         });
-        $finder = new FileViewFinder($this->app['files'], [__DIR__ . '/../resources/views']);
+        $finder = new FileViewFinder($this->app['files'], [__DIR__.'/../resources/views']);
         $factory = new Factory($resolver, $finder, $this->app['events']);
         $factory->addExtension('php', 'php');
 

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -3,7 +3,6 @@
 namespace Barryvdh\LaravelIdeHelper;
 
 use Barryvdh\Reflection\DocBlock;
-use Barryvdh\Reflection\DocBlock\Tag;
 
 class Macro extends Method
 {
@@ -21,7 +20,7 @@ class Macro extends Method
         $alias,
         $class,
         $methodName = null,
-        $interfaces = array()
+        $interfaces = []
     ) {
         parent::__construct($method, $alias, $class, $methodName, $interfaces);
     }
@@ -41,6 +40,6 @@ class Macro extends Method
     protected function initClassDefinedProperties($method, \ReflectionClass $class)
     {
         $this->namespace = $class->getNamespaceName();
-        $this->declaringClassName = '\\' . ltrim($class->name, '\\');
+        $this->declaringClassName = '\\'.ltrim($class->name, '\\');
     }
 }

--- a/src/Method.php
+++ b/src/Method.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Laravel IDE Helper Generator
+ * Laravel IDE Helper Generator.
  *
  * @author    Barry vd. Heuvel <barryvdh@gmail.com>
  * @copyright 2014 Barry vd. Heuvel / Fruitcake Studio (http://www.fruitcakestudio.nl)
@@ -12,26 +12,26 @@ namespace Barryvdh\LaravelIdeHelper;
 
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Context;
-use Barryvdh\Reflection\DocBlock\Tag;
-use Barryvdh\Reflection\DocBlock\Tag\ReturnTag;
-use Barryvdh\Reflection\DocBlock\Tag\ParamTag;
 use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
+use Barryvdh\Reflection\DocBlock\Tag;
+use Barryvdh\Reflection\DocBlock\Tag\ParamTag;
+use Barryvdh\Reflection\DocBlock\Tag\ReturnTag;
 
 class Method
 {
-    /** @var \Barryvdh\Reflection\DocBlock  */
+    /** @var \Barryvdh\Reflection\DocBlock */
     protected $phpdoc;
 
-    /** @var \ReflectionMethod  */
+    /** @var \ReflectionMethod */
     protected $method;
 
     protected $output = '';
     protected $declaringClassName;
     protected $name;
     protected $namespace;
-    protected $params = array();
-    protected $params_with_default = array();
-    protected $interfaces = array();
+    protected $params = [];
+    protected $params_with_default = [];
+    protected $interfaces = [];
     protected $real_name;
     protected $return = null;
     protected $root;
@@ -43,7 +43,7 @@ class Method
      * @param string|null $methodName
      * @param array $interfaces
      */
-    public function __construct($method, $alias, $class, $methodName = null, $interfaces = array())
+    public function __construct($method, $alias, $class, $methodName = null, $interfaces = [])
     {
         $this->method = $method;
         $this->interfaces = $interfaces;
@@ -52,7 +52,7 @@ class Method
         $this->initClassDefinedProperties($method, $class);
 
         //Reference the 'real' function in the declaring class
-        $this->root = '\\' . ltrim($class->getName(), '\\');
+        $this->root = '\\'.ltrim($class->getName(), '\\');
 
         //Create a DocBlock and serializer instance
         $this->initPhpDoc($method);
@@ -88,11 +88,11 @@ class Method
     {
         $declaringClass = $method->getDeclaringClass();
         $this->namespace = $declaringClass->getNamespaceName();
-        $this->declaringClassName = '\\' . ltrim($declaringClass->name, '\\');
+        $this->declaringClassName = '\\'.ltrim($declaringClass->name, '\\');
     }
 
     /**
-     * Get the class wherein the function resides
+     * Get the class wherein the function resides.
      *
      * @return string
      */
@@ -102,7 +102,7 @@ class Method
     }
 
     /**
-     * Return the class from which this function would be called
+     * Return the class from which this function would be called.
      *
      * @return string
      */
@@ -132,7 +132,7 @@ class Method
     }
 
     /**
-     * Get the docblock for this method
+     * Get the docblock for this method.
      *
      * @param string $prefix
      * @return mixed
@@ -140,11 +140,12 @@ class Method
     public function getDocComment($prefix = "\t\t")
     {
         $serializer = new DocBlockSerializer(1, $prefix);
+
         return $serializer->getDocComment($this->phpdoc);
     }
 
     /**
-     * Get the method name
+     * Get the method name.
      *
      * @return string
      */
@@ -154,7 +155,7 @@ class Method
     }
 
     /**
-     * Get the real method name
+     * Get the real method name.
      *
      * @return string
      */
@@ -164,7 +165,7 @@ class Method
     }
 
     /**
-     * Get the parameters for this method
+     * Get the parameters for this method.
      *
      * @param bool $implode Wether to implode the array or not
      * @return string
@@ -175,7 +176,7 @@ class Method
     }
 
     /**
-     * Get the parameters for this method including default values
+     * Get the parameters for this method including default values.
      *
      * @param bool $implode Wether to implode the array or not
      * @return string
@@ -219,7 +220,7 @@ class Method
     }
 
     /**
-     * Normalize the parameters
+     * Normalize the parameters.
      *
      * @param DocBlock $phpdoc
      */
@@ -235,14 +236,14 @@ class Method
                 $tag->setContent($content);
 
                 // Get the expanded type and re-set the content
-                $content = $tag->getType() . ' ' . $tag->getVariableName() . ' ' . $tag->getDescription();
+                $content = $tag->getType().' '.$tag->getVariableName().' '.$tag->getDescription();
                 $tag->setContent(trim($content));
             }
         }
     }
 
     /**
-     * Normalize the return tag (make full namespace, replace interfaces)
+     * Normalize the return tag (make full namespace, replace interfaces).
      *
      * @param DocBlock $phpdoc
      */
@@ -262,7 +263,7 @@ class Method
             }
 
             // Set the changed content
-            $tag->setContent($returnValue . ' ' . $tag->getDescription());
+            $tag->setContent($returnValue.' '.$tag->getDescription());
             $this->return = $returnValue;
 
             if ($tag->getType() === '$this') {
@@ -295,7 +296,7 @@ class Method
      */
     public function shouldReturn()
     {
-        if ($this->return !== "void" && $this->method->name !== "__construct") {
+        if ($this->return !== 'void' && $this->method->name !== '__construct') {
             return true;
         }
 
@@ -303,7 +304,7 @@ class Method
     }
 
     /**
-     * Get the parameters and format them correctly
+     * Get the parameters and format them correctly.
      *
      * @param  \ReflectionMethod $method
      * @return array
@@ -311,25 +312,25 @@ class Method
     public function getParameters($method)
     {
         //Loop through the default values for paremeters, and make the correct output string
-        $params = array();
-        $paramsWithDefault = array();
+        $params = [];
+        $paramsWithDefault = [];
         foreach ($method->getParameters() as $param) {
-            $paramStr = $param->isVariadic() ? '...$' . $param->getName() : '$' . $param->getName();
+            $paramStr = $param->isVariadic() ? '...$'.$param->getName() : '$'.$param->getName();
             $params[] = $paramStr;
-            if ($param->isOptional() && !$param->isVariadic()) {
+            if ($param->isOptional() && ! $param->isVariadic()) {
                 $default = $param->isDefaultValueAvailable() ? $param->getDefaultValue() : null;
                 if (is_bool($default)) {
                     $default = $default ? 'true' : 'false';
                 } elseif (is_array($default)) {
                     $default = '[]';
-                } elseif (is_null($default)) {
+                } elseif (null === $default) {
                     $default = 'null';
                 } elseif (is_int($default)) {
                     //$default = $default;
                 } elseif (is_resource($default)) {
                     //skip to not fail
                 } else {
-                    $default = "'" . trim($default) . "'";
+                    $default = "'".trim($default)."'";
                 }
                 $paramStr .= " = $default";
             }
@@ -357,7 +358,7 @@ class Method
         if ($method) {
             $namespace = $method->getDeclaringClass()->getNamespaceName();
             $phpdoc = new DocBlock($method, new Context($namespace));
-            
+
             if (strpos($phpdoc->getText(), '{@inheritdoc}') !== false) {
                 //Not at the end yet, try another parent/interface..
                 return $this->getInheritDoc($method);

--- a/tests/Console/ModelsCommand/AbstractModelsCommand.php
+++ b/tests/Console/ModelsCommand/AbstractModelsCommand.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand;
 
@@ -14,10 +16,11 @@ abstract class AbstractModelsCommand extends TestCase
         // Skip older Laravel version for these tests
         if (version_compare(Application::VERSION, '6.0', '<')) {
             $this->markTestSkipped('This test requires Laravel 6.0 or higher');
+
             return;
         }
 
-        $this->loadMigrationsFrom(__DIR__ . '/migrations');
+        $this->loadMigrationsFrom(__DIR__.'/migrations');
         $this->artisan('migrate');
     }
 

--- a/tests/Console/ModelsCommand/CustomDate/Models/CustomDate.php
+++ b/tests/Console/ModelsCommand/CustomDate/Models/CustomDate.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomDate\Models;
 

--- a/tests/Console/ModelsCommand/CustomDate/Test.php
+++ b/tests/Console/ModelsCommand/CustomDate/Test.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomDate;
 
@@ -45,7 +47,7 @@ class Test extends AbstractModelsCommand
         $mockFilesystem = Mockery::mock(Filesystem::class);
         $mockFilesystem
             ->shouldReceive('get')
-            ->andReturn(file_get_contents(__DIR__ . '/Models/CustomDate.php'))
+            ->andReturn(file_get_contents(__DIR__.'/Models/CustomDate.php'))
             ->once();
         $mockFilesystem
             ->shouldReceive('put')

--- a/tests/Console/ModelsCommand/CustomDate/Test.php
+++ b/tests/Console/ModelsCommand/CustomDate/Test.php
@@ -70,7 +70,9 @@ class Test extends AbstractModelsCommand
         $this->assertEmpty($tester->getDisplay());
 
         $expectedContent = <<<'PHP'
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomDate\Models;
 

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdoc/Models/Post.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdoc/Models/Post.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhpdoc\Models;
 

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdoc/Test.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdoc/Test.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhpdoc;
 
@@ -28,7 +30,7 @@ class Test extends AbstractModelsCommand
         $mockFilesystem = Mockery::mock(Filesystem::class);
         $mockFilesystem
             ->shouldReceive('get')
-            ->andReturn(file_get_contents(__DIR__ . '/Models/Post.php'))
+            ->andReturn(file_get_contents(__DIR__.'/Models/Post.php'))
             ->once();
         $mockFilesystem
             ->shouldReceive('put')

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdoc/Test.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdoc/Test.php
@@ -53,7 +53,9 @@ class Test extends AbstractModelsCommand
         $this->assertEmpty($tester->getDisplay());
 
         $expectedContent = <<<'PHP'
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhpdoc\Models;
 

--- a/tests/Console/ModelsCommand/Getter/Models/Simple.php
+++ b/tests/Console/ModelsCommand/Getter/Models/Simple.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Getter\Models;
 

--- a/tests/Console/ModelsCommand/Getter/Test.php
+++ b/tests/Console/ModelsCommand/Getter/Test.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Getter;
 
@@ -28,7 +30,7 @@ class Test extends AbstractModelsCommand
         $mockFilesystem = Mockery::mock(Filesystem::class);
         $mockFilesystem
             ->shouldReceive('get')
-            ->andReturn(file_get_contents(__DIR__ . '/Models/Simple.php'))
+            ->andReturn(file_get_contents(__DIR__.'/Models/Simple.php'))
             ->once();
         $mockFilesystem
             ->shouldReceive('put')

--- a/tests/Console/ModelsCommand/Getter/Test.php
+++ b/tests/Console/ModelsCommand/Getter/Test.php
@@ -53,7 +53,9 @@ class Test extends AbstractModelsCommand
         $this->assertEmpty($tester->getDisplay());
 
         $expectedContent = <<<'PHP'
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Getter\Models;
 

--- a/tests/Console/ModelsCommand/Relations/Models/Simple.php
+++ b/tests/Console/ModelsCommand/Relations/Models/Simple.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models;
 
@@ -18,22 +20,22 @@ class Simple extends Model
     // Regular relations
     public function relationHasMany(): HasMany
     {
-        return $this->hasMany(Simple::class);
+        return $this->hasMany(self::class);
     }
 
     public function relationHasOne(): HasOne
     {
-        return $this->hasOne(Simple::class);
+        return $this->hasOne(self::class);
     }
 
     public function relationBelongsTo(): BelongsTo
     {
-        return $this->belongsTo(Simple::class);
+        return $this->belongsTo(self::class);
     }
 
     public function relationBelongsToMany(): BelongsToMany
     {
-        return $this->belongsToMany(Simple::class);
+        return $this->belongsToMany(self::class);
     }
 
     public function relationMorphTo(): MorphTo
@@ -43,17 +45,17 @@ class Simple extends Model
 
     public function relationMorphOne(): MorphOne
     {
-        return $this->morphOne(Simple::class, 'relationMorphTo');
+        return $this->morphOne(self::class, 'relationMorphTo');
     }
 
     public function relationMorphMany(): MorphMany
     {
-        return $this->morphMany(Simple::class, 'relationMorphTo');
+        return $this->morphMany(self::class, 'relationMorphTo');
     }
 
     public function relationMorphedByMany(): MorphToMany
     {
-        return $this->morphedByMany(Simple::class, 'foo');
+        return $this->morphedByMany(self::class, 'foo');
     }
 
     // Custom relations

--- a/tests/Console/ModelsCommand/Relations/ModelsOtherNamespace/AnotherModel.php
+++ b/tests/Console/ModelsCommand/Relations/ModelsOtherNamespace/AnotherModel.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\ModelsOtherNamespace;
 

--- a/tests/Console/ModelsCommand/Relations/Test.php
+++ b/tests/Console/ModelsCommand/Relations/Test.php
@@ -53,7 +53,9 @@ class Test extends AbstractModelsCommand
         $this->assertEmpty($tester->getDisplay());
 
         $expectedContent = <<<'PHP'
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models;
 
@@ -97,22 +99,22 @@ class Simple extends Model
     // Regular relations
     public function relationHasMany(): HasMany
     {
-        return $this->hasMany(Simple::class);
+        return $this->hasMany(self::class);
     }
 
     public function relationHasOne(): HasOne
     {
-        return $this->hasOne(Simple::class);
+        return $this->hasOne(self::class);
     }
 
     public function relationBelongsTo(): BelongsTo
     {
-        return $this->belongsTo(Simple::class);
+        return $this->belongsTo(self::class);
     }
 
     public function relationBelongsToMany(): BelongsToMany
     {
-        return $this->belongsToMany(Simple::class);
+        return $this->belongsToMany(self::class);
     }
 
     public function relationMorphTo(): MorphTo
@@ -122,17 +124,17 @@ class Simple extends Model
 
     public function relationMorphOne(): MorphOne
     {
-        return $this->morphOne(Simple::class, 'relationMorphTo');
+        return $this->morphOne(self::class, 'relationMorphTo');
     }
 
     public function relationMorphMany(): MorphMany
     {
-        return $this->morphMany(Simple::class, 'relationMorphTo');
+        return $this->morphMany(self::class, 'relationMorphTo');
     }
 
     public function relationMorphedByMany(): MorphToMany
     {
-        return $this->morphedByMany(Simple::class, 'foo');
+        return $this->morphedByMany(self::class, 'foo');
     }
 
     // Custom relations

--- a/tests/Console/ModelsCommand/Relations/Test.php
+++ b/tests/Console/ModelsCommand/Relations/Test.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations;
 
@@ -28,7 +30,7 @@ class Test extends AbstractModelsCommand
         $mockFilesystem = Mockery::mock(Filesystem::class);
         $mockFilesystem
             ->shouldReceive('get')
-            ->andReturn(file_get_contents(__DIR__ . '/Models/Simple.php'))
+            ->andReturn(file_get_contents(__DIR__.'/Models/Simple.php'))
             ->once();
         $mockFilesystem
             ->shouldReceive('put')

--- a/tests/Console/ModelsCommand/ResetAndSmartReset/Models/Simple.php
+++ b/tests/Console/ModelsCommand/ResetAndSmartReset/Models/Simple.php
@@ -1,11 +1,13 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Text of existing phpdoc
+ * Text of existing phpdoc.
  *
  * @property string $foo
  */

--- a/tests/Console/ModelsCommand/ResetAndSmartReset/Test.php
+++ b/tests/Console/ModelsCommand/ResetAndSmartReset/Test.php
@@ -61,9 +61,11 @@ use Illuminate\Database\Eloquent\Model;
  * Text of existing phpdoc
  *
  * @property string $foo
+ * @property integer $id
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple query()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple whereId($value)
  * @mixin \Eloquent
  */
 class Simple extends Model
@@ -114,9 +116,11 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple
  *
+ * @property integer $id
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple query()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple whereId($value)
  * @mixin \Eloquent
  */
 class Simple extends Model
@@ -167,9 +171,11 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Text of existing phpdoc
  *
+ * @property integer $id
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple query()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple whereId($value)
  * @mixin \Eloquent
  */
 class Simple extends Model

--- a/tests/Console/ModelsCommand/ResetAndSmartReset/Test.php
+++ b/tests/Console/ModelsCommand/ResetAndSmartReset/Test.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset;
 
@@ -28,7 +30,7 @@ class Test extends AbstractModelsCommand
         $mockFilesystem = Mockery::mock(Filesystem::class);
         $mockFilesystem
             ->shouldReceive('get')
-            ->andReturn(file_get_contents(__DIR__ . '/Models/Simple.php'))
+            ->andReturn(file_get_contents(__DIR__.'/Models/Simple.php'))
             ->once();
         $mockFilesystem
             ->shouldReceive('put')
@@ -83,7 +85,7 @@ PHP;
         $mockFilesystem = Mockery::mock(Filesystem::class);
         $mockFilesystem
             ->shouldReceive('get')
-            ->andReturn(file_get_contents(__DIR__ . '/Models/Simple.php'))
+            ->andReturn(file_get_contents(__DIR__.'/Models/Simple.php'))
             ->once();
         $mockFilesystem
             ->shouldReceive('put')
@@ -138,7 +140,7 @@ PHP;
         $mockFilesystem = Mockery::mock(Filesystem::class);
         $mockFilesystem
             ->shouldReceive('get')
-            ->andReturn(file_get_contents(__DIR__ . '/Models/Simple.php'))
+            ->andReturn(file_get_contents(__DIR__.'/Models/Simple.php'))
             ->once();
         $mockFilesystem
             ->shouldReceive('put')

--- a/tests/Console/ModelsCommand/ResetAndSmartReset/Test.php
+++ b/tests/Console/ModelsCommand/ResetAndSmartReset/Test.php
@@ -53,14 +53,16 @@ class Test extends AbstractModelsCommand
         $this->assertEmpty($tester->getDisplay());
 
         $expectedContent = <<<'PHP'
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Text of existing phpdoc
+ * Text of existing phpdoc.
  *
  * @property string $foo
  * @property integer $id
@@ -109,7 +111,9 @@ PHP;
         $this->assertEmpty($tester->getDisplay());
 
         $expectedContent = <<<'PHP'
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models;
 
@@ -164,14 +168,16 @@ PHP;
         $this->assertEmpty($tester->getDisplay());
 
         $expectedContent = <<<'PHP'
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Text of existing phpdoc
+ * Text of existing phpdoc.
  *
  * @property integer $id
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple newModelQuery()

--- a/tests/Console/ModelsCommand/SoftDeletes/Models/Simple.php
+++ b/tests/Console/ModelsCommand/SoftDeletes/Models/Simple.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SoftDeletes\Models;
 

--- a/tests/Console/ModelsCommand/SoftDeletes/Test.php
+++ b/tests/Console/ModelsCommand/SoftDeletes/Test.php
@@ -53,7 +53,9 @@ class Test extends AbstractModelsCommand
         $this->assertEmpty($tester->getDisplay());
 
         $expectedContent = <<<'PHP'
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SoftDeletes\Models;
 

--- a/tests/Console/ModelsCommand/SoftDeletes/Test.php
+++ b/tests/Console/ModelsCommand/SoftDeletes/Test.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SoftDeletes;
 
@@ -28,7 +30,7 @@ class Test extends AbstractModelsCommand
         $mockFilesystem = Mockery::mock(Filesystem::class);
         $mockFilesystem
             ->shouldReceive('get')
-            ->andReturn(file_get_contents(__DIR__ . '/Models/Simple.php'))
+            ->andReturn(file_get_contents(__DIR__.'/Models/Simple.php'))
             ->once();
         $mockFilesystem
             ->shouldReceive('put')

--- a/tests/Console/ModelsCommand/migrations/____custom_dates_table.php
+++ b/tests/Console/ModelsCommand/migrations/____custom_dates_table.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/tests/Console/ModelsCommand/migrations/____posts_table.php
+++ b/tests/Console/ModelsCommand/migrations/____posts_table.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
@@ -10,7 +12,7 @@ class PostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
-            
+
             $table->char('char_nullable')->nullable();
             $table->char('char_not_nullable');
 

--- a/tests/Console/ModelsCommand/migrations/____simple_table.php
+++ b/tests/Console/ModelsCommand/migrations/____simple_table.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 class ExampleTest extends TestCase
 {
     /**
-     * Test that we can actually instantiate the class
+     * Test that we can actually instantiate the class.
      */
     public function testCanInstantiate()
     {
@@ -21,7 +21,7 @@ class ExampleTest extends TestCase
     }
 
     /**
-     * Test the output of a class
+     * Test the output of a class.
      */
     public function testOutput()
     {
@@ -58,6 +58,5 @@ class ExampleClass
      */
     public function setName($last, $first = 'Barry', ...$middle)
     {
-        return;
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests;
 


### PR DESCRIPTION
## Intro
The initial idea was to simply ensure to automate (and keep it consistent) with the short array syntax => https://github.com/barryvdh/laravel-ide-helper/pull/493#issuecomment-570712736
> sure

The more I looked at it, it become clear that the general code style wasn't really coherent.

I've used https://github.com/matt-allan/laravel-code-style in the past, basically just a pre-set of php-cs-fixer config settings, most suitable for Laravel related packages.

Thus, this PR switched over to php-cs-fixer and uses that config with some "useful additions".

Since this PR could not be green _without actually including the style fixes_, the final diff of course 'sploded 💥 

[I therefore suggest to rather focus on the diff except the last 3 commits first](https://github.com/barryvdh/laravel-ide-helper/compare/9e567d538875ad87ab96b8dba9d8af6fc8e20dcd%E2%80%A6e09211e6d22dd6390fc7a25e9d7f07b6dd497ddc)

## Summary
- Replace phpcs (PHP_CodeSniffer) with php-cs-fixer and use https://github.com/matt-allan/laravel-code-style with some more config options
  - Still integrated into grumphp
- Run it on github actions instead of travis
- Fixed the whole codebase and adapted tests

I left some in-line comments to raise some eyes on selected parts.