### PR TITLE
Generate noinspections PHPStorm tags

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -58,6 +58,7 @@ class ModelsCommand extends Command
     protected $dirs = array();
     protected $reset;
     protected $keep_text;
+    protected $phpstorm_noinspections;
     /**
      * @var bool[string]
      */
@@ -96,6 +97,7 @@ class ModelsCommand extends Command
         $model = $this->argument('model');
         $ignore = $this->option('ignore');
         $this->reset = $this->option('reset');
+        $this->phpstorm_noinspections = $this->option('phpstorm-noinspections');
         if ($this->option('smart-reset')) {
             $this->keep_text = $this->reset = true;
         }
@@ -154,6 +156,7 @@ class ModelsCommand extends Command
           array('nowrite', 'N', InputOption::VALUE_NONE, 'Don\'t write to Model file'),
           array('reset', 'R', InputOption::VALUE_NONE, 'Remove the original phpdocs instead of appending'),
           array('smart-reset', 'r', InputOption::VALUE_NONE, 'Refresh the properties/methods list, but keep the text'),
+          array('phpstorm-noinspections', 'p', InputOption::VALUE_NONE, 'Add PhpFullyQualifiedNameUsageInspection and PhpUnnecessaryFullyQualifiedNameInspection PHPStorm noinspection tags'),
           array('ignore', 'I', InputOption::VALUE_OPTIONAL, 'Which models to ignore', ''),
         );
     }
@@ -721,6 +724,10 @@ class ModelsCommand extends Command
 
         if ($this->write && ! $phpdoc->getTagsByName('mixin')) {
             $phpdoc->appendTag(Tag::createInstance("@mixin \\Eloquent", $phpdoc));
+        }
+        if ($this->phpstorm_noinspections) {
+            $phpdoc->appendTag(Tag::createInstance("@noinspection PhpFullyQualifiedNameUsageInspection", $phpdoc));
+            $phpdoc->appendTag(Tag::createInstance("@noinspection PhpUnnecessaryFullyQualifiedNameInspection", $phpdoc));
         }
 
         $serializer = new DocBlockSerializer();

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -156,7 +156,10 @@ class ModelsCommand extends Command
           array('nowrite', 'N', InputOption::VALUE_NONE, 'Don\'t write to Model file'),
           array('reset', 'R', InputOption::VALUE_NONE, 'Remove the original phpdocs instead of appending'),
           array('smart-reset', 'r', InputOption::VALUE_NONE, 'Refresh the properties/methods list, but keep the text'),
-          array('phpstorm-noinspections', 'p', InputOption::VALUE_NONE, 'Add PhpFullyQualifiedNameUsageInspection and PhpUnnecessaryFullyQualifiedNameInspection PHPStorm noinspection tags'),
+          array('phpstorm-noinspections', 'p', InputOption::VALUE_NONE,
+              'Add PhpFullyQualifiedNameUsageInspection and PhpUnnecessaryFullyQualifiedNameInspection PHPStorm ' .
+              'noinspection tags'
+          ),
           array('ignore', 'I', InputOption::VALUE_OPTIONAL, 'Which models to ignore', ''),
         );
     }
@@ -735,7 +738,9 @@ class ModelsCommand extends Command
              * Relations, other models in the same namespace
              * @see https://www.jetbrains.com/help/phpstorm/php-unnecessary-fully-qualified-name.html
              */
-            $phpdoc->appendTag(Tag::createInstance("@noinspection PhpUnnecessaryFullyQualifiedNameInspection", $phpdoc));
+            $phpdoc->appendTag(
+                Tag::createInstance("@noinspection PhpUnnecessaryFullyQualifiedNameInspection", $phpdoc)
+            );
         }
 
         $serializer = new DocBlockSerializer();

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -726,7 +726,15 @@ class ModelsCommand extends Command
             $phpdoc->appendTag(Tag::createInstance("@mixin \\Eloquent", $phpdoc));
         }
         if ($this->phpstorm_noinspections) {
+            /**
+             * Facades, Eloquent API
+             * @see https://www.jetbrains.com/help/phpstorm/php-fully-qualified-name-usage.html
+             */
             $phpdoc->appendTag(Tag::createInstance("@noinspection PhpFullyQualifiedNameUsageInspection", $phpdoc));
+            /**
+             * Relations, other models in the same namespace
+             * @see https://www.jetbrains.com/help/phpstorm/php-unnecessary-fully-qualified-name.html
+             */
             $phpdoc->appendTag(Tag::createInstance("@noinspection PhpUnnecessaryFullyQualifiedNameInspection", $phpdoc));
         }
 

