### PR TITLE
Fix class namespaces from uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 [![Build Status][ico-travis]][link-travis]
 [![Total Downloads][ico-downloads]][link-downloads]
 
+## About this fork
+
+This fork fixes the long-standing problem that the IDE Helper cannot correctly determine the namespace for method parameters and returns if the types in the docblock do not contain the fully qualified name space.
+
+The solution in this fork extracts the use statements from each class in order to determine the full namespace for each class alias.
+
 **Complete PHPDocs, directly from the source**
 
 This package generates helper files that enable your IDE to provide accurate autocompletion.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,6 @@
 [![Build Status][ico-travis]][link-travis]
 [![Total Downloads][ico-downloads]][link-downloads]
 
-## About this fork
-
-This fork fixes the long-standing problem that the IDE Helper cannot correctly determine the namespace for method parameters and returns if the types in the docblock do not contain the fully qualified name space.
-
-The solution in this fork extracts the use statements from each class in order to determine the full namespace for each class alias.
-
 **Complete PHPDocs, directly from the source**
 
 This package generates helper files that enable your IDE to provide accurate autocompletion.

--- a/src/Method.php
+++ b/src/Method.php
@@ -12,10 +12,10 @@ namespace Barryvdh\LaravelIdeHelper;
 
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Context;
-use Barryvdh\Reflection\DocBlock\Tag;
-use Barryvdh\Reflection\DocBlock\Tag\ReturnTag;
-use Barryvdh\Reflection\DocBlock\Tag\ParamTag;
 use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
+use Barryvdh\Reflection\DocBlock\Tag;
+use Barryvdh\Reflection\DocBlock\Tag\ParamTag;
+use Barryvdh\Reflection\DocBlock\Tag\ReturnTag;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 
@@ -37,6 +37,7 @@ class Method
     protected $real_name;
     protected $return = null;
     protected $root;
+    protected $uses = array();
 
     /**
      * @param \ReflectionMethod|\ReflectionFunctionAbstract $method
@@ -53,11 +54,15 @@ class Method
         $this->real_name = $method->isClosure() ? $this->name : $method->name;
         $this->initClassDefinedProperties($method, $class);
 
+        // TODO: Runtime-cache this.
+        $this->uses = $this->getUses($class);
+
         //Reference the 'real' function in the declaring class
         $this->root = '\\' . ltrim($class->getName(), '\\');
 
         //Create a DocBlock and serializer instance
         $this->initPhpDoc($method);
+
 
         //Normalize the description and inherit the docs from parents/interfaces
         try {
@@ -237,7 +242,8 @@ class Method
                 $tag->setContent($content);
 
                 // Get the expanded type and re-set the content
-                $content = $tag->getType() . ' ' . $tag->getVariableName() . ' ' . $tag->getDescription();
+                $type    = $this->subsituteMissingClasses($tag->getType());
+                $content = $type . ' ' . $tag->getVariableName() . ' ' . $tag->getDescription();
                 $tag->setContent(trim($content));
             }
         }
@@ -262,6 +268,8 @@ class Method
             foreach ($this->interfaces as $interface => $real) {
                 $returnValue = str_replace($interface, $real, $returnValue);
             }
+
+            $returnValue = $this->subsituteMissingClasses($returnValue);
 
             // Set the changed content
             $tag->setContent($returnValue . ' ' . $tag->getDescription());
@@ -370,4 +378,98 @@ class Method
             }
         }
     }
+
+    /**
+     * @param \ReflectionClass $class
+     *
+     * @return array
+     */
+    protected function getUses(\ReflectionClass $class)
+    {
+        $start = false;
+        $currentString = '';
+        $currentUse = '';
+        $uses = [];
+        foreach (token_get_all(file_get_contents($class->getFileName())) as $token) {
+            if ($start === false) {
+                if (is_numeric($token[0])) {
+                    switch (token_name($token[0])) {
+                        case 'T_CLASS':
+                            // Stop on reaching class definition for performance reasons.
+                            // This leads to not catching any use statements behind the class definition.
+                            break 2;
+                        case 'T_USE':
+                            $start         = true;
+                            $currentString = '';
+                            $currentUse    = '';
+                            break;
+                    }
+                }
+            } else {
+                if ($token[0] != ';') {
+                    if (is_numeric($token[0])) {
+                        switch (token_name($token[0])) {
+                            case 'T_WHITESPACE':
+                                // Skip Whitespaces.
+                                break;
+                            case 'T_AS':
+                                $currentUse    = $currentString;
+                                $currentString = '';
+                                break;
+                            default:
+                                $currentString .= $token[1] ?? '';
+                        }
+                    } else {
+                        $currentString .= $token[1] ?? '';
+                    }
+
+                } else {
+                    if ($currentUse != '') {
+                        $uses[$currentString] = $currentUse;
+                    } else {
+                        $uses[$this->classBasename($currentString)] = $currentString;
+                    }
+
+                    $start = false;
+                }
+            }
+        }
+        return $uses;
+    }
+
+    /**
+     * @param string $types
+     *
+     * @return string
+     */
+    protected function subsituteMissingClasses(string $types)
+    {
+        $newTypes = [];
+        foreach (explode('|', $types) as $type) {
+            if (!class_exists($type)) {
+                $baseClassName = $this->classBasename($type);
+
+                if ($this->uses[$baseClassName] ?? false) {
+                    $type = $this->uses[$baseClassName];
+                    if (substr($type, 0, 1) != '\\') {
+                        $type = '\\' . $type;
+                    }
+                }
+            }
+            $newTypes[] = $type;
+        }
+
+        return implode('|', $newTypes);
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return string
+     */
+    protected function classBasename(string $className)
+    {
+        return basename(str_replace('\\', '/', $className));
+    }
+
 }

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -4,6 +4,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests;
 
 use Barryvdh\LaravelIdeHelper\Method;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 
 class ExampleTest extends TestCase
