### PR TITLE
Fix typos; Optimise if-else branches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     ],
     "require": {
         "php": ">=7.2",
+        "ext-json": "*",
         "barryvdh/reflection-docblock": "^2.0.6",
         "composer/composer": "^1.6 || ^2.0@dev",
         "doctrine/dbal": "~2.3",

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -85,46 +85,47 @@ class GeneratorCommand extends Command
             $this->error(
                 'Error generating IDE Helper: first delete your compiled file (php artisan clear-compiled)'
             );
+            return;
+        }
+
+        $filename = $this->argument('filename');
+        $format = $this->option('format');
+
+        // Strip the php extension
+        if (substr($filename, -4, 4) === '.php') {
+            $filename = substr($filename, 0, -4);
+        }
+
+        $filename .= '.' . $format;
+
+        if ($this->option('memory')) {
+            $this->useMemoryDriver();
+        }
+
+
+        $helpers = '';
+        if ($this->option('helpers') || ($this->config->get('ide-helper.include_helpers'))) {
+            foreach ($this->config->get('ide-helper.helper_files', array()) as $helper) {
+                if (file_exists($helper)) {
+                    $helpers .= str_replace(array('<?php', '?>'), '', $this->files->get($helper));
+                }
+            }
         } else {
-            $filename = $this->argument('filename');
-            $format = $this->option('format');
-
-            // Strip the php extension
-            if (substr($filename, -4, 4) == '.php') {
-                $filename = substr($filename, 0, -4);
-            }
-
-            $filename .= '.' . $format;
-
-            if ($this->option('memory')) {
-                $this->useMemoryDriver();
-            }
-
-
             $helpers = '';
-            if ($this->option('helpers') || ($this->config->get('ide-helper.include_helpers'))) {
-                foreach ($this->config->get('ide-helper.helper_files', array()) as $helper) {
-                    if (file_exists($helper)) {
-                        $helpers .= str_replace(array('<?php', '?>'), '', $this->files->get($helper));
-                    }
-                }
-            } else {
-                $helpers = '';
+        }
+
+        $generator = new Generator($this->config, $this->view, $this->getOutput(), $helpers);
+        $content = $generator->generate($format);
+        $written = $this->files->put($filename, $content);
+
+        if ($written !== false) {
+            $this->info("A new helper file was written to $filename");
+
+            if ($this->option('write_mixins')) {
+                Eloquent::writeEloquentModelHelper($this, $this->files);
             }
-
-            $generator = new Generator($this->config, $this->view, $this->getOutput(), $helpers);
-            $content = $generator->generate($format);
-            $written = $this->files->put($filename, $content);
-
-            if ($written !== false) {
-                $this->info("A new helper file was written to $filename");
-
-                if ($this->option('write_mixins')) {
-                    Eloquent::writeEloquentModelHelper($this, $this->files);
-                }
-            } else {
-                $this->error("The helper file could not be created at $filename");
-            }
+        } else {
+            $this->error("The helper file could not be created at $filename");
         }
     }
 

--- a/src/Eloquent.php
+++ b/src/Eloquent.php
@@ -85,25 +85,29 @@ class Eloquent
         }
 
         $filename = $reflection->getFileName();
-        if ($filename) {
-            $contents = $files->get($filename);
-            if ($contents) {
-                $count    = 0;
-                $contents = str_replace($originalDoc, $docComment, $contents, $count);
-                if ($count > 0) {
-                    if ($files->put($filename, $contents)) {
-                        $command->info('Wrote expected docblock to ' . $filename);
-                    } else {
-                        $command->error('File write failed to ' . $filename);
-                    }
-                } else {
-                    $command->error('Content did not change ' . $contents);
-                }
-            } else {
-                $command->error('No file contents found ' . $filename);
-            }
-        } else {
+        if (!$filename) {
             $command->error('Filename not found ' . $class);
+            return;
         }
+
+        $contents = $files->get($filename);
+        if (!$contents) {
+            $command->error('No file contents found ' . $filename);
+            return;
+        }
+
+        $count = 0;
+        $contents = str_replace($originalDoc, $docComment, $contents, $count);
+        if ($count <= 0) {
+            $command->error('Content did not change ' . $contents);
+            return;
+        }
+
+        if (!$files->put($filename, $contents)) {
+            $command->error('File write failed to ' . $filename);
+            return;
+        }
+
+        $command->info('Wrote expected docblock to ' . $filename);
     }
 }

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -3,7 +3,6 @@
 namespace Barryvdh\LaravelIdeHelper;
 
 use Barryvdh\Reflection\DocBlock;
-use Barryvdh\Reflection\DocBlock\Tag;
 
 class Macro extends Method
 {

--- a/src/Method.php
+++ b/src/Method.php
@@ -251,35 +251,37 @@ class Method
      */
     protected function normalizeReturn(DocBlock $phpdoc)
     {
-        //Get the return type and adjust them for beter autocomplete
+        //Get the return type and adjust them for better autocomplete
         $returnTags = $phpdoc->getTagsByName('return');
-        if ($returnTags) {
-            /** @var ReturnTag $tag */
-            $tag = reset($returnTags);
-            // Get the expanded type
-            $returnValue = $tag->getType();
 
-            // Replace the interfaces
-            foreach ($this->interfaces as $interface => $real) {
-                $returnValue = str_replace($interface, $real, $returnValue);
-            }
-
-            // Set the changed content
-            $tag->setContent($returnValue . ' ' . $tag->getDescription());
-            $this->return = $returnValue;
-
-            if ($tag->getType() === '$this') {
-                Str::contains($this->root, Builder::class)
-                    ? $tag->setType($this->root . '|static')
-                    : $tag->setType($this->root);
-            }
-        } else {
+        if (count($returnTags) === 0) {
             $this->return = null;
+            return;
+        }
+
+        /** @var ReturnTag $tag */
+        $tag = reset($returnTags);
+        // Get the expanded type
+        $returnValue = $tag->getType();
+
+        // Replace the interfaces
+        foreach ($this->interfaces as $interface => $real) {
+            $returnValue = str_replace($interface, $real, $returnValue);
+        }
+
+        // Set the changed content
+        $tag->setContent($returnValue . ' ' . $tag->getDescription());
+        $this->return = $returnValue;
+
+        if ($tag->getType() === '$this') {
+            Str::contains($this->root, Builder::class)
+                ? $tag->setType($this->root . '|static')
+                : $tag->setType($this->root);
         }
     }
 
     /**
-     * Convert keywwords that are incorrect.
+     * Convert keywords that are incorrect.
      *
      * @param  string $string
      * @return string
@@ -311,11 +313,11 @@ class Method
      * Get the parameters and format them correctly
      *
      * @param  \ReflectionMethod $method
-     * @return array
+     * @return void
      */
     public function getParameters($method)
     {
-        //Loop through the default values for paremeters, and make the correct output string
+        //Loop through the default values for parameters, and make the correct output string
         $params = array();
         $paramsWithDefault = array();
         foreach ($method->getParameters() as $param) {
@@ -366,9 +368,9 @@ class Method
             if (strpos($phpdoc->getText(), '{@inheritdoc}') !== false) {
                 //Not at the end yet, try another parent/interface..
                 return $this->getInheritDoc($method);
-            } else {
-                return $phpdoc;
             }
+
+            return $phpdoc;
         }
     }
 }


### PR DESCRIPTION
This PR is cleaning low hanging fruits to bring it up to date:
- Correct typos
- Optimise if-else branches to reduce indentation
- Remove Docblocks for functions which contain type definitions.
- Cleanup unused params and namespace imports

Please feel free to comment and suggest other approaches.