### PR TITLE
Avoid duplicate tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,14 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "*"
+  schedule:
+  - cron: '0 0 * * *'
 
 jobs:
   php-tests:


### PR DESCRIPTION
Run on push to master only, not other ones (avoids double runs when pushing to a separate branch)