### PR TITLE
Make writing relation count properties optional

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -52,6 +52,22 @@ return array(
 
     /*
     |--------------------------------------------------------------------------
+    | Write Model relation count properties
+    |--------------------------------------------------------------------------
+    |
+    | Set to false to disable writing of relation count properties to model DocBlocks.
+    |
+    | If set to true, every "x to many" relation will generate an accompanying
+    | "$relation_count" property DocBlock comment.
+    |
+    | If set to false, no such DocBlock comments will be generated.
+    |
+    */
+
+    'write_model_relation_count_properties' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Write Eloquent Model Mixins
     |--------------------------------------------------------------------------
     |

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -57,11 +57,6 @@ return array(
     |
     | Set to false to disable writing of relation count properties to model DocBlocks.
     |
-    | If set to true, every "x to many" relation will generate an accompanying
-    | "$relation_count" property DocBlock comment.
-    |
-    | If set to false, no such DocBlock comments will be generated.
-    |
     */
 
     'write_model_relation_count_properties' => true,

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -57,6 +57,7 @@ class ModelsCommand extends Command
     protected $description = 'Generate autocompletion for models';
 
     protected $write_model_magic_where;
+    protected $write_model_relation_count_properties;
     protected $properties = array();
     protected $methods = array();
     protected $write = false;
@@ -107,6 +108,8 @@ class ModelsCommand extends Command
             $this->keep_text = $this->reset = true;
         }
         $this->write_model_magic_where = $this->laravel['config']->get('ide-helper.write_model_magic_where', true);
+        $this->write_model_relation_count_properties =
+            $this->laravel['config']->get('ide-helper.write_model_relation_count_properties', true);
 
         //If filename is default and Write is not specified, ask what to do
         if (!$this->write && $filename === $this->filename && !$this->option('nowrite')) {
@@ -587,12 +590,14 @@ class ModelsCommand extends Command
                                         true,
                                         null
                                     );
-                                    $this->setProperty(
-                                        Str::snake($method) . '_count',
-                                        'int|null',
-                                        true,
-                                        false
-                                    );
+                                    if ($this->write_model_relation_count_properties) {
+                                        $this->setProperty(
+                                            Str::snake($method) . '_count',
+                                            'int|null',
+                                            true,
+                                            false
+                                        );
+                                    }
                                 } elseif ($relation === "morphTo") {
                                     // Model isn't specified because relation is polymorphic
                                     $this->setProperty(

--- a/tests/Console/ModelsCommand/MagicWhere/Models/Post.php
+++ b/tests/Console/ModelsCommand/MagicWhere/Models/Post.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\MagicWhere\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+}

--- a/tests/Console/ModelsCommand/MagicWhere/Test.php
+++ b/tests/Console/ModelsCommand/MagicWhere/Test.php
@@ -1,0 +1,150 @@
+<?php declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\MagicWhere;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+use Illuminate\Filesystem\Filesystem;
+use Mockery;
+
+class Test extends AbstractModelsCommand
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('ide-helper', [
+            'model_locations' => [
+                // This is calculated from the base_path() which points to
+                // vendor/orchestra/testbench-core/laravel
+                '/../../../../tests/Console/ModelsCommand/MagicWhere/Models',
+            ],
+            'write_model_magic_where' => false
+        ]);
+    }
+
+    public function test(): void
+    {
+        $actualContent = null;
+        $mockFilesystem = Mockery::mock(Filesystem::class);
+        $mockFilesystem
+            ->shouldReceive('get')
+            ->andReturn(file_get_contents(__DIR__ . '/Models/Post.php'))
+            ->once();
+        $mockFilesystem
+            ->shouldReceive('put')
+            ->with(
+                Mockery::any(),
+                Mockery::capture($actualContent)
+            )
+            ->andReturn(1) // Simulate we wrote _something_ to the file
+            ->once();
+
+        $this->instance(Filesystem::class, $mockFilesystem);
+
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--write' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertEmpty($tester->getDisplay());
+
+        $expectedContent = <<<'PHP'
+<?php declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\MagicWhere\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\MagicWhere\Models\Post
+ *
+ * @property integer $id
+ * @property string|null $char_nullable
+ * @property string $char_not_nullable
+ * @property string|null $string_nullable
+ * @property string $string_not_nullable
+ * @property string|null $text_nullable
+ * @property string $text_not_nullable
+ * @property string|null $medium_text_nullable
+ * @property string $medium_text_not_nullable
+ * @property string|null $long_text_nullable
+ * @property string $long_text_not_nullable
+ * @property integer|null $integer_nullable
+ * @property integer $integer_not_nullable
+ * @property integer|null $tiny_integer_nullable
+ * @property integer $tiny_integer_not_nullable
+ * @property integer|null $small_integer_nullable
+ * @property integer $small_integer_not_nullable
+ * @property integer|null $medium_integer_nullable
+ * @property integer $medium_integer_not_nullable
+ * @property integer|null $big_integer_nullable
+ * @property integer $big_integer_not_nullable
+ * @property integer|null $unsigned_integer_nullable
+ * @property integer $unsigned_integer_not_nullable
+ * @property integer|null $unsigned_tiny_integer_nullable
+ * @property integer $unsigned_tiny_integer_not_nullable
+ * @property integer|null $unsigned_small_integer_nullable
+ * @property integer $unsigned_small_integer_not_nullable
+ * @property integer|null $unsigned_medium_integer_nullable
+ * @property integer $unsigned_medium_integer_not_nullable
+ * @property integer|null $unsigned_big_integer_nullable
+ * @property integer $unsigned_big_integer_not_nullable
+ * @property float|null $float_nullable
+ * @property float $float_not_nullable
+ * @property float|null $double_nullable
+ * @property float $double_not_nullable
+ * @property string|null $decimal_nullable
+ * @property string $decimal_not_nullable
+ * @property string|null $unsigned_decimal_nullable
+ * @property string $unsigned_decimal_not_nullable
+ * @property integer|null $boolean_nullable
+ * @property integer $boolean_not_nullable
+ * @property string|null $enum_nullable
+ * @property string $enum_not_nullable
+ * @property string|null $json_nullable
+ * @property string $json_not_nullable
+ * @property string|null $jsonb_nullable
+ * @property string $jsonb_not_nullable
+ * @property string|null $date_nullable
+ * @property string $date_not_nullable
+ * @property string|null $datetime_nullable
+ * @property string $datetime_not_nullable
+ * @property string|null $datetimetz_nullable
+ * @property string $datetimetz_not_nullable
+ * @property string|null $time_nullable
+ * @property string $time_not_nullable
+ * @property string|null $timetz_nullable
+ * @property string $timetz_not_nullable
+ * @property string|null $timestamp_nullable
+ * @property string $timestamp_not_nullable
+ * @property string|null $timestamptz_nullable
+ * @property string $timestamptz_not_nullable
+ * @property integer|null $year_nullable
+ * @property integer $year_not_nullable
+ * @property mixed|null $binary_nullable
+ * @property mixed $binary_not_nullable
+ * @property string|null $uuid_nullable
+ * @property string $uuid_not_nullable
+ * @property string|null $ipaddress_nullable
+ * @property string $ipaddress_not_nullable
+ * @property string|null $macaddress_nullable
+ * @property string $macaddress_not_nullable
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @method static \Illuminate\Database\Eloquent\Builder|Post newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Post newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Post query()
+ * @mixin \Eloquent
+ */
+class Post extends Model
+{
+}
+
+PHP;
+
+        $this->assertSame($expectedContent, $actualContent);
+    }
+}

