### PR TITLE
Add static return type to builder methods

### DIFF
--- a/src/Method.php
+++ b/src/Method.php
@@ -16,6 +16,8 @@ use Barryvdh\Reflection\DocBlock\Tag;
 use Barryvdh\Reflection\DocBlock\Tag\ReturnTag;
 use Barryvdh\Reflection\DocBlock\Tag\ParamTag;
 use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
 
 class Method
 {
@@ -69,7 +71,7 @@ class Method
         $this->getParameters($method);
 
         //Make the method static
-        $this->phpdoc->appendTag(Tag::createInstance('@static', $this->phpdoc));
+        $this->phpdoc-> appendTag(Tag::createInstance('@static', $this->phpdoc));
     }
 
     /**
@@ -266,7 +268,9 @@ class Method
             $this->return = $returnValue;
 
             if ($tag->getType() === '$this') {
-                $tag->setType($this->root);
+                Str::contains($this->root, Builder::class)
+                    ? $tag->setType($this->root . '|static')
+                    : $tag->setType($this->root);
             }
         } else {
             $this->return = null;
@@ -357,7 +361,7 @@ class Method
         if ($method) {
             $namespace = $method->getDeclaringClass()->getNamespaceName();
             $phpdoc = new DocBlock($method, new Context($namespace));
-            
+
             if (strpos($phpdoc->getText(), '{@inheritdoc}') !== false) {
                 //Not at the end yet, try another parent/interface..
                 return $this->getInheritDoc($method);

--- a/src/Method.php
+++ b/src/Method.php
@@ -71,7 +71,7 @@ class Method
         $this->getParameters($method);
 
         //Make the method static
-        $this->phpdoc-> appendTag(Tag::createInstance('@static', $this->phpdoc));
+        $this->phpdoc->appendTag(Tag::createInstance('@static', $this->phpdoc));
     }
 
     /**

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -3,6 +3,7 @@
 namespace Barryvdh\LaravelIdeHelper\Tests;
 
 use Barryvdh\LaravelIdeHelper\Method;
+use Illuminate\Database\Eloquent\Builder;
 use PHPUnit\Framework\TestCase;
 
 class ExampleTest extends TestCase
@@ -45,6 +46,33 @@ class ExampleTest extends TestCase
         $this->assertEquals(['$last', '$first', '...$middle'], $method->getParams(false));
         $this->assertEquals('$last, $first = \'Barry\', ...$middle', $method->getParamsWithDefault(true));
         $this->assertEquals(['$last', '$first = \'Barry\'', '...$middle'], $method->getParamsWithDefault(false));
+        $this->assertEquals(true, $method->shouldReturn());
+    }
+
+    /**
+     * Test the output of a class
+     */
+    public function testEloquentBuilderOutput()
+    {
+        $reflectionClass = new \ReflectionClass(Builder::class);
+        $reflectionMethod = $reflectionClass->getMethod('with');
+
+        $method = new Method($reflectionMethod, 'Builder', $reflectionClass);
+
+        $output = '/**
+ * Set the relationships that should be eager loaded.
+ *
+ * @param mixed $relations
+ * @return \Illuminate\Database\Eloquent\Builder|static 
+ * @static 
+ */';
+        $this->assertEquals($output, $method->getDocComment(''));
+        $this->assertEquals('with', $method->getName());
+        $this->assertEquals('\\'.Builder::class, $method->getDeclaringClass());
+        $this->assertEquals('$relations', $method->getParams(true));
+        $this->assertEquals(['$relations'], $method->getParams(false));
+        $this->assertEquals('$relations', $method->getParamsWithDefault(true));
+        $this->assertEquals(['$relations'], $method->getParamsWithDefault(false));
         $this->assertEquals(true, $method->shouldReturn());
     }
 

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -39,14 +39,14 @@ class ExampleTest extends TestCase
  * @param string $middle
  * @static 
  */';
