### PR TITLE
Sort models found in file system

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -276,7 +276,12 @@ class ModelsCommand extends Command
             $dirs = glob($dir, GLOB_ONLYDIR);
             foreach ($dirs as $dir) {
                 if (file_exists($dir)) {
-                    foreach (ClassMapGenerator::createMap($dir) as $model => $path) {
+                    $classMap = ClassMapGenerator::createMap($dir);
+
+                    // Sort list so it's stable across different environments
+                    ksort($classMap);
+
+                    foreach ($classMap as $model => $path) {
                         $models[] = $model;
                     }
                 }


### PR DESCRIPTION
## Summary
Ensures they're always ordered / processed independent of the
environment. `ClassMapGenerator::createMap` uses symfony/finder which
itself supports sorting but this isn't used from the `ClassMapGenerator`.

We don't have tests but I tested this in a private project successfully.

### Links
- Fixes https://github.com/barryvdh/laravel-ide-helper/issues/885