### PR TITLE
Prevent undefined property errors

### DIFF
--- a/tests/Console/ModelsCommand/Relations/Models/Simple.php
+++ b/tests/Console/ModelsCommand/Relations/Models/Simple.php
@@ -62,4 +62,9 @@ class Simple extends Model
     {
         return $this->belongsTo(AnotherModel::class);
     }
+
+    public function relationBelongsToSameNameAsColumn(): BelongsTo
+    {
+        return $this->belongsTo(AnotherModel::class, __FUNCTION__);
+    }
 }

--- a/tests/Console/ModelsCommand/Relations/Test.php
+++ b/tests/Console/ModelsCommand/Relations/Test.php
@@ -73,6 +73,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  * @property-read \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\ModelsOtherNamespace\AnotherModel $relationBelongsToInAnotherNamespace
  * @property-read \Illuminate\Database\Eloquent\Collection|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple[] $relationBelongsToMany
  * @property-read int|null $relation_belongs_to_many_count
+ * @property-read \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\ModelsOtherNamespace\AnotherModel $relationBelongsToSameNameAsColumn
  * @property-read \Illuminate\Database\Eloquent\Collection|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple[] $relationHasMany
  * @property-read int|null $relation_has_many_count
  * @property-read \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple $relationHasOne
@@ -135,6 +136,11 @@ class Simple extends Model
     public function relationBelongsToInAnotherNamespace(): BelongsTo
     {
         return $this->belongsTo(AnotherModel::class);
+    }
+
+    public function relationBelongsToSameNameAsColumn(): BelongsTo
+    {
+        return $this->belongsTo(AnotherModel::class, __FUNCTION__);
     }
 }
 


### PR DESCRIPTION
If the property name matches the foreign key name creating a BelongsTo relation triggers an undefined property error. Disabling constraints prevents accessing the property and thus prevents the error.

This is a workaround for an issue in Laravel that may or may not be fixed (see https://github.com/laravel/framework/issues/31098). However since we don't actually need the constraints it seems worth disabling them to prevent the underlying issue from surfacing?

Resolves #484.