### PR TITLE
Remove unnecessary version checks due to unsupported old Laravel/Lumen versions

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -128,16 +128,7 @@ class Generator
                 class_exists('Auth') && is_a('Auth', '\Illuminate\Support\Facades\Auth', true)
                 && app()->bound('auth')
             ) {
-                if (class_exists('\Illuminate\Foundation\Application')) {
-                    $authMethod = version_compare(Application::VERSION, '5.2', '>=') ? 'guard' : 'driver';
-                } else {
-                    $refClass = new ReflectionClass('\Laravel\Lumen\Application');
-                    $versionStr = $refClass->newInstanceWithoutConstructor()->version();
-                    $authMethod = strpos($versionStr, 'Lumen (5.0') === 0 ?
-                        'driver' :
-                        (strpos($versionStr, 'Lumen (5.1') === 0 ? 'driver' : 'guard');
-                }
-                $class = get_class(\Auth::$authMethod());
+                $class = get_class(\Auth::guard());
                 $this->extra['Auth'] = array($class);
                 $this->interfaces['\Illuminate\Auth\UserProviderInterface'] = $class;
             }


### PR DESCRIPTION
## Summary

- support for < L5.5 was dropped, so no need to check if it's >= Laravel 5.2
- for the same reason, the Lumen 5.0/5.1 check isn't necessary because only supporting Laravel 5.5 means we only support the Laravel 5.5 _components_ which means the minimum supported Lumen version is also 5.5 (per https://lumen.laravel.com/docs/master/releases#5.5.0 )

**TL;DR:** Nowadays we an just call `\Auth::guard()` directly and don't worry

There no tests for this, so I tested this codechange in a private Laravel project successfuly