### PR TITLE
[GHA] Add timeouts

### DIFF
--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   normalize:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout

--- a/.github/workflows/run-static-analysis.yml
+++ b/.github/workflows/run-static-analysis.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
     build:
+        timeout-minutes: 15
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   php-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       COMPOSER_NO_INTERACTION: 1
 
@@ -70,6 +71,7 @@ jobs:
 
   check-style:
     name: Check Code Style
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       COMPOSER_NO_INTERACTION: 1


### PR DESCRIPTION
Prevent things like https://github.com/barryvdh/laravel-ide-helper/pull/958/checks?check_run_id=796677164 where jobs runnaway for up to 6 hours (GHA default timeout…)

I figured if within 15 minutes it's not done, there's a problem anyway.