@@ -32,12 +33,12 @@ class ExampleTest extends TestCase
         $method = new Method($reflectionMethod, 'Example', $reflectionClass);
 
         $output = '/**
- * 
+ *
  *
  * @param string $last
  * @param string $first
  * @param string $middle
- * @static 
+ * @static
  */';
         $this->assertSame($output, $method->getDocComment(''));
         $this->assertSame('setName', $method->getName());
@@ -63,8 +64,8 @@ class ExampleTest extends TestCase
  * Set the relationships that should be eager loaded.
  *
  * @param mixed $relations
- * @return \Illuminate\Database\Eloquent\Builder|static 
- * @static 
+ * @return \Illuminate\Database\Eloquent\Builder|static
+ * @static
  */';
         $this->assertSame($output, $method->getDocComment(''));
         $this->assertSame('with', $method->getName());
@@ -90,6 +91,28 @@ class ExampleTest extends TestCase
         $this->assertSame('$chars = \'$\\\'\\\\\'', $method->getParamsWithDefault(true));
         $this->assertSame(['$chars = \'$\\\'\\\\\''], $method->getParamsWithDefault(false));
     }
+
+    public function testRespectsImportedNamespaces()
+    {
+        $reflectionClass = new \ReflectionClass(SampleClass::class);
+        $reflectionMethod = $reflectionClass->getMethod('someMethod');
+
+        $method = new Method($reflectionMethod, 'SampleClass', $reflectionClass);
+
+        $output = '/**
+ *
+ *
+ * @param \Illuminate\Support\Collection $collection
+ * @param \Illuminate\Database\Eloquent\Builder $builder
+ * @param \Barryvdh\LaravelIdeHelper\Tests\UnknownClass $unknownClass
+ * @return \Illuminate\Support\Collection
+ * @static
+ */';
+
+        $this->assertSame($output, $method->getDocComment(''));
+        $this->assertSame('with', $method->getName());
+        $this->assertSame('\\'. SampleClass::class, $method->getDeclaringClass());
+    }
 }
 
 class ExampleClass
