### PR TITLE
[Chore] Composer 2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "illuminate/view": "^5.5 || ^6 || ^7",
         "mockery/mockery": "^1.3",
         "orchestra/testbench": "^3 || ^4 || ^5",
-        "phpro/grumphp": "^0.17.1",
+        "phpro/grumphp": "^0.19.0",
         "squizlabs/php_codesniffer": "^3.5",
         "vimeo/psalm": "^3.12"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.2",
         "barryvdh/reflection-docblock": "^2.0.6",
-        "composer/composer": "^1.6",
+        "composer/composer": "^1.6 || ^2.0@dev",
         "doctrine/dbal": "~2.3",
         "illuminate/console": "^5.5 || ^6 || ^7",
         "illuminate/filesystem": "^5.5 || ^6 || ^7",

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,6 +1,4 @@
-parameters:
-    git_dir: .
-    bin_dir: vendor/bin
+grumphp:
     tasks:
         phpunit:
             config_file: ~


### PR DESCRIPTION
👋 I think this should allow usage with composer 2. There isn't an official tag yet, so `^2.0@dev` should suffice to allow dev stability versions of the release. Naturally once the official composer 2 release is made, we should update the dependency to be `"composer/composer": "^1.6 || ^2.0",`

------

I have verified that our (ide-helper's) usage of composer is limited to `ClassMapGenerator::createMap`, whose signature doesn't seem to have changed in composer 2.

------

`grumphp` added support for composer 2 in [`0.18.1`](https://github.com/phpro/grumphp/pull/768), hence why I have updated it in this PR.

Related: https://github.com/psalm/psalm-plugin-laravel/issues/89