--- a/tests/Console/ModelsCommand/PHPStormNoInspection/Models/Simple.php
+++ b/tests/Console/ModelsCommand/PHPStormNoInspection/Models/Simple.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Simple extends Model
+{
+}

--- a/tests/Console/ModelsCommand/PHPStormNoInspection/Test.php
+++ b/tests/Console/ModelsCommand/PHPStormNoInspection/Test.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+use Illuminate\Filesystem\Filesystem;
+use Mockery;
+use function file_get_contents;
+
+class Test extends AbstractModelsCommand
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('ide-helper', [
+            'model_locations' => [
+                // This is calculated from the base_path() which points to
+                // vendor/orchestra/testbench-core/laravel
+                '/../../../../tests/Console/ModelsCommand/PHPStormNoInspection/Models',
+            ],
+        ]);
+    }
+
+    public function testNoinspectionNotPresent(): void
+    {
+        $actualContent = null;
+        $mockFilesystem = Mockery::mock(Filesystem::class);
+        $mockFilesystem
+            ->shouldReceive('get')
+            ->andReturn(file_get_contents(__DIR__ . '/Models/Simple.php'))
+            ->once();
+        $mockFilesystem
+            ->shouldReceive('put')
+            ->with(
+                Mockery::any(),
+                Mockery::capture($actualContent)
+            )
+            ->andReturn(1) // Simulate we wrote _something_ to the file
+            ->once();
+
+        $this->instance(Filesystem::class, $mockFilesystem);
+
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--write' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertEmpty($tester->getDisplay());
+
+        $expectedContent = <<<'PHP'
+<?php declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple
+ *
+ * @property integer $id
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple query()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple whereId($value)
+ * @mixin \Eloquent
+ */
+class Simple extends Model
+{
+}
+
+PHP;
+
+        $this->assertSame($expectedContent, $actualContent);
+    }
+
+    public function testNoinspectionPresent(): void
+    {
+        $actualContent = null;
+        $mockFilesystem = Mockery::mock(Filesystem::class);
+        $mockFilesystem
+            ->shouldReceive('get')
+            ->andReturn(file_get_contents(__DIR__ . '/Models/Simple.php'))
+            ->once();
+        $mockFilesystem
+            ->shouldReceive('put')
+            ->with(
+                Mockery::any(),
+                Mockery::capture($actualContent)
+            )
+            ->andReturn(1) // Simulate we wrote _something_ to the file
+            ->once();
+
+        $this->instance(Filesystem::class, $mockFilesystem);
+
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--write' => true,
+            '--phpstorm-noinspections' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertEmpty($tester->getDisplay());
+
+        $expectedContent = <<<'PHP'
+<?php declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple
+ *
+ * @property integer $id
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple query()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple whereId($value)
+ * @mixin \Eloquent
+ * @noinspection PhpFullyQualifiedNameUsageInspection
+ * @noinspection PhpUnnecessaryFullyQualifiedNameInspection
+ */
+class Simple extends Model
+{
+}
+
+PHP;
+
+        $this->assertSame($expectedContent, $actualContent);
+    }
+}


### PR DESCRIPTION
When using write option for models eq
```bash
 php artisan ide-helper:models --smart-reset --write 
```
Generated PHPDoc has fully qualified names, about which PHPStorm complains (as it should). However, this is problematic since later during automatic code cleanup tasks these names are replaced with `use` statements. This generates unnecessary changes in the files, especially if some developers forget to run code cleanup. Later on, all of this stays in the git history.

As a solution, this PR adds a new option to the model command. `--phpstorm-noinspections` eg
```bash
php artisan ide-helper:models --smart-reset --write --phpstorm-noinspections
```
This will include two PHPStorm inspections at the end of the PHPDoc comment
```
 * @noinspection PhpFullyQualifiedNameUsageInspection
 * @noinspection PhpUnnecessaryFullyQualifiedNameInspection
```

which will stop PHPStorm from replacing the autogenerated FQN with use statements.

