### PR TITLE
Remove deprecated sublime option

### DIFF
--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -172,7 +172,6 @@ class GeneratorCommand extends Command
             array('write_mixins', "W", InputOption::VALUE_OPTIONAL, 'Write mixins to Laravel Model?', $writeMixins),
             array('helpers', "H", InputOption::VALUE_NONE, 'Include the helper files'),
             array('memory', "M", InputOption::VALUE_NONE, 'Use sqlite memory driver'),
-            array('sublime', "S", InputOption::VALUE_NONE, 'DEPRECATED: Use different style for SublimeText CodeIntel'),
         );
     }
 }


### PR DESCRIPTION
It has been marked as deprecated for 7 years (!) and the option isn't
used in the current code, i.e it does nothing.