### PR TITLE
Small improvements for github actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 
 # Ignore all test and documentation with "export-ignore".
 /.gitattributes     export-ignore
+/.github            export-ignore
 /.gitignore         export-ignore
-/.travis.yml        export-ignore
 /phpunit.xml.dist   export-ignore
 /tests              export-ignore

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -85,6 +85,8 @@ jobs:
           coverage: none
 
       - name: Install dependencies
-        run: composer update  --prefer-dist --no-suggest --no-progress
+        run: |
+          composer remove phpro/grumphp vimeo/psalm --no-update --dev
+          composer update --prefer-dist --no-suggest --no-progress
 
       - run: composer check-style

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,3 +1,4 @@
+name: Tests
 on:
   push:
   pull_request:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -68,7 +68,25 @@ jobs:
         composer update --${{ matrix.dependency-version }} --prefer-dist --no-suggest --no-progress
 
     - name: Execute Unit Tests
-      run: vendor/bin/phpunit
+      run: composer test
 
-    - name: Check PSR-12 Codestyle
-      run: vendor/bin/phpcs --standard=psr2 src/
+  check-style:
+    name: Check Code Style
+    runs-on: ubuntu-latest
+    env:
+      COMPOSER_NO_INTERACTION: 1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update  --prefer-dist --no-suggest --no-progress
+
+      - run: composer check-style

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   php-tests:
     runs-on: ubuntu-latest
+    env:
+      COMPOSER_NO_INTERACTION: 1
 
     strategy:
       matrix:
@@ -61,9 +63,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        composer remove phpro/grumphp --no-interaction --no-update --dev
-        composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --no-progress
-        composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+        composer remove phpro/grumphp --no-update --dev
+        composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-update --no-progress
+        composer update --${{ matrix.dependency-version }} --prefer-dist --no-suggest --no-progress
 
     - name: Execute Unit Tests
       run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Latest Version on Packagist][ico-version]][link-packagist]
 [![Software License][ico-license]](LICENSE.md)
-[![Build Status][ico-travis]][link-travis]
 [![Total Downloads][ico-downloads]][link-downloads]
 
 **Complete PHPDocs, directly from the source**
@@ -299,8 +298,6 @@ The Laravel IDE Helper Generator is open-sourced software licensed under the [MI
 
 [ico-version]: https://img.shields.io/packagist/v/barryvdh/laravel-ide-helper.svg?style=flat-square
 [ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
-[ico-travis]: https://img.shields.io/travis/barryvdh/laravel-ide-helper/master.svg?style=flat-square
 [ico-downloads]: https://img.shields.io/packagist/dt/barryvdh/laravel-ide-helper.svg?style=flat-square
 [link-packagist]: https://packagist.org/packages/barryvdh/laravel-ide-helper
-[link-travis]: https://travis-ci.org/barryvdh/laravel-ide-helper
 [link-downloads]: https://packagist.org/packages/barryvdh/laravel-ide-helper


### PR DESCRIPTION
I.e. some of the not-yet-implemented feedback from https://github.com/barryvdh/laravel-ide-helper/pull/960

- clean up mention of travis
- prefer composer scripts for final execution
- use env var for no-interactive
- adjust .gitignore exports
- separate non-matrix job for phpcs

Oh, and gave the workflow file a name so it appears more nicely in e.g. https://github.com/barryvdh/laravel-ide-helper/actions