### PR TITLE
Make createLocalViewFactory compatible with Laravel 8

### DIFF
--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -15,6 +15,7 @@ use Barryvdh\LaravelIdeHelper\Console\EloquentCommand;
 use Barryvdh\LaravelIdeHelper\Console\GeneratorCommand;
 use Barryvdh\LaravelIdeHelper\Console\MetaCommand;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Engines\PhpEngine;
@@ -116,7 +117,11 @@ class IdeHelperServiceProvider extends ServiceProvider
     {
         $resolver = new EngineResolver();
         $resolver->register('php', function () {
-            return new PhpEngine();
+            if ((int) Application::VERSION < 8) {
+                return new PhpEngine();
+            }
+
+            return new PhpEngine($this->app['files']);
         });
         $finder = new FileViewFinder($this->app['files'], [__DIR__ . '/../resources/views']);
         $factory = new Factory($resolver, $finder, $this->app['events']);

--- a/tests/Console/MetaCommand/MetaCommandTest.php
+++ b/tests/Console/MetaCommand/MetaCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\MetaCommand;
+
+use Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider;
+use Barryvdh\LaravelIdeHelper\Tests\TestCase;
+use Illuminate\Filesystem\Filesystem;
+use Mockery\MockInterface;
+
+class MetaCommandTest extends TestCase
+{
+    public function testCommand(): void
+    {
+        $this->mockFilesystem();
+
+        /** @var Filesystem|MockInterface $mockFileSystem */
+        $mockFileSystem = $this->app->make(Filesystem::class);
+        $this->instance('files', $mockFileSystem);
+
+        $mockFileSystem
+            ->shouldReceive('getRequire')
+            ->andReturnUsing(function ($__path, $__data) {
+                return (static function () use ($__path, $__data) {
+                    extract($__data, EXTR_SKIP);
+
+                    return require $__path;
+                })();
+            });
+
+        $this->artisan('ide-helper:meta');
+
+        // We're not testing the whole file, just some basic structure elements
+        self::assertStringContainsString("namespace PHPSTORM_META {\n", $this->mockFilesystemOutput);
+        self::assertStringContainsString("PhpStorm Meta file, to provide autocomplete information for PhpStorm\n", $this->mockFilesystemOutput);
+        self::assertStringContainsString('override(', $this->mockFilesystemOutput);
+    }
+
+    /**
+     * Get package providers.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     *
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        return [IdeHelperServiceProvider::class];
+    }
+}

--- a/tests/Console/ModelsCommand/AbstractModelsCommand.php
+++ b/tests/Console/ModelsCommand/AbstractModelsCommand.php
@@ -7,13 +7,9 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider;
 use Barryvdh\LaravelIdeHelper\Tests\SnapshotPhpDriver;
 use Barryvdh\LaravelIdeHelper\Tests\TestCase;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 abstract class AbstractModelsCommand extends TestCase
 {
-    protected $mockFilesystemOutput;
-
     protected function setUp(): void
     {
         parent::setUp();
@@ -55,33 +51,6 @@ abstract class AbstractModelsCommand extends TestCase
 
         // Don't override integer -> int for tests
         $config->set('ide-helper.type_overrides', []);
-    }
-
-    protected function mockFilesystem()
-    {
-        $this->mockOutput = '';
-
-        $mockFilesystem = Mockery::mock(Filesystem::class);
-
-        $mockFilesystem
-            ->shouldReceive('get')
-            ->andReturnUsing(function ($file) {
-                return file_get_contents($file);
-            });
-
-        $mockFilesystem
-            ->shouldReceive('put')
-            ->with(
-                Mockery::any(),
-                Mockery::any()
-            )
-            ->andReturnUsing(function ($path, $contents) {
-                $this->mockFilesystemOutput .= $contents;
-
-                return strlen($contents);
-            });
-
-        $this->instance(Filesystem::class, $mockFilesystem);
     }
 
     protected function assertMatchesMockedSnapshot()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Barryvdh\LaravelIdeHelper\Tests;
 
 use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Mockery;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use Spatie\Snapshots\MatchesSnapshots;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -12,6 +14,8 @@ use Symfony\Component\Console\Tester\CommandTester;
 abstract class TestCase extends BaseTestCase
 {
     use MatchesSnapshots;
+
+    protected $mockFilesystemOutput;
 
     /**
      * The `CommandTester` is directly returned, use methods like
@@ -49,5 +53,31 @@ abstract class TestCase extends BaseTestCase
     protected function assertMatchesTxtSnapshot(?string $actualContent)
     {
         $this->assertMatchesSnapshot($actualContent, new SnapshotTxtDriver());
+    }
+
+    protected function mockFilesystem()
+    {
+        $mockFilesystem = Mockery::mock(Filesystem::class);
+
+        $mockFilesystem
+            ->shouldReceive('get')
+            ->andReturnUsing(function ($file) {
+                return file_get_contents($file);
+            });
+
+        $mockFilesystem
+            ->shouldReceive('put')
+            ->with(
+                Mockery::any(),
+                Mockery::any()
+            )
+            ->andReturnUsing(function ($path, $contents) {
+                $this->mockFilesystemOutput .= $contents;
+
+                return strlen($contents);
+            });
+
+        $this->instance(Filesystem::class, $mockFilesystem);
+        $this->instance('files', $mockFilesystem);
     }
 }


### PR DESCRIPTION
## Summary
- Make createLocalViewFactory compatible with Laravel 8
- move `mockFilesystem` up so we can use it in other tests
- add a (really basic) test for `ide-helper:meta`
### Links
- Fixes https://github.com/barryvdh/laravel-ide-helper/issues/1024