### PR TITLE
Support database.schema.table in \Illuminate\Database\Eloquent\Model::$table

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -378,7 +378,14 @@ class ModelsCommand extends Command
 
         $database = null;
         if (strpos($table, '.')) {
-            list($database, $table) = explode('.', $table);
+            /*
+             * This adds support for when the models `$table` is either:
+             * - `database.table` => ['database', 'table']
+             *   or when a schema is given
+             * - `database.schema.table` => ['database', 'schema.table']
+             */
+            $database = strtok($table, '.');
+            $table = strtok('');
         }
 
         $columns = $schema->listTableColumns($table, $database);


### PR DESCRIPTION
## Summary

The current code handles `database.table` but fails when
`database.schema.table` is present, as it populates
`$database = 'database'; $table = 'schema';` and "drops"
 the table entirely.

There were two previous attempts for PgSQL [1] and MsSQL [2] with two
different approaches; this is yet another one with the goal to be simple
and not being too dependent on which driver is used.

Other databases don't support this feature (AFAIK) but IMHO a driver
specific check shouldn't be necessary; KISS.

### Links
- [1] https://github.com/barryvdh/laravel-ide-helper/pull/392
- [2] https://github.com/barryvdh/laravel-ide-helper/pull/781
- Fixes https://github.com/barryvdh/laravel-ide-helper/issues/780
- Fixes https://github.com/barryvdh/laravel-ide-helper/issues/483