### PR TITLE
chore: use composer scripts in grumphp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "illuminate/view": "^5.5 || ^6 || ^7",
         "mockery/mockery": "^1.3",
         "orchestra/testbench": "^3 || ^4 || ^5",
-        "phpro/grumphp": "^0.17.1",
+        "phpro/grumphp": "^0.19.0",
         "squizlabs/php_codesniffer": "^3.5",
         "vimeo/psalm": "^3.12"
     },

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,27 +1,19 @@
-parameters:
-    git_dir: .
-    bin_dir: vendor/bin
+grumphp:
     tasks:
         phpunit:
-            config_file: ~
-            testsuite: ~
-            group: []
-            always_execute: false
-        phpcs:
-            standard: PSR2
-            warning_severity: ~
-            ignore_patterns:
-                - tests/
+            script: test
             triggered_by: [php]
-            whitelist_patterns:
-                - /^src\/.*/
-                - /^config\/.*/
-        psalm:
-            config: psalm.xml
-            ignore_patterns: []
-            no_cache: false
-            report: null
-            output_format: null
-            threads: null
-            triggered_by: ['php']
-            show_info: false
+            metadata:
+                task: composer_script
+
+        phpcs:
+            script: check-style
+            triggered_by: [php]
+            metadata:
+                task: composer_script
+
+        static analysis:
+            script: analyze
+            triggered_by: [php]
+            metadata:
+                task: composer_script


### PR DESCRIPTION
This reduces the # of places we need to change configurations for various dev tools. Now grumphp will just execute the composer script listed under the `script` key.

I updated grumphp because this later version has support for running various different composer scripts