@@ -107,5 +130,18 @@ class ExampleClass
     public function setSpecialChars($chars = "\$'\\")
     {
         return;
+    }
+}
+
+class SampleClass {
+    /**
+     * @param Collection   $collection
+     * @param Builder      $builder
+     * @param UnknownClass $unknownClass
+     *
+     * @return Collection
+     */
+    function someMethod(Collection $collection, Builder $builder, UnknownClass $unknownClass) {
+        return collect();
     }
 }

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -4,8 +4,9 @@ namespace Barryvdh\LaravelIdeHelper\Tests;
 
 use Barryvdh\LaravelIdeHelper\Method;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Collection;
+use \Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Carbon as AliasedCarbon;
 
 class ExampleTest extends TestCase
 {
@@ -104,6 +105,7 @@ class ExampleTest extends TestCase
  *
  * @param \Illuminate\Support\Collection $collection
  * @param \Illuminate\Database\Eloquent\Builder $builder
+ * @param \Illuminate\Support\Carbon $carbon
  * @param \Barryvdh\LaravelIdeHelper\Tests\UnknownClass $unknownClass
  * @return \Illuminate\Support\Collection
  * @static
@@ -135,13 +137,14 @@ class ExampleClass
 
 class SampleClass {
     /**
-     * @param Collection   $collection
-     * @param Builder      $builder
-     * @param UnknownClass $unknownClass
+     * @param Collection    $collection
+     * @param Builder       $builder
+     * @param AliasedCarbon $carbon
+     * @param UnknownClass  $unknownClass
      *
      * @return Collection
      */
-    function someMethod(Collection $collection, Builder $builder, UnknownClass $unknownClass) {
+    function someMethod(Collection $collection, Builder $builder, AliasedCarbon $carbon, UnknownClass $unknownClass) {
         return collect();
     }
 }


### PR DESCRIPTION
This pull request adresses a long-standing issue the ide-helper has if @param and @return types in methods do not include the fully qualified namespace. 

## Why this is an issue 

Both our code style and PHPStorm encourages importing namespaces via use statements and then removing the unnecessary FQNs everywhere, including the PHPdoc blocks. When doing this, the ide-helper does not know how to resolve the types anymore and just puts them all in the namespace of the current class.

## Observed behavior

If we have a class like this, the ide-helper is totally clueless where the Collection and Builder classes come from:

```
<?php

namespace Sample\Namespace;

use Illuminate\Support\Collection;
use Illuminate\Database\Eloquent\Builder;

class SampleClass {
    /**
     * @param Collection    $collection
     * @param Builder       $builder
     *
     * @return Collection
     */
    function someMethod(Collection $collection, Builder $builder) {
        return collect();
    }
}     
```


This will result in the ide-helper producing a PHPdoc like this:

```
/**
 *
 *
 * @param \Sample\Namespace\Collection $collection
 * @param \Sample\Namespace\Builder $builder
 * @return \Sample\Namespace\Collection
 * @static
*/
```

## Expected behavior

Instead, you would expect ide-helper to respect the imports and produce the following PHPdoc instead:

```
/**
 *
 *
 * @param \Illuminate\Support\Collection $collection
 * @param \Illuminate\Database\Eloquent\Builder $builder
 * @return \Illuminate\Support\Collection
 * @static
*/
```

## About the pull request

The solution is designed to be minimally invasive and just fix class names that do not exist after processing by the ReturnTag class. If the class could not be found in the determined scope, the class imports are searched, and if a corresponding use statement is found, the namespace is applied accordingly. This also takes aliasing into account.

Although this requires a scan of the class sources, and the uses are, in the current form, unnecessarily re-read for each method in a class, the process is still sufficiently fast. However, I would advise to use a runtime cache to steamline the process. I leave that up for discussion, and if desired, I'll see if I can add this to this pull request within the next couple of days.