### PR TITLE
fix: unregister meta command custom autoloader when it is no longer needed

### DIFF
--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -103,6 +103,8 @@ class MetaCommand extends Command
             }
         }
 
+        $this->unregisterClassAutoloadExceptions();
+
         $content = $this->view->make('meta', [
           'bindings' => $bindings,
           'methods' => $this->methods,
@@ -158,5 +160,15 @@ class MetaCommand extends Command
         return array(
             array('filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the meta file', $filename),
         );
+    }
+
+    /**
+     * Remove our custom autoloader that we pushed onto the autoload stack
+     */
+    private function unregisterClassAutoloadExceptions()
+    {
+        $autoloadFunctions = spl_autoload_functions();
+        $ourAutoloader = array_pop($autoloadFunctions);
+        spl_autoload_unregister($ourAutoloader);
     }
 }


### PR DESCRIPTION
I brought this up in #915 

Without removing our custom autoloader in `MetaCommand.php`, subsequent php code executed in the same process will trigger this autoloader, preventing any usage of `class_exists()` calls.

If you have any advice on how to write a regression test for this, please feel free to advise! I did pull this commit into  my codebase where i was running into the autoloader problem, and it seemed to fix it.