### PR TITLE
isRelationForeignKeyNullable: private -> protected

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -578,7 +578,7 @@ class ModelsCommand extends Command
      *
      * @return bool
      */
-    private function isRelationForeignKeyNullable(Relation $relation)
+    protected function isRelationForeignKeyNullable(Relation $relation)
     {
         $reflectionObj = new \ReflectionObject($relation);
         if (!$reflectionObj->hasProperty('foreignKey')) {


### PR DESCRIPTION
# Overview

We can support [topclaudy/compoships](https://github.com/topclaudy/compoships) by overriding `isRelationForeignKeyNullable()`.

CC: @topclaudy @barryvdh @MartinP7r @sptdigital @isclopezm @mpash @aaronflorey @burut13 @deare

## Before 

We need to override three methods.
  
- **`protected function getPropertiesFromMethods()`** (So huge method)
- `private function getCollectionClass()`
- `private function isRelationForeignKeyNullable()`

## After

We need to override only one method.

- `protected function isRelationForeignKeyNullable()`

```php
<?php

namespace App\Console\Commands\IdeHelper;

use Barryvdh\LaravelIdeHelper\Console\ModelsCommand as BaseModelsCommand;
use Illuminate\Support\Arr;
use Illuminate\Database\Eloquent\Relations\Relation;

class ModelsCommand extends BaseModelsCommand
{
    protected function isRelationForeignKeyNullable(Relation $relation)
    {
        $reflectionObj = new \ReflectionObject($relation);
        if (!$reflectionObj->hasProperty('foreignKey')) {
            return false;
        }
        $fkProp = $reflectionObj->getProperty('foreignKey');
        $fkProp->setAccessible(true);

        return (bool)Arr::first((array)$fkProp->getValue($relation), function (string $value) {
            return isset($this->nullableColumns[$value]);
        });
    }
}
```

# Related Issues

- [error when using composite key package · Issue #838 · barryvdh/laravel-ide-helper](https://github.com/barryvdh/laravel-ide-helper/issues/838)
- [Support for composite primary keys · Issue #706 · barryvdh/laravel-ide-helper](https://github.com/barryvdh/laravel-ide-helper/issues/706)