### PR TITLE
Prevent generation of invalid code for certain parameter default values

### DIFF
--- a/src/Method.php
+++ b/src/Method.php
@@ -329,7 +329,7 @@ class Method
                 } elseif (is_resource($default)) {
                     //skip to not fail
                 } else {
-                    $default = "'" . trim($default) . "'";
+                    $default = var_export($default, true);
                 }
                 $paramStr .= " = $default";
             }

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -49,9 +49,9 @@ class ExampleTest extends TestCase
     }
 
     /**
-     * Test special characters in method
+     * Test special characters in methods default values
      */
-    public function testSpecialChars()
+    public function testDefaultSpecialChars()
     {
         $reflectionClass = new \ReflectionClass(ExampleClass::class);
         $reflectionMethod = $reflectionClass->getMethod('setSpecialChars');

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -47,6 +47,21 @@ class ExampleTest extends TestCase
         $this->assertEquals(['$last', '$first = \'Barry\'', '...$middle'], $method->getParamsWithDefault(false));
         $this->assertEquals(true, $method->shouldReturn());
     }
+
+    /**
+     * Test special characters in method
+     */
+    public function testSpecialChars()
+    {
+        $reflectionClass = new \ReflectionClass(ExampleClass::class);
+        $reflectionMethod = $reflectionClass->getMethod('setSpecialChars');
+
+        $method = new Method($reflectionMethod, 'Example', $reflectionClass);
+        $this->assertEquals('$chars', $method->getParams(true));
+        $this->assertEquals(['$chars'], $method->getParams(false));
+        $this->assertEquals('$chars = \'$\\\'\\\\\'', $method->getParamsWithDefault(true));
+        $this->assertEquals(['$chars = \'$\\\'\\\\\''], $method->getParamsWithDefault(false));
+    }
 }
 
 class ExampleClass
@@ -57,6 +72,11 @@ class ExampleClass
      * @param string $middle
      */
     public function setName($last, $first = 'Barry', ...$middle)
+    {
+        return;
+    }
+
+    public function setSpecialChars($chars = "\$'\\")
     {
         return;
     }


### PR DESCRIPTION
Certain default values for method parameters (strings containing single quotes or trailing backslashes) currently generate an invalid `_ide_helper.php` file.

This PR fixes that by replacing the current naïve code generation with a call to `var_export()`.