### PR TITLE
[README] Be clear that models require FQN

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The existing PHPDoc is replaced, or added if not found.
 With the `--reset (-R)` option, the existing PHPDocs are ignored, and only the newly found columns/relations are saved as PHPDocs.
 
 ```bash
-php artisan ide-helper:models Post
+php artisan ide-helper:models "App\Models\Post"
 ```
 
 ```php
@@ -154,7 +154,7 @@ php artisan ide-helper:models Post
 By default, models in `app/models` are scanned. The optional argument tells what models to use (also outside app/models).
 
 ```bash
-php artisan ide-helper:models Post User
+php artisan ide-helper:models "App\Models\Post" "App\Models\User"
 ```
 
 You can also scan a different directory, using the `--dir` option (relative from the base path):
@@ -168,19 +168,17 @@ You can publish the config file (`php artisan vendor:publish`) and set the defau
 Models can be ignored using the `--ignore (-I)` option
 
 ```bash
-php artisan ide-helper:models --ignore="Post,User"
+php artisan ide-helper:models --ignore="App\Models\Post,App\Models\User"
 ```
 
 Or can be ignored by setting the `ignored_models` config
 
 ```php
 'ignored_models' => [
-    Post::class,
+    App\Post::class,
     Api\User::class
 ],
 ```
-
-> Note: With namespaces, wrap your model name in double-quotes (`"`): `php artisan ide-helper:models "API\User"`, or escape the slashes (`Api\\User`).
 
 #### Magic `where*` methods
 


### PR DESCRIPTION
## Summary
I've tested this and yes, it *always* requires a FQN.

Therefore I removed the extra note regarding namespace/wrapping because
even by default Laravel has the `App\` namesapce, which requires this.

Fixes https://github.com/barryvdh/laravel-ide-helper/issues/995