### PR TITLE
Add better support for macros and mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Support Laravel 8 [\#1022 / barryvdh](https://github.com/barryvdh/laravel-ide-helper/pull/1022)
 - Add option to force usage of FQN [\#1031 / edvordo](https://github.com/barryvdh/laravel-ide-helper/pull/1031)
+- Add support for macros of all macroable classes [\#1006 / domkrm](https://github.com/barryvdh/laravel-ide-helper/pull/1006)
 
 2020-08-11, 2.8.0
 -----------------

--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ You can use an in-memory SQLite driver by adding the `-M` option.
 You can choose to include helper files. This is not enabled by default, but you can override it with the `--helpers (-H)` option.
 The `Illuminate/Support/helpers.php` is already set up, but you can add/remove your own files in the config file.
 
+### Automatic PHPDoc generation for macros and mixins
+
+This package can generate PHPDocs for macros and mixins which will be added to the `_ide_helper.php` file.
+
+But this only works if you use type hinting when declaring a macro.
+
+```php
+Str::macro('concat', function(string $str1, string $str2) : string {
+    return $str1 . $str2;
+});
+```
+
 ### Automatic PHPDocs for models
 
 If you don't want to write your properties yourself, you can use the command `php artisan ide-helper:models` to generate

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -3,6 +3,7 @@
 namespace Barryvdh\LaravelIdeHelper;
 
 use Barryvdh\Reflection\DocBlock;
+use Barryvdh\Reflection\DocBlock\Tag;
 
 class Macro extends Method
 {
@@ -30,7 +31,26 @@ class Macro extends Method
      */
     protected function initPhpDoc($method)
     {
-        $this->phpdoc = new DocBlock($method);
+        $this->phpdoc = new DocBlock('/** */');
+
+        // Add macro parameters
+        foreach ($method->getParameters() as $parameter) {
+            $type = $parameter->hasType() ? $parameter->getType()->getName() : 'mixed';
+            $type .= $parameter->hasType() && $parameter->getType()->allowsNull() ? '|null' : '';
+
+            $name = $parameter->isVariadic() ? '...' : '';
+            $name .= '$' . $parameter->getName();
+
+            $this->phpdoc->appendTag(Tag::createInstance("@param {$type} {$name}"));
+        }
+
+        // Add macro return type
+        if ($method->hasReturnType()) {
+            $type = $method->getReturnType()->getName();
+            $type .= $method->getReturnType()->allowsNull() ? '|null' : '';
+
+            $this->phpdoc->appendTag(Tag::createInstance("@return {$type}"));
+        }
     }
 
     /**


### PR DESCRIPTION
I have added macro support for all macroable classes, not only the alias classes.
But this only works if the macros are declared in any loaded service provider and type hinting is used.
Also no description is possible, only parameter and return types.