### PR TITLE
Improve gitignore a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-build
-vendor
-composer.lock
-.idea
 .phpunit.result.cache
+
+/.idea
+/composer.lock
+/vendor


### PR DESCRIPTION
- `build` isn't used AFAIK?
- add `/` prefix were we know they're only expected to be in the root anyway
  except `.phpunit.result.cache` which may appear anywhere it's run from