### PR TITLE
Add the option to hide the generated datetime from the generated files

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -242,4 +242,8 @@ return array(
     */
     'include_class_docblocks' => false,
 
+    /**
+     * Hide the datetime from the generated files
+     */
+    'hide_datetime' => false,
 );

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -12,7 +12,7 @@
 
 /**
  * A helper file for Laravel, to provide autocomplete information to your IDE
- * Generated for Laravel <?= $version ?> on <?= date("Y-m-d H:i:s") ?>.
+ * Generated for Laravel <?= $version ?><?php if(!(isset($hide_datetime) && $hide_datetime)): ?> on <?= date("Y-m-d H:i:s") ?><?php endif;?>.
  *
  * This file should not be included in your code, only analyzed by your IDE!
  *
@@ -22,14 +22,14 @@
 
 <?php foreach($namespaces_by_extends_ns as $namespace => $aliases): ?>
 <?php if ($namespace == '\Illuminate\Database\Eloquent'): continue; endif; ?>
-namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
+namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
 <?php foreach($aliases as $alias): ?>
 
-    <?= trim($alias->getDocComment('    ')) ?> 
+    <?= trim($alias->getDocComment('    ')) ?>
     <?= $alias->getClassType() ?> <?= $alias->getExtendsClass() ?> {
         <?php foreach($alias->getMethods() as $method): ?>
 
-        <?= trim($method->getDocComment('        ')) ?> 
+        <?= trim($method->getDocComment('        ')) ?>
         public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
         {<?php if($method->getDeclaringClass() !== $method->getRoot()): ?>
 
@@ -41,23 +41,23 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
             <?php endif?>
             <?= $method->shouldReturn() ? 'return ': '' ?><?= $method->getRootMethodCall() ?>;
         }
-        <?php endforeach; ?> 
+        <?php endforeach; ?>
     }
-<?php endforeach; ?> 
+<?php endforeach; ?>
 }
 
 <?php endforeach; ?>
 
 <?php foreach($namespaces_by_alias_ns as $namespace => $aliases): ?>
-namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> { 
+namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
 <?php foreach($aliases as $alias): ?>
 
     <?= $alias->getClassType() ?> <?= $alias->getShortName() ?> extends <?= $alias->getExtends() ?> {<?php if ($alias->getExtendsNamespace() == '\Illuminate\Database\Eloquent'): ?>
-        <?php foreach($alias->getMethods() as $method): ?> 
-            <?= trim($method->getDocComment('            ')) ?> 
+        <?php foreach($alias->getMethods() as $method): ?>
+            <?= trim($method->getDocComment('            ')) ?>
             public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
             {<?php if($method->getDeclaringClass() !== $method->getRoot()): ?>
-    
+
                 //Method inherited from <?= $method->getDeclaringClass() ?>
                 <?php endif; ?>
 
@@ -68,14 +68,14 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
             }
         <?php endforeach; ?>
 <?php endif; ?>}
-<?php endforeach; ?> 
+<?php endforeach; ?>
 }
 
 <?php endforeach; ?>
 
 <?php if($helpers): ?>
 namespace {
-<?= $helpers ?> 
+<?= $helpers ?>
 }
 <?php endif; ?>
 

--- a/resources/views/meta.php
+++ b/resources/views/meta.php
@@ -6,7 +6,9 @@ namespace PHPSTORM_META {
 
    /**
     * PhpStorm Meta file, to provide autocomplete information for PhpStorm
+<?php if(!(isset($hide_datetime) && $hide_datetime)): ?>
     * Generated on <?= date("Y-m-d H:i:s") ?>.
+<?php endif; ?>
     *
     * @author Barry vd. Heuvel <barryvdh@gmail.com>
     * @see https://github.com/barryvdh/laravel-ide-helper

--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -110,6 +110,7 @@ class MetaCommand extends Command
           'bindings' => $bindings,
           'methods' => $this->methods,
           'factories' => $factories,
+          'hide_datetime' => $this->config->get('ide-helper.hide_datetime', false)
         ])->render();
 
         $filename = $this->option('filename');

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -88,6 +88,7 @@ class Generator
             ->with('version', $app->version())
             ->with('include_fluent', $this->config->get('ide-helper.include_fluent', true))
             ->with('factories', $this->config->get('ide-helper.include_factory_builders') ? Factories::all() : [])
+            ->with('hide_datetime', $this->config->get('ide-helper.hide_datetime', false))
             ->render();
     }
 


### PR DESCRIPTION
On some projects I want to be sure that we didn't miss anything in the generated files. That is why I prefer to run the generate commands in the pipeline.

Because of the timestamps the files are always changed, with this PR it is possible to hide the datetime from the generated files so it is possible to see automated if there is any change found and a new file need to be committed.