### PR TITLE
Fixed error reading dynamic properties

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -443,10 +443,7 @@ class ModelsCommand extends Command
         $methods = $reflection->getMethods();
         if ($methods) {
             usort($methods, function ($a, $b) {
-                if ($a->name == $b->name) {
-                    return 0;
-                }
-                return ($a->name < $b->name) ? -1 : 1;
+                return $a->name <=> $b->name;
             });
             foreach ($methods as $reflection_method) {
                 $method = $reflection_method->name;

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -439,10 +439,17 @@ class ModelsCommand extends Command
      */
     protected function getPropertiesFromMethods($model)
     {
-        $methods = get_class_methods($model);
+        $reflection = new ReflectionClass($model);
+        $methods = $reflection->getMethods();
         if ($methods) {
-            sort($methods);
-            foreach ($methods as $method) {
+            usort($methods, function ($a, $b) {
+                if ($a->name == $b->name) {
+                    return 0;
+                }
+                return ($a->name < $b->name) ? -1 : 1;
+            });
+            foreach ($methods as $reflection_method) {
+                $method = $reflection_method->name;
                 if (Str::startsWith($method, 'get') && Str::endsWith(
                     $method,
                     'Attribute'
@@ -458,7 +465,7 @@ class ModelsCommand extends Command
                 } elseif (Str::startsWith($method, 'set') && Str::endsWith(
                     $method,
                     'Attribute'
-                ) && $method !== 'setAttribute'
+                ) && $method !== 'setAttribute' && $method !== 'setClassCastableAttribute'
                 ) {
                     //Magic set<name>Attribute
                     $name = Str::snake(substr($method, 3, -9));

--- a/tests/Console/ModelsCommand/Getter/Models/Simple.php
+++ b/tests/Console/ModelsCommand/Getter/Models/Simple.php
@@ -101,4 +101,99 @@ class Simple extends Model
     public function getAttributeReturnsVoidAttribute(): void
     {
     }
+
+    /**
+     * @return int
+     */
+    protected function getProtectedAttributeWithIntReturnPhpdocAttribute()
+    {
+    }
+
+    protected function getProtectedAttributeWithIntReturnTypeAttribute(): int
+    {
+    }
+
+    /**
+     * @return int
+     */
+    protected function getProtectedAttributeWithIntReturnTypeAndPhpdocAttribute(): int
+    {
+    }
+
+    /**
+     * @return string
+     */
+    protected function getProtectedAttributeWithIntReturnTypeAndButPhpdocStringAttribute(): int
+    {
+    }
+
+    protected function getProtectedAttributeWithoutTypeAttribute()
+    {
+    }
+
+    /**
+     * @return what|ever|we-write/here
+     */
+    protected function getProtectedAttributeTakesPhpdocLiteralAttribute()
+    {
+    }
+
+    protected function getProtectedAttributeReturnTypeIntOrNullAttribute(): ?int
+    {
+    }
+
+    protected function getProtectedAttributeReturnsImportedClassAttribute(): DateTime
+    {
+    }
+
+    protected function getProtectedAttributeReturnsFqnClassAttribute(): \Illuminate\Support\Facades\Date
+    {
+    }
+
+    protected function getProtectedAttributeReturnsArrayAttribute(): array
+    {
+    }
+
+    protected function getProtectedAttributeReturnsNullableArrayAttribute(): ?array
+    {
+    }
+
+    protected function getProtectedAttributeReturnsStdClassAttribute(): \stdClass
+    {
+    }
+
+    protected function getProtectedAttributeReturnsNullableStdClassAttribute(): ?\stdClass
+    {
+    }
+
+    protected function getProtectedAttributeReturnsBoolAttribute(): bool
+    {
+    }
+
+    protected function getProtectedAttributeReturnsNullableBoolAttribute(): ?bool
+    {
+    }
+
+    protected function getProtectedAttributeReturnsFloatAttribute(): bool
+    {
+    }
+
+    protected function getProtectedAttributeReturnsNullableFloatAttribute(): ?bool
+    {
+    }
+
+    protected function getProtectedAttributeReturnsCallableAttribute(): callable
+    {
+    }
+
+    protected function getProtectedAttributeReturnsNullableCallableAttribute(): ?callable
+    {
+    }
+
+    /**
+     * Doesn't make sense, but…
+     */
+    protected function getProtectedAttributeReturnsVoidAttribute(): void
+    {
+    }
 }

--- a/tests/Console/ModelsCommand/Getter/Test.php
+++ b/tests/Console/ModelsCommand/Getter/Test.php
@@ -82,6 +82,26 @@ use Illuminate\Database\Eloquent\Model;
  * @property-read int $attribute_with_int_return_type_and_phpdoc
  * @property-read int $attribute_with_int_return_type
  * @property-read mixed $attribute_without_type
+ * @property-read int|null $protected_attribute_return_type_int_or_null
+ * @property-read array $protected_attribute_returns_array
+ * @property-read bool $protected_attribute_returns_bool
+ * @property-read callable $protected_attribute_returns_callable
+ * @property-read bool $protected_attribute_returns_float
+ * @property-read \Illuminate\Support\Facades\Date $protected_attribute_returns_fqn_class
+ * @property-read \DateTime $protected_attribute_returns_imported_class
+ * @property-read array|null $protected_attribute_returns_nullable_array
+ * @property-read bool|null $protected_attribute_returns_nullable_bool
+ * @property-read callable|null $protected_attribute_returns_nullable_callable
+ * @property-read bool|null $protected_attribute_returns_nullable_float
+ * @property-read \stdClass|null $protected_attribute_returns_nullable_std_class
+ * @property-read \stdClass $protected_attribute_returns_std_class
+ * @property-read void $protected_attribute_returns_void
+ * @property-read \what|\ever|\we-write/here $protected_attribute_takes_phpdoc_literal
+ * @property-read int $protected_attribute_with_int_return_phpdoc
+ * @property-read string $protected_attribute_with_int_return_type_and_but_phpdoc_string
+ * @property-read int $protected_attribute_with_int_return_type_and_phpdoc
+ * @property-read int $protected_attribute_with_int_return_type
+ * @property-read mixed $protected_attribute_without_type
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Getter\Models\Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Getter\Models\Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Getter\Models\Simple query()
@@ -182,6 +202,101 @@ class Simple extends Model
      * Doesn't make sense, but…
      */
     public function getAttributeReturnsVoidAttribute(): void
+    {
+    }
+
+    /**
+     * @return int
+     */
+    protected function getProtectedAttributeWithIntReturnPhpdocAttribute()
+    {
+    }
+
+    protected function getProtectedAttributeWithIntReturnTypeAttribute(): int
+    {
+    }
+
+    /**
+     * @return int
+     */
+    protected function getProtectedAttributeWithIntReturnTypeAndPhpdocAttribute(): int
+    {
+    }
+
+    /**
+     * @return string
+     */
+    protected function getProtectedAttributeWithIntReturnTypeAndButPhpdocStringAttribute(): int
+    {
+    }
+
+    protected function getProtectedAttributeWithoutTypeAttribute()
+    {
+    }
+
+    /**
+     * @return what|ever|we-write/here
+     */
+    protected function getProtectedAttributeTakesPhpdocLiteralAttribute()
+    {
+    }
+
+    protected function getProtectedAttributeReturnTypeIntOrNullAttribute(): ?int
+    {
+    }
+
+    protected function getProtectedAttributeReturnsImportedClassAttribute(): DateTime
+    {
+    }
+
+    protected function getProtectedAttributeReturnsFqnClassAttribute(): \Illuminate\Support\Facades\Date
+    {
+    }
+
+    protected function getProtectedAttributeReturnsArrayAttribute(): array
+    {
+    }
+
+    protected function getProtectedAttributeReturnsNullableArrayAttribute(): ?array
+    {
+    }
+
+    protected function getProtectedAttributeReturnsStdClassAttribute(): \stdClass
+    {
+    }
+
+    protected function getProtectedAttributeReturnsNullableStdClassAttribute(): ?\stdClass
+    {
+    }
+
+    protected function getProtectedAttributeReturnsBoolAttribute(): bool
+    {
+    }
+
+    protected function getProtectedAttributeReturnsNullableBoolAttribute(): ?bool
+    {
+    }
+
+    protected function getProtectedAttributeReturnsFloatAttribute(): bool
+    {
+    }
+
+    protected function getProtectedAttributeReturnsNullableFloatAttribute(): ?bool
+    {
+    }
+
+    protected function getProtectedAttributeReturnsCallableAttribute(): callable
+    {
+    }
+
+    protected function getProtectedAttributeReturnsNullableCallableAttribute(): ?callable
+    {
+    }
+
+    /**
+     * Doesn't make sense, but…
+     */
+    protected function getProtectedAttributeReturnsVoidAttribute(): void
     {
     }
 }

--- a/tests/Console/ModelsCommand/Scopes/Models/Simple.php
+++ b/tests/Console/ModelsCommand/Scopes/Models/Simple.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Scopes\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class Simple extends Model
+{
+    protected function scopeReturnWithoutParameters(Builder $builder)
+    {
+    }
+
+    protected function scopeReturnWithParameters(Builder $builder, $foo, int $bar, string $baz = null)
+    {
+    }
+}

--- a/tests/Console/ModelsCommand/Scopes/Test.php
+++ b/tests/Console/ModelsCommand/Scopes/Test.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Scopes;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+use Illuminate\Filesystem\Filesystem;
+use Mockery;
+
+class Test extends AbstractModelsCommand
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('ide-helper', [
+            'model_locations' => [
+                // This is calculated from the base_path() which points to
+                // vendor/orchestra/testbench-core/laravel
+                '/../../../../tests/Console/ModelsCommand/Scopes/Models',
+            ],
+        ]);
+    }
+
+    public function test(): void
+    {
+        $actualContent = null;
+        $mockFilesystem = Mockery::mock(Filesystem::class);
+        $mockFilesystem
+            ->shouldReceive('get')
+            ->andReturn(file_get_contents(__DIR__ . '/Models/Simple.php'))
+            ->once();
+        $mockFilesystem
+            ->shouldReceive('put')
+            ->with(
+                Mockery::any(),
+                Mockery::capture($actualContent)
+            )
+            ->andReturn(1) // Simulate we wrote _something_ to the file
+            ->once();
+
+        $this->instance(Filesystem::class, $mockFilesystem);
+
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--write' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertEmpty($tester->getDisplay());
+
+        $expectedContent = <<<'PHP'
+<?php declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Scopes\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Scopes\Models\Simple
+ *
+ * @property integer $id
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Scopes\Models\Simple newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Scopes\Models\Simple newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Scopes\Models\Simple query()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Scopes\Models\Simple returnWithParameters($foo, $bar, $baz = null)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Scopes\Models\Simple returnWithoutParameters()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Scopes\Models\Simple whereId($value)
+ * @mixin \Eloquent
+ */
+class Simple extends Model
+{
+    protected function scopeReturnWithoutParameters(Builder $builder)
+    {
+    }
+
+    protected function scopeReturnWithParameters(Builder $builder, $foo, int $bar, string $baz = null)
+    {
+    }
+}
+
+PHP;
+
+        $this->assertSame($expectedContent, $actualContent);
+    }
+}


### PR DESCRIPTION
Now, when generating, the `get_class_methods` method is used, which does not return `protected` methods from the model, so it is not possible to get the correct list of model properties:

![2020-05-15_15-20-15](https://user-images.githubusercontent.com/10347617/82050023-11846d00-96c0-11ea-9a4a-30dffb84401d.jpg)

![2020-05-15_15-19-58](https://user-images.githubusercontent.com/10347617/82050013-0d584f80-96c0-11ea-8811-cec7bb0dc4ad.jpg)

Using `ReflectionClass` instead, we can get all the methods available in the model and generate the correct doc-block:

![2020-05-15_16-56-16](https://user-images.githubusercontent.com/10347617/82058159-084dcd00-96cd-11ea-9956-d654f3eb6cd7.jpg)
