### PR TITLE
Fixed bug in model command where loose string comparison would override properties for model relations

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -503,7 +503,7 @@ class ModelsCommand extends Command
                                'morphedByMany' => '\Illuminate\Database\Eloquent\Relations\MorphToMany'
                              ) as $relation => $impl) {
                         $search = '$this->' . $relation . '(';
-                        if (stripos($code, $search) || stripos($impl, (string)$type) !== false) {
+                        if (stripos($code, $search) || $impl === (string)$type) {
                             //Resolve the relation's model to a Relation object.
                             $methodReflection = new \ReflectionMethod($model, $method);
                             if ($methodReflection->getNumberOfParameters()) {

--- a/tests/Console/ModelsCommand/Relations/Test.php
+++ b/tests/Console/ModelsCommand/Relations/Test.php
@@ -79,7 +79,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  * @property-read \Illuminate\Database\Eloquent\Collection|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple[] $relationMorphMany
  * @property-read int|null $relation_morph_many_count
  * @property-read \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple $relationMorphOne
- * @property-read \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple $relationMorphTo
+ * @property-read \Illuminate\Database\Eloquent\Model|\Eloquent $relationMorphTo
  * @property-read \Illuminate\Database\Eloquent\Collection|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple[] $relationMorphedByMany
  * @property-read int|null $relation_morphed_by_many_count
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple newModelQuery()


### PR DESCRIPTION
This is the same as https://github.com/barryvdh/laravel-ide-helper/pull/804 **without** the refactoring (and adapting the tests).

I don't thin that refactoring so many lines in contrast for a single line change makes sense and could be the reason this wasn't merged already.

Note: I cherry-picked the original commit, which means @markokeeffe as the author **is kept**.