--- a/tests/Console/ModelsCommand/RelationCountProperties/Models/Post.php
+++ b/tests/Console/ModelsCommand/RelationCountProperties/Models/Post.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\RelationCountProperties\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Post extends Model
+{
+    public function relationHasMany(): HasMany
+    {
+        return $this->hasMany(Post::class);
+    }
+}

--- a/tests/Console/ModelsCommand/RelationCountProperties/Test.php
+++ b/tests/Console/ModelsCommand/RelationCountProperties/Test.php
@@ -1,0 +1,231 @@
+<?php declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\RelationCountProperties;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomCollection\Models\Simple;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Filesystem\Filesystem;
+use Mockery;
+
+class Test extends AbstractModelsCommand
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('ide-helper', [
+            'model_locations' => [
+                // This is calculated from the base_path() which points to
+                // vendor/orchestra/testbench-core/laravel
+                '/../../../../tests/Console/ModelsCommand/RelationCountProperties/Models',
+            ],
+            'write_model_relation_count_properties' => false
+        ]);
+    }
+
+    public function test(): void
+    {
+        $actualContent = null;
+        $mockFilesystem = Mockery::mock(Filesystem::class);
+        $mockFilesystem
+            ->shouldReceive('get')
+            ->andReturn(file_get_contents(__DIR__ . '/Models/Post.php'))
+            ->once();
+        $mockFilesystem
+            ->shouldReceive('put')
+            ->with(
+                Mockery::any(),
+                Mockery::capture($actualContent)
+            )
+            ->andReturn(1) // Simulate we wrote _something_ to the file
+            ->once();
+
+        $this->instance(Filesystem::class, $mockFilesystem);
+
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--write' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertEmpty($tester->getDisplay());
+
+        $expectedContent = <<<'PHP'
+<?php declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\RelationCountProperties\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\RelationCountProperties\Models\Post
+ *
+ * @property integer $id
+ * @property string|null $char_nullable
+ * @property string $char_not_nullable
+ * @property string|null $string_nullable
+ * @property string $string_not_nullable
+ * @property string|null $text_nullable
+ * @property string $text_not_nullable
+ * @property string|null $medium_text_nullable
+ * @property string $medium_text_not_nullable
+ * @property string|null $long_text_nullable
+ * @property string $long_text_not_nullable
+ * @property integer|null $integer_nullable
+ * @property integer $integer_not_nullable
+ * @property integer|null $tiny_integer_nullable
+ * @property integer $tiny_integer_not_nullable
+ * @property integer|null $small_integer_nullable
+ * @property integer $small_integer_not_nullable
+ * @property integer|null $medium_integer_nullable
+ * @property integer $medium_integer_not_nullable
+ * @property integer|null $big_integer_nullable
+ * @property integer $big_integer_not_nullable
+ * @property integer|null $unsigned_integer_nullable
+ * @property integer $unsigned_integer_not_nullable
+ * @property integer|null $unsigned_tiny_integer_nullable
+ * @property integer $unsigned_tiny_integer_not_nullable
+ * @property integer|null $unsigned_small_integer_nullable
+ * @property integer $unsigned_small_integer_not_nullable
+ * @property integer|null $unsigned_medium_integer_nullable
+ * @property integer $unsigned_medium_integer_not_nullable
+ * @property integer|null $unsigned_big_integer_nullable
+ * @property integer $unsigned_big_integer_not_nullable
+ * @property float|null $float_nullable
+ * @property float $float_not_nullable
+ * @property float|null $double_nullable
+ * @property float $double_not_nullable
+ * @property string|null $decimal_nullable
+ * @property string $decimal_not_nullable
+ * @property string|null $unsigned_decimal_nullable
+ * @property string $unsigned_decimal_not_nullable
+ * @property integer|null $boolean_nullable
+ * @property integer $boolean_not_nullable
+ * @property string|null $enum_nullable
+ * @property string $enum_not_nullable
+ * @property string|null $json_nullable
+ * @property string $json_not_nullable
+ * @property string|null $jsonb_nullable
+ * @property string $jsonb_not_nullable
+ * @property string|null $date_nullable
+ * @property string $date_not_nullable
+ * @property string|null $datetime_nullable
+ * @property string $datetime_not_nullable
+ * @property string|null $datetimetz_nullable
+ * @property string $datetimetz_not_nullable
+ * @property string|null $time_nullable
+ * @property string $time_not_nullable
+ * @property string|null $timetz_nullable
+ * @property string $timetz_not_nullable
+ * @property string|null $timestamp_nullable
+ * @property string $timestamp_not_nullable
+ * @property string|null $timestamptz_nullable
+ * @property string $timestamptz_not_nullable
+ * @property integer|null $year_nullable
+ * @property integer $year_not_nullable
+ * @property mixed|null $binary_nullable
+ * @property mixed $binary_not_nullable
+ * @property string|null $uuid_nullable
+ * @property string $uuid_not_nullable
+ * @property string|null $ipaddress_nullable
+ * @property string $ipaddress_not_nullable
+ * @property string|null $macaddress_nullable
+ * @property string $macaddress_not_nullable
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection|Post[] $relationHasMany
+ * @method static \Illuminate\Database\Eloquent\Builder|Post newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Post newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Post query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBigIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBigIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBinaryNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBinaryNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBooleanNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBooleanNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereCharNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereCharNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDateNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDateNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDatetimeNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDatetimeNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDatetimetzNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDatetimetzNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDecimalNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDecimalNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDoubleNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDoubleNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereEnumNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereEnumNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereFloatNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereFloatNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereIpaddressNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereIpaddressNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereJsonNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereJsonNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereJsonbNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereJsonbNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereLongTextNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereLongTextNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMacaddressNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMacaddressNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMediumIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMediumIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMediumTextNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMediumTextNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereSmallIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereSmallIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereStringNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereStringNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTextNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTextNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimeNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimeNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimestampNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimestampNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimestamptzNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimestamptzNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimetzNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimetzNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTinyIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTinyIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedMediumIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedMediumIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedSmallIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedSmallIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedTinyIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedTinyIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUuidNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUuidNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNullable($value)
+ * @mixin \Eloquent
+ */
+class Post extends Model
+{
+    public function relationHasMany(): HasMany
+    {
+        return $this->hasMany(Post::class);
+    }
+}
+
+PHP;
+
+        $this->assertSame($expectedContent, $actualContent);
+    }
+}


### PR DESCRIPTION
Accidentally fucked up https://github.com/barryvdh/laravel-ide-helper/pull/837 by deleting the branch or force-pushing (can't reopen), so here's a new PR.

I've rebased on top of current master, added a test for `write_model_relation_count_properties` and also added another test for `write_model_magic_where` while I was at it.

CC @mfn 