-        $this->assertEquals($output, $method->getDocComment(''));
-        $this->assertEquals('setName', $method->getName());
-        $this->assertEquals('\\'.ExampleClass::class, $method->getDeclaringClass());
-        $this->assertEquals('$last, $first, ...$middle', $method->getParams(true));
-        $this->assertEquals(['$last', '$first', '...$middle'], $method->getParams(false));
-        $this->assertEquals('$last, $first = \'Barry\', ...$middle', $method->getParamsWithDefault(true));
-        $this->assertEquals(['$last', '$first = \'Barry\'', '...$middle'], $method->getParamsWithDefault(false));
-        $this->assertEquals(true, $method->shouldReturn());
+        $this->assertSame($output, $method->getDocComment(''));
+        $this->assertSame('setName', $method->getName());
+        $this->assertSame('\\'.ExampleClass::class, $method->getDeclaringClass());
+        $this->assertSame('$last, $first, ...$middle', $method->getParams(true));
+        $this->assertSame(['$last', '$first', '...$middle'], $method->getParams(false));
+        $this->assertSame('$last, $first = \'Barry\', ...$middle', $method->getParamsWithDefault(true));
+        $this->assertSame(['$last', '$first = \'Barry\'', '...$middle'], $method->getParamsWithDefault(false));
+        $this->assertSame(true, $method->shouldReturn());
     }
 
     /**
@@ -66,14 +66,14 @@ class ExampleTest extends TestCase
  * @return \Illuminate\Database\Eloquent\Builder|static 
  * @static 
  */';
-        $this->assertEquals($output, $method->getDocComment(''));
-        $this->assertEquals('with', $method->getName());
-        $this->assertEquals('\\'.Builder::class, $method->getDeclaringClass());
-        $this->assertEquals('$relations', $method->getParams(true));
-        $this->assertEquals(['$relations'], $method->getParams(false));
-        $this->assertEquals('$relations', $method->getParamsWithDefault(true));
-        $this->assertEquals(['$relations'], $method->getParamsWithDefault(false));
-        $this->assertEquals(true, $method->shouldReturn());
+        $this->assertSame($output, $method->getDocComment(''));
+        $this->assertSame('with', $method->getName());
+        $this->assertSame('\\'.Builder::class, $method->getDeclaringClass());
+        $this->assertSame('$relations', $method->getParams(true));
+        $this->assertSame(['$relations'], $method->getParams(false));
+        $this->assertSame('$relations', $method->getParamsWithDefault(true));
+        $this->assertSame(['$relations'], $method->getParamsWithDefault(false));
+        $this->assertSame(true, $method->shouldReturn());
     }
 
     /**
@@ -85,10 +85,10 @@ class ExampleTest extends TestCase
         $reflectionMethod = $reflectionClass->getMethod('setSpecialChars');
 
         $method = new Method($reflectionMethod, 'Example', $reflectionClass);
-        $this->assertEquals('$chars', $method->getParams(true));
-        $this->assertEquals(['$chars'], $method->getParams(false));
-        $this->assertEquals('$chars = \'$\\\'\\\\\'', $method->getParamsWithDefault(true));
-        $this->assertEquals(['$chars = \'$\\\'\\\\\''], $method->getParamsWithDefault(false));
+        $this->assertSame('$chars', $method->getParams(true));
+        $this->assertSame(['$chars'], $method->getParams(false));
+        $this->assertSame('$chars = \'$\\\'\\\\\'', $method->getParamsWithDefault(true));
+        $this->assertSame(['$chars = \'$\\\'\\\\\''], $method->getParamsWithDefault(false));
     }
 }
 


### PR DESCRIPTION
Fixes #923 

So this is an attempt to add `static` to the return type on the builder methods generated by `ide-helper:generate`. I am not 100% sure if this is the right location for this but it wasn't immediately obvious where else it could go. 

I have tested this on a number of my projects and it works as expected.

_ide-helper.php_
```php
* @return \Illuminate\Database\Eloquent\Builder|static
...
public static function where($column, $operator = null, $value = null, $boolean = 'and')
```

Unfortunately the Generator command doesn't have any tests - which is understandable due to its complexity. But I have added a test for the `Method` class I have changed