### PR TITLE
change: typehint the collection type

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -531,10 +531,10 @@ class ModelsCommand extends Command
                                     'morphedByMany',
                                 ];
                                 if (strpos(get_class($relationObj), 'Many') !== false) {
-                                    //Collection or array of models (because Collection is Arrayable)
+                                    //Collection of type model
                                     $this->setProperty(
                                         $method,
-                                        $this->getCollectionClass($relatedModel) . '|' . $relatedModel . '[]',
+                                        $this->getCollectionClass($relatedModel) . '<' . $relatedModel  . '>',
                                         true,
                                         null
                                     );

--- a/tests/Console/ModelsCommand/Relations/Test.php
+++ b/tests/Console/ModelsCommand/Relations/Test.php
@@ -72,17 +72,17 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  * @property integer $id
  * @property-read \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple $relationBelongsTo
  * @property-read \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\ModelsOtherNamespace\AnotherModel $relationBelongsToInAnotherNamespace
- * @property-read \Illuminate\Database\Eloquent\Collection|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple[] $relationBelongsToMany
+ * @property-read \Illuminate\Database\Eloquent\Collection<\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple> $relationBelongsToMany
  * @property-read int|null $relation_belongs_to_many_count
  * @property-read \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\ModelsOtherNamespace\AnotherModel $relationBelongsToSameNameAsColumn
- * @property-read \Illuminate\Database\Eloquent\Collection|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple[] $relationHasMany
+ * @property-read \Illuminate\Database\Eloquent\Collection<\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple> $relationHasMany
  * @property-read int|null $relation_has_many_count
  * @property-read \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple $relationHasOne
- * @property-read \Illuminate\Database\Eloquent\Collection|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple[] $relationMorphMany
+ * @property-read \Illuminate\Database\Eloquent\Collection<\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple> $relationMorphMany
  * @property-read int|null $relation_morph_many_count
  * @property-read \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple $relationMorphOne
  * @property-read \Illuminate\Database\Eloquent\Model|\Eloquent $relationMorphTo
- * @property-read \Illuminate\Database\Eloquent\Collection|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple[] $relationMorphedByMany
+ * @property-read \Illuminate\Database\Eloquent\Collection<\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple> $relationMorphedByMany
  * @property-read int|null $relation_morphed_by_many_count
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple newQuery()


### PR DESCRIPTION
Now that phpstorm has support for generics, we can typehint that the collection returned will be of type model, rather than returning a generic collection|model[]

This should be very helpful for https://github.com/nunomaduro/larastan