### PR TITLE
[README] Add gha badge for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Latest Version on Packagist][ico-version]][link-packagist]
 [![Software License][ico-license]](LICENSE.md)
+[![Build Status][ico-gha]][link-gha]
 [![Total Downloads][ico-downloads]][link-downloads]
 
 **Complete PHPDocs, directly from the source**
@@ -298,6 +299,8 @@ The Laravel IDE Helper Generator is open-sourced software licensed under the [MI
 
 [ico-version]: https://img.shields.io/packagist/v/barryvdh/laravel-ide-helper.svg?style=flat-square
 [ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
+[ico-gha]: https://github.com/barryvdh/laravel-ide-helper/workflows/Tests/badge.svg
 [ico-downloads]: https://img.shields.io/packagist/dt/barryvdh/laravel-ide-helper.svg?style=flat-square
 [link-packagist]: https://packagist.org/packages/barryvdh/laravel-ide-helper
+[link-gha]: https://github.com/barryvdh/laravel-ide-helper/actions
 [link-downloads]: https://packagist.org/packages/barryvdh/laravel-ide-helper


### PR DESCRIPTION
As requested per https://github.com/barryvdh/laravel-ide-helper/pull/961#discussion_r443749363
> Can we add the Actions badges?

GHA badges are "per workflow" and we got three, but I figured the most relevant one is about the tests.