### PR TITLE
[GHA] Drop non-supported Laravel versions and simplify matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,39 +12,9 @@ jobs:
     strategy:
       matrix:
         php: [7.4, 7.3, 7.2]
-        laravel: [7.*]
-        testbench: [5.*]
+        laravel: [7.*, 6.*, 5.5.*]
         dependency-version: [prefer-lowest, prefer-stable]
-        include:
-          - laravel: 7.*
-            testbench: 5.*
-            php: 7.4
-            dependency-version: prefer-stable
-          - laravel: 6.*
-            testbench: 4.*
-            php: 7.3
-            dependency-version: prefer-stable
-          - laravel: 5.8.*
-            testbench: 3.8.*
-            php: 7.3
-            dependency-version: prefer-stable
-          - laravel: 5.7.*
-            testbench: 3.7.*
-            php: 7.2
-            dependency-version: prefer-stable
-          - laravel: 5.6.*
-            testbench: 3.6.*
-            php: 7.2
-            dependency-version: prefer-stable
-          - laravel: 5.5.*
-            testbench: 3.5.*
-            php: 7.2
-            dependency-version: prefer-stable
         exclude:
-          - laravel: 5.7.*
-            php: 7.4
-          - laravel: 5.6.*
-            php: 7.4
           - laravel: 5.5.*
             php: 7.4
 
@@ -63,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         composer remove phpro/grumphp vimeo/psalm --no-update --dev
-        composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-update --no-progress
+        composer require "laravel/framework:${{ matrix.laravel }}" --no-update --no-progress
         composer update --${{ matrix.dependency-version }} --prefer-dist --no-suggest --no-progress
 
     - name: Execute Unit Tests


### PR DESCRIPTION
## Summary
Also drop dedicated testbench version, composer can figure it out itself

https://laravel.com/docs/7.x/releases#support-policy

Only 5.5 receives security fixes until 2020-08-30,
everything else < 6 isn't supported anymore.
Therefore I dropped all versions not officially
supported.

I also find the change in the matrix more readable without having to
mentally parse a set of a lot "includes",
I think this clarifies the intent better.

This also results in more jobs are more (correctly allowed) variations are now covered.