### PR TITLE
[TESTS] Ensure output mocking is disabled so we can actually catch the output 😅

### DIFF
--- a/tests/Console/ModelsCommand/CustomCollection/Test.php
+++ b/tests/Console/ModelsCommand/CustomCollection/Test.php
@@ -51,7 +51,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/CustomDate/Test.php
+++ b/tests/Console/ModelsCommand/CustomDate/Test.php
@@ -67,7 +67,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdoc/Test.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdoc/Test.php
@@ -50,7 +50,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdocCamel/Test.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdocCamel/Test.php
@@ -52,7 +52,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdocFinal/Test.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdocFinal/Test.php
@@ -50,7 +50,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Test.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Test.php
@@ -54,7 +54,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/Test.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/Test.php
@@ -50,7 +50,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Model information was written to _ide_helper_models.php', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/Getter/Test.php
+++ b/tests/Console/ModelsCommand/Getter/Test.php
@@ -50,7 +50,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/Ignored/Test.php
+++ b/tests/Console/ModelsCommand/Ignored/Test.php
@@ -55,7 +55,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/Interfaces/Test.php
+++ b/tests/Console/ModelsCommand/Interfaces/Test.php
@@ -47,7 +47,7 @@ final class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Model information was written to _ide_helper_models.php', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Test.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Test.php
@@ -61,7 +61,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/MagicWhere/Test.php
+++ b/tests/Console/ModelsCommand/MagicWhere/Test.php
@@ -51,8 +51,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
-
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/PHPStormNoInspection/Test.php
+++ b/tests/Console/ModelsCommand/PHPStormNoInspection/Test.php
@@ -52,7 +52,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 
@@ -83,7 +83,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/RelationCountProperties/Test.php
+++ b/tests/Console/ModelsCommand/RelationCountProperties/Test.php
@@ -53,8 +53,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
-
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/Relations/Test.php
+++ b/tests/Console/ModelsCommand/Relations/Test.php
@@ -50,7 +50,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/ResetAndSmartReset/Test.php
+++ b/tests/Console/ModelsCommand/ResetAndSmartReset/Test.php
@@ -50,7 +50,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 
@@ -81,7 +81,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 
@@ -112,7 +112,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/Console/ModelsCommand/SoftDeletes/Test.php
+++ b/tests/Console/ModelsCommand/SoftDeletes/Test.php
@@ -50,7 +50,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertEmpty($tester->getDisplay());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
         $this->assertMatchesPhpSnapshot($actualContent);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Barryvdh\LaravelIdeHelper\Tests;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\OutputStyle;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use Spatie\Snapshots\MatchesSnapshots;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -29,6 +30,9 @@ abstract class TestCase extends BaseTestCase
      */
     protected function runCommand(Command $command, array $arguments = [], array $interactiveInput = []): CommandTester
     {
+        // TODO: once Laravel 5.5 is dropped, call `$this->withoutMockingConsoleOutput()` instead
+        $this->app->offsetUnset(OutputStyle::class);
+
         $command->setLaravel($this->app);
 
         $tester = new CommandTester($command);


### PR DESCRIPTION
Discovered via https://github.com/barryvdh/laravel-ide-helper/pull/1017#issuecomment-679318764

This only happens if you run an artisan command _before_ `runCommand`,
but since every of these tests performs migrations, using artisan,
the mocked output instance is left behind and also affected us.

The call added in `runCommand` explicitly unregisters
`\Illuminate\Console\OutputStyle` and thus also throwing away possibly
mocked versions.