### PR TITLE
[CODESTYLE] Replace phpcs with php-cs-fixer

### DIFF
--- a/.github/workflows/fix-code-style.yml
+++ b/.github/workflows/fix-code-style.yml
@@ -23,15 +23,10 @@ jobs:
           tools: composer:v2
 
       - name: Install dependencies
-        run: |
-          composer remove phpro/grumphp vimeo/psalm --no-update --dev
-          composer update --prefer-dist --no-progress
+        run: composer update --prefer-dist --no-progress
 
       - run: composer fix-style
         continue-on-error: true
-
-      # Revert manual modifications so they don't get commited 💥
-      - run: git checkout -- composer.json
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .phpunit.result.cache
 
 /.idea
+/.php_cs
+/.php_cs.cache
 /composer.lock
 /vendor

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /.idea
 /.php_cs
 /.php_cs.cache
+/.php_cs.tests.cache
 /composer.lock
 /vendor

--- a/.php_cs.common.php
+++ b/.php_cs.common.php
@@ -53,4 +53,5 @@ return [
     'space_after_semicolon' => true,
     'trailing_comma_in_multiline_array' => true,
     'trim_array_spaces' => true,
+    'unary_operator_spaces' => true,
 ];

--- a/.php_cs.common.php
+++ b/.php_cs.common.php
@@ -47,6 +47,7 @@ return [
     'array_syntax' => [
         'syntax' => 'short',
     ],
+    'fully_qualified_strict_types' => true,
     'no_unused_imports' => true,
     'single_quote' => true,
 ];

--- a/.php_cs.common.php
+++ b/.php_cs.common.php
@@ -47,6 +47,9 @@ return [
     'array_syntax' => [
         'syntax' => 'short',
     ],
+    'concat_space' => [
+        'spacing' => 'one',
+    ],
     'fully_qualified_strict_types' => true,
     'native_function_invocation' => [
         'include' => [],

--- a/.php_cs.common.php
+++ b/.php_cs.common.php
@@ -52,4 +52,5 @@ return [
     'single_quote' => true,
     'space_after_semicolon' => true,
     'trailing_comma_in_multiline_array' => true,
+    'trim_array_spaces' => true,
 ];

--- a/.php_cs.common.php
+++ b/.php_cs.common.php
@@ -54,4 +54,5 @@ return [
     'trailing_comma_in_multiline_array' => true,
     'trim_array_spaces' => true,
     'unary_operator_spaces' => true,
+    'whitespace_after_comma_in_array' => true,
 ];

--- a/.php_cs.common.php
+++ b/.php_cs.common.php
@@ -50,4 +50,5 @@ return [
     'fully_qualified_strict_types' => true,
     'no_unused_imports' => true,
     'single_quote' => true,
+    'space_after_semicolon' => true,
 ];

--- a/.php_cs.common.php
+++ b/.php_cs.common.php
@@ -51,4 +51,5 @@ return [
     'no_unused_imports' => true,
     'single_quote' => true,
     'space_after_semicolon' => true,
+    'trailing_comma_in_multiline_array' => true,
 ];

--- a/.php_cs.common.php
+++ b/.php_cs.common.php
@@ -1,0 +1,52 @@
+<?php
+
+// Share common rules between non-test and test files
+return [
+    // PSR12 from https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4943
+    '@PSR2' => true,
+    'blank_line_after_opening_tag' => true,
+    'braces' => [
+        // Not-yet-implemented
+        // 'allow_single_line_anonymous_class_with_empty_body' => true,
+    ],
+    'compact_nullable_typehint' => true,
+    'declare_equal_normalize' => true,
+    'lowercase_cast' => true,
+    'lowercase_static_reference' => true,
+    'new_with_braces' => true,
+    'no_blank_lines_after_class_opening' => true,
+    'no_leading_import_slash' => true,
+    'no_whitespace_in_blank_line' => true,
+    'ordered_class_elements' => [
+        'order' => [
+            'use_trait',
+        ],
+    ],
+    'ordered_imports' => [
+        'imports_order' => [
+            'class',
+            'function',
+            'const',
+        ],
+        'sort_algorithm' => 'alpha',
+    ],
+    'return_type_declaration' => true,
+    'short_scalar_cast' => true,
+    'single_blank_line_before_namespace' => true,
+    'single_trait_insert_per_statement' => true,
+    'ternary_operator_spaces' => true,
+    'visibility_required' => [
+        'elements' => [
+            'const',
+            'method',
+            'property',
+        ],
+    ],
+
+    // Further quality-of-life improvements
+    'array_syntax' => [
+        'syntax' => 'short',
+    ],
+    'no_unused_imports' => true,
+    'single_quote' => true,
+];

--- a/.php_cs.common.php
+++ b/.php_cs.common.php
@@ -48,6 +48,10 @@ return [
         'syntax' => 'short',
     ],
     'fully_qualified_strict_types' => true,
+    'native_function_invocation' => [
+        'include' => [],
+        'strict' => true,
+    ],
     'no_unused_imports' => true,
     'single_quote' => true,
     'space_after_semicolon' => true,

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -8,6 +8,45 @@ $finder = PhpCsFixer\Finder::create()
 return PhpCsFixer\Config::create()
     ->setFinder($finder)
     ->setRules([
+        // PSR12 from https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4943
         '@PSR2' => true,
+        'blank_line_after_opening_tag' => true,
+        'braces' => [
+            // Not-yet-implemented
+            // 'allow_single_line_anonymous_class_with_empty_body' => true,
+        ],
+        'compact_nullable_typehint' => true,
+        'declare_equal_normalize' => true,
+        'lowercase_cast' => true,
+        'lowercase_static_reference' => true,
+        'new_with_braces' => true,
+        'no_blank_lines_after_class_opening' => true,
+        'no_leading_import_slash' => true,
+        'no_whitespace_in_blank_line' => true,
+        'ordered_class_elements' => [
+            'order' => [
+                'use_trait',
+            ],
+        ],
+        'ordered_imports' => [
+            'imports_order' => [
+                'class',
+                'function',
+                'const',
+            ],
+            'sort_algorithm' => 'none',
+        ],
+        'return_type_declaration' => true,
+        'short_scalar_cast' => true,
+        'single_blank_line_before_namespace' => true,
+        'single_trait_insert_per_statement' => true,
+        'ternary_operator_spaces' => true,
+        'visibility_required' => [
+            'elements' => [
+                'const',
+                'method',
+                'property',
+            ],
+        ],
     ])
     ->setRiskyAllowed(true);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -34,7 +34,7 @@ return PhpCsFixer\Config::create()
                 'function',
                 'const',
             ],
-            'sort_algorithm' => 'none',
+            'sort_algorithm' => 'alpha',
         ],
         'return_type_declaration' => true,
         'short_scalar_cast' => true,

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -48,5 +48,8 @@ return PhpCsFixer\Config::create()
                 'property',
             ],
         ],
+
+        // Further quality-of-life improvements
+        'no_unused_imports' => true,
     ])
     ->setRiskyAllowed(true);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -54,5 +54,6 @@ return PhpCsFixer\Config::create()
             'syntax' => 'short',
         ],
         'no_unused_imports' => true,
+        'single_quote' => true,
     ])
     ->setRiskyAllowed(true);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,13 @@
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->exclude('__snapshots__');
+
+return PhpCsFixer\Config::create()
+    ->setFinder($finder)
+    ->setRules([
+        '@PSR2' => true,
+    ])
+    ->setRiskyAllowed(true);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -50,6 +50,9 @@ return PhpCsFixer\Config::create()
         ],
 
         // Further quality-of-life improvements
+        'array_syntax' => [
+            'syntax' => 'short',
+        ],
         'no_unused_imports' => true,
     ])
     ->setRiskyAllowed(true);

--- a/.php_cs.tests.php
+++ b/.php_cs.tests.php
@@ -7,6 +7,14 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = require __DIR__ . '/.php_cs.common.php';
 
+// Additional rules for tests
+$config = array_merge(
+    $config,
+    [
+        'declare_strict_types' => true,
+    ]
+);
+
 return PhpCsFixer\Config::create()
     ->setFinder($finder)
     ->setRules($config)

--- a/.php_cs.tests.php
+++ b/.php_cs.tests.php
@@ -2,8 +2,8 @@
 require __DIR__ . '/vendor/autoload.php';
 
 $finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__)
-    ->exclude('tests');
+    ->in(__DIR__ . '/tests')
+    ->exclude('__snapshots__');
 
 $config = require __DIR__ . '/.php_cs.common.php';
 
@@ -11,4 +11,4 @@ return PhpCsFixer\Config::create()
     ->setFinder($finder)
     ->setRules($config)
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__ . '/.php_cs.cache');
+    ->setCacheFile(__DIR__ . '/.php_cs.tests.cache');

--- a/composer.json
+++ b/composer.json
@@ -68,8 +68,8 @@
     "prefer-stable": true,
     "scripts": {
         "analyze": "psalm",
-        "check-style": "phpcs -p --standard=PSR12 config/ resources/ src/ tests/ '--ignore=*__snapshots_*'",
-        "fix-style": "phpcbf -p --standard=PSR12 config/ resources/ src/ tests/ '--ignore=*__snapshots_*'",
+        "check-style": "php-cs-fixer fix --diff --diff-format=udiff --dry-run",
+        "fix-style": "php-cs-fixer fix",
         "test": "phpunit",
         "test-regenerate": "phpunit -d --update-snapshots"
     }

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "phpdocumentor/type-resolver": "^1.1.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2",
         "illuminate/config": "^6 || ^7 || ^8",
         "illuminate/view": "^6 || ^7 || ^8",
         "mockery/mockery": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
         "orchestra/testbench": "^4 || ^5 || ^6",
         "phpro/grumphp": "^0.19.0",
         "spatie/phpunit-snapshot-assertions": "^1.4 || ^2.2 || ^3",
-        "squizlabs/php_codesniffer": "^3.5",
         "vimeo/psalm": "^3.12"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -68,8 +68,14 @@
     "prefer-stable": true,
     "scripts": {
         "analyze": "psalm",
-        "check-style": "php-cs-fixer fix --diff --diff-format=udiff --dry-run",
-        "fix-style": "php-cs-fixer fix",
+        "check-style": [
+            "php-cs-fixer fix --diff --diff-format=udiff --dry-run",
+            "php-cs-fixer fix --diff --diff-format=udiff --dry-run --config=.php_cs.tests.php"
+        ],
+        "fix-style": [
+            "php-cs-fixer fix",
+            "php-cs-fixer fix --config=.php_cs.tests.php"
+        ],
         "test": "phpunit",
         "test-regenerate": "phpunit -d --update-snapshots"
     }

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -1,6 +1,6 @@
 <?php
 
-return array(
+return [
 
     /*
     |--------------------------------------------------------------------------
@@ -98,9 +98,9 @@ return array(
 
     'include_helpers' => false,
 
-    'helper_files' => array(
+    'helper_files' => [
         base_path() . '/vendor/laravel/framework/src/Illuminate/Support/helpers.php',
-    ),
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -115,9 +115,9 @@ return array(
     |
     */
 
-    'model_locations' => array(
+    'model_locations' => [
         'app',
-    ),
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -128,9 +128,9 @@ return array(
     |
     */
 
-    'ignored_models' => array(
+    'ignored_models' => [
 
-    ),
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -141,12 +141,12 @@ return array(
     |
     */
 
-    'extra' => array(
-        'Eloquent' => array('Illuminate\Database\Eloquent\Builder', 'Illuminate\Database\Query\Builder'),
-        'Session' => array('Illuminate\Session\Store'),
-    ),
+    'extra' => [
+        'Eloquent' => ['Illuminate\Database\Eloquent\Builder', 'Illuminate\Database\Query\Builder'],
+        'Session' => ['Illuminate\Session\Store'],
+    ],
 
-    'magic' => array(),
+    'magic' => [],
 
     /*
     |--------------------------------------------------------------------------
@@ -158,9 +158,9 @@ return array(
     |
     */
 
-    'interfaces' => array(
+    'interfaces' => [
 
-    ),
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -188,9 +188,9 @@ return array(
     |  ),
     |
     */
-    'custom_db_types' => array(
+    'custom_db_types' => [
 
-    ),
+    ],
 
     /*
      |--------------------------------------------------------------------------
@@ -226,10 +226,10 @@ return array(
     | Cast the given "real type" to the given "type".
     |
     */
-    'type_overrides' => array(
+    'type_overrides' => [
         'integer' => 'int',
         'boolean' => 'bool',
-    ),
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -242,4 +242,4 @@ return array(
     */
     'include_class_docblocks' => false,
 
-);
+];

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -5,7 +5,7 @@ grumphp:
             triggered_by: [php]
             metadata:
                 task: composer_script
-        phpcs:
+        phpcsfixer:
             script: check-style
             triggered_by: [php]
             metadata:

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -31,12 +31,12 @@ class Alias
     protected $short;
     protected $namespace = '__root';
     protected $root = null;
-    protected $classes = array();
-    protected $methods = array();
-    protected $usedMethods = array();
+    protected $classes = [];
+    protected $methods = [];
+    protected $usedMethods = [];
     protected $valid = false;
-    protected $magicMethods = array();
-    protected $interfaces = array();
+    protected $magicMethods = [];
+    protected $interfaces = [];
     protected $phpdoc = null;
 
     /** @var ConfigRepository  */
@@ -50,7 +50,7 @@ class Alias
      * @param array            $magicMethods
      * @param array            $interfaces
      */
-    public function __construct($config, $alias, $facade, $magicMethods = array(), $interfaces = array())
+    public function __construct($config, $alias, $facade, $magicMethods = [], $interfaces = [])
     {
         $this->alias = $alias;
         $this->magicMethods = $magicMethods;
@@ -82,7 +82,7 @@ class Alias
 
 
         if ($facade === '\Illuminate\Database\Eloquent\Model') {
-            $this->usedMethods = array('decrement', 'increment');
+            $this->usedMethods = ['decrement', 'increment'];
         }
     }
 

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -289,12 +289,12 @@ class Alias
             //When the database connection is not set, some classes will be skipped
         } catch (\PDOException $e) {
             $this->error(
-                "PDOException: " . $e->getMessage() .
+                'PDOException: ' . $e->getMessage() .
                 "\nPlease configure your database connection correctly, or use the sqlite memory driver (-M)." .
                 " Skipping $facade."
             );
         } catch (\Exception $e) {
-            $this->error("Exception: " . $e->getMessage() . "\nSkipping $facade.");
+            $this->error('Exception: ' . $e->getMessage() . "\nSkipping $facade.");
         }
     }
 

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -11,13 +11,13 @@
 
 namespace Barryvdh\LaravelIdeHelper;
 
-use Closure;
-use ReflectionClass;
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Context;
-use Barryvdh\Reflection\DocBlock\Tag\MethodTag;
-use Illuminate\Config\Repository as ConfigRepository;
 use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
+use Barryvdh\Reflection\DocBlock\Tag\MethodTag;
+use Closure;
+use Illuminate\Config\Repository as ConfigRepository;
+use ReflectionClass;
 
 class Alias
 {

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -25,7 +25,6 @@ use Symfony\Component\Console\Input\InputArgument;
  */
 class GeneratorCommand extends Command
 {
-
     /**
      * The console command name.
      *
@@ -59,7 +58,8 @@ class GeneratorCommand extends Command
      * @param \Illuminate\View\Factory $view
      */
     public function __construct(
-        /*ConfigRepository */ $config,
+        /*ConfigRepository */ 
+        $config,
         Filesystem $files,
         /* Illuminate\View\Factory */
         $view

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -15,8 +15,8 @@ use Barryvdh\LaravelIdeHelper\Eloquent;
 use Barryvdh\LaravelIdeHelper\Generator;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * A command to generate autocomplete information for your IDE

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -169,10 +169,10 @@ class GeneratorCommand extends Command
         $writeMixins = $this->config->get('ide-helper.write_eloquent_model_mixins');
 
         return [
-            ['format', "F", InputOption::VALUE_OPTIONAL, 'The format for the IDE Helper', $format],
-            ['write_mixins', "W", InputOption::VALUE_OPTIONAL, 'Write mixins to Laravel Model?', $writeMixins],
-            ['helpers', "H", InputOption::VALUE_NONE, 'Include the helper files'],
-            ['memory', "M", InputOption::VALUE_NONE, 'Use sqlite memory driver'],
+            ['format', 'F', InputOption::VALUE_OPTIONAL, 'The format for the IDE Helper', $format],
+            ['write_mixins', 'W', InputOption::VALUE_OPTIONAL, 'Write mixins to Laravel Model?', $writeMixins],
+            ['helpers', 'H', InputOption::VALUE_NONE, 'Include the helper files'],
+            ['memory', 'M', InputOption::VALUE_NONE, 'Use sqlite memory driver'],
         ];
     }
 }

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -153,7 +153,7 @@ class GeneratorCommand extends Command
 
         return [
             [
-                'filename', InputArgument::OPTIONAL, 'The path to the helper file', $filename
+                'filename', InputArgument::OPTIONAL, 'The path to the helper file', $filename,
             ],
         ];
     }

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -105,9 +105,9 @@ class GeneratorCommand extends Command
 
         $helpers = '';
         if ($this->option('helpers') || ($this->config->get('ide-helper.include_helpers'))) {
-            foreach ($this->config->get('ide-helper.helper_files', array()) as $helper) {
+            foreach ($this->config->get('ide-helper.helper_files', []) as $helper) {
                 if (file_exists($helper)) {
-                    $helpers .= str_replace(array('<?php', '?>'), '', $this->files->get($helper));
+                    $helpers .= str_replace(['<?php', '?>'], '', $this->files->get($helper));
                 }
             }
         } else {
@@ -134,10 +134,10 @@ class GeneratorCommand extends Command
         //Use a sqlite database in memory, to avoid connection errors on Database facades
         $this->config->set(
             'database.connections.sqlite',
-            array(
+            [
                 'driver' => 'sqlite',
                 'database' => ':memory:',
-            )
+            ]
         );
         $this->config->set('database.default', 'sqlite');
     }
@@ -151,11 +151,11 @@ class GeneratorCommand extends Command
     {
         $filename = $this->config->get('ide-helper.filename');
 
-        return array(
-            array(
+        return [
+            [
                 'filename', InputArgument::OPTIONAL, 'The path to the helper file', $filename
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -168,11 +168,11 @@ class GeneratorCommand extends Command
         $format = $this->config->get('ide-helper.format');
         $writeMixins = $this->config->get('ide-helper.write_eloquent_model_mixins');
 
-        return array(
-            array('format', "F", InputOption::VALUE_OPTIONAL, 'The format for the IDE Helper', $format),
-            array('write_mixins', "W", InputOption::VALUE_OPTIONAL, 'Write mixins to Laravel Model?', $writeMixins),
-            array('helpers', "H", InputOption::VALUE_NONE, 'Include the helper files'),
-            array('memory', "M", InputOption::VALUE_NONE, 'Use sqlite memory driver'),
-        );
+        return [
+            ['format', "F", InputOption::VALUE_OPTIONAL, 'The format for the IDE Helper', $format],
+            ['write_mixins', "W", InputOption::VALUE_OPTIONAL, 'Write mixins to Laravel Model?', $writeMixins],
+            ['helpers', "H", InputOption::VALUE_NONE, 'Include the helper files'],
+            ['memory', "M", InputOption::VALUE_NONE, 'Use sqlite memory driver'],
+        ];
     }
 }

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -58,7 +58,7 @@ class GeneratorCommand extends Command
      * @param \Illuminate\View\Factory $view
      */
     public function __construct(
-        /*ConfigRepository */ 
+        /*ConfigRepository */
         $config,
         Filesystem $files,
         /* Illuminate\View\Factory */

--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -23,7 +23,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class MetaCommand extends Command
 {
-
     /**
      * The console command name.
      *

--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -86,7 +86,7 @@ class MetaCommand extends Command
 
         $this->registerClassAutoloadExceptions();
 
-        $bindings = array();
+        $bindings = [];
         foreach ($this->getAbstracts() as $abstract) {
             // Validator and seeder cause problems
             if (in_array($abstract, ['validator', 'seeder'])) {
@@ -160,9 +160,9 @@ class MetaCommand extends Command
     {
         $filename = $this->config->get('ide-helper.meta_filename');
 
-        return array(
-            array('filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the meta file', $filename),
-        );
+        return [
+            ['filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the meta file', $filename],
+        ];
     }
 
     /**

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -248,7 +248,7 @@ class ModelsCommand extends Command
                     $ignore[]              = $name;
                     $this->nullableColumns = [];
                 } catch (\Throwable $e) {
-                    $this->error("Exception: " . $e->getMessage() .
+                    $this->error('Exception: ' . $e->getMessage() .
                         "\nCould not analyze class $name.\n\nTrace:\n" .
                         $e->getTraceAsString());
                 }
@@ -454,7 +454,7 @@ class ModelsCommand extends Command
             );
             if ($this->write_model_magic_where) {
                 $this->setMethod(
-                    Str::camel("where_" . $name),
+                    Str::camel('where_' . $name),
                     $this->getClassNameInDestinationFile($model, \Illuminate\Database\Eloquent\Builder::class)
                     . '|'
                     . $this->getClassNameInDestinationFile($model, get_class($model)),
@@ -521,7 +521,7 @@ class ModelsCommand extends Command
 
                     $this->setMethod(
                         $method,
-                        $builder . "|" . $this->getClassNameInDestinationFile($model, get_class($model))
+                        $builder . '|' . $this->getClassNameInDestinationFile($model, get_class($model))
                     );
                 } elseif (
                     !method_exists('Illuminate\Database\Eloquent\Model', $method)
@@ -621,7 +621,7 @@ class ModelsCommand extends Command
                                             false
                                         );
                                     }
-                                } elseif ($relation === "morphTo") {
+                                } elseif ($relation === 'morphTo') {
                                     // Model isn't specified because relation is polymorphic
                                     $this->setProperty(
                                         $method,
@@ -756,9 +756,9 @@ class ModelsCommand extends Command
         $methods = [];
         foreach ($phpdoc->getTags() as $tag) {
             $name = $tag->getName();
-            if ($name == "property" || $name == "property-read" || $name == "property-write") {
+            if ($name == 'property' || $name == 'property-read' || $name == 'property-write') {
                 $properties[] = $tag->getVariableName();
-            } elseif ($name == "method") {
+            } elseif ($name == 'method') {
                 $methods[] = $tag->getMethodName();
             }
         }
@@ -799,20 +799,20 @@ class ModelsCommand extends Command
 
         if ($this->write && ! $phpdoc->getTagsByName('mixin')) {
             $eloquentClassNameInModel = $this->getClassNameInDestinationFile($reflection, 'Eloquent');
-            $phpdoc->appendTag(Tag::createInstance("@mixin " . $eloquentClassNameInModel, $phpdoc));
+            $phpdoc->appendTag(Tag::createInstance('@mixin ' . $eloquentClassNameInModel, $phpdoc));
         }
         if ($this->phpstorm_noinspections) {
             /**
              * Facades, Eloquent API
              * @see https://www.jetbrains.com/help/phpstorm/php-fully-qualified-name-usage.html
              */
-            $phpdoc->appendTag(Tag::createInstance("@noinspection PhpFullyQualifiedNameUsageInspection", $phpdoc));
+            $phpdoc->appendTag(Tag::createInstance('@noinspection PhpFullyQualifiedNameUsageInspection', $phpdoc));
             /**
              * Relations, other models in the same namespace
              * @see https://www.jetbrains.com/help/phpstorm/php-unnecessary-fully-qualified-name.html
              */
             $phpdoc->appendTag(
-                Tag::createInstance("@noinspection PhpUnnecessaryFullyQualifiedNameInspection", $phpdoc)
+                Tag::createInstance('@noinspection PhpUnnecessaryFullyQualifiedNameInspection', $phpdoc)
             );
         }
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -797,7 +797,7 @@ class ModelsCommand extends Command
             $phpdoc->appendTag($tag);
         }
 
-        if ($this->write && ! $phpdoc->getTagsByName('mixin')) {
+        if ($this->write && !$phpdoc->getTagsByName('mixin')) {
             $eloquentClassNameInModel = $this->getClassNameInDestinationFile($reflection, 'Eloquent');
             $phpdoc->appendTag(Tag::createInstance('@mixin ' . $eloquentClassNameInModel, $phpdoc));
         }

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -161,14 +161,14 @@ class ModelsCommand extends Command
         return [
           ['filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the helper file', $this->filename],
           ['dir', 'D', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
-              'The model dir, supports glob patterns', []],
+              'The model dir, supports glob patterns', [], ],
           ['write', 'W', InputOption::VALUE_NONE, 'Write to Model file'],
           ['nowrite', 'N', InputOption::VALUE_NONE, 'Don\'t write to Model file'],
           ['reset', 'R', InputOption::VALUE_NONE, 'Remove the original phpdocs instead of appending'],
           ['smart-reset', 'r', InputOption::VALUE_NONE, 'Refresh the properties/methods list, but keep the text'],
           ['phpstorm-noinspections', 'p', InputOption::VALUE_NONE,
               'Add PhpFullyQualifiedNameUsageInspection and PhpUnnecessaryFullyQualifiedNameInspection PHPStorm ' .
-              'noinspection tags'
+              'noinspection tags',
           ],
           ['ignore', 'I', InputOption::VALUE_OPTIONAL, 'Which models to ignore', ''],
         ];
@@ -563,7 +563,7 @@ class ModelsCommand extends Command
                                'morphTo' => '\Illuminate\Database\Eloquent\Relations\MorphTo',
                                'morphMany' => '\Illuminate\Database\Eloquent\Relations\MorphMany',
                                'morphToMany' => '\Illuminate\Database\Eloquent\Relations\MorphToMany',
-                               'morphedByMany' => '\Illuminate\Database\Eloquent\Relations\MorphToMany'
+                               'morphedByMany' => '\Illuminate\Database\Eloquent\Relations\MorphToMany',
                              ] as $relation => $impl
                     ) {
                         $search = '$this->' . $relation . '(';

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -58,10 +58,10 @@ class ModelsCommand extends Command
 
     protected $write_model_magic_where;
     protected $write_model_relation_count_properties;
-    protected $properties = array();
-    protected $methods = array();
+    protected $properties = [];
+    protected $methods = [];
     protected $write = false;
-    protected $dirs = array();
+    protected $dirs = [];
     protected $reset;
     protected $keep_text;
     protected $phpstorm_noinspections;
@@ -146,9 +146,9 @@ class ModelsCommand extends Command
      */
     protected function getArguments()
     {
-        return array(
-          array('model', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Which models to include', array()),
-        );
+        return [
+          ['model', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Which models to include', []],
+        ];
     }
 
     /**
@@ -158,20 +158,20 @@ class ModelsCommand extends Command
      */
     protected function getOptions()
     {
-        return array(
-          array('filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the helper file', $this->filename),
-          array('dir', 'D', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
-              'The model dir, supports glob patterns', array()),
-          array('write', 'W', InputOption::VALUE_NONE, 'Write to Model file'),
-          array('nowrite', 'N', InputOption::VALUE_NONE, 'Don\'t write to Model file'),
-          array('reset', 'R', InputOption::VALUE_NONE, 'Remove the original phpdocs instead of appending'),
-          array('smart-reset', 'r', InputOption::VALUE_NONE, 'Refresh the properties/methods list, but keep the text'),
-          array('phpstorm-noinspections', 'p', InputOption::VALUE_NONE,
+        return [
+          ['filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the helper file', $this->filename],
+          ['dir', 'D', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+              'The model dir, supports glob patterns', []],
+          ['write', 'W', InputOption::VALUE_NONE, 'Write to Model file'],
+          ['nowrite', 'N', InputOption::VALUE_NONE, 'Don\'t write to Model file'],
+          ['reset', 'R', InputOption::VALUE_NONE, 'Remove the original phpdocs instead of appending'],
+          ['smart-reset', 'r', InputOption::VALUE_NONE, 'Refresh the properties/methods list, but keep the text'],
+          ['phpstorm-noinspections', 'p', InputOption::VALUE_NONE,
               'Add PhpFullyQualifiedNameUsageInspection and PhpUnnecessaryFullyQualifiedNameInspection PHPStorm ' .
               'noinspection tags'
-          ),
-          array('ignore', 'I', InputOption::VALUE_OPTIONAL, 'Which models to ignore', ''),
-        );
+          ],
+          ['ignore', 'I', InputOption::VALUE_OPTIONAL, 'Which models to ignore', ''],
+        ];
     }
 
     protected function generateDocs($loadModels, $ignore = '')
@@ -195,7 +195,7 @@ class ModelsCommand extends Command
         if (empty($loadModels)) {
             $models = $this->loadModels();
         } else {
-            $models = array();
+            $models = [];
             foreach ($loadModels as $model) {
                 $models = array_merge($models, explode(',', $model));
             }
@@ -203,7 +203,7 @@ class ModelsCommand extends Command
 
         $ignore = array_merge(
             explode(',', $ignore),
-            $this->laravel['config']->get('ide-helper.ignored_models', array())
+            $this->laravel['config']->get('ide-helper.ignored_models', [])
         );
 
         foreach ($models as $name) {
@@ -213,8 +213,8 @@ class ModelsCommand extends Command
                 }
                 continue;
             }
-            $this->properties = array();
-            $this->methods = array();
+            $this->properties = [];
+            $this->methods = [];
             if (class_exists($name)) {
                 try {
                     // handle abstract classes, interfaces, ...
@@ -268,7 +268,7 @@ class ModelsCommand extends Command
 
     protected function loadModels()
     {
-        $models = array();
+        $models = [];
         foreach ($this->dirs as $dir) {
             if (is_dir(base_path($dir))) {
                 $dir = base_path($dir);
@@ -364,7 +364,7 @@ class ModelsCommand extends Command
      */
     protected function getTypeOverride($type)
     {
-        $typeOverrides = $this->laravel['config']->get('ide-helper.type_overrides', array());
+        $typeOverrides = $this->laravel['config']->get('ide-helper.type_overrides', []);
 
         return $typeOverrides[$type] ?? $type;
     }
@@ -382,7 +382,7 @@ class ModelsCommand extends Command
         $databasePlatform->registerDoctrineTypeMapping('enum', 'string');
 
         $platformName = $databasePlatform->getName();
-        $customTypes = $this->laravel['config']->get("ide-helper.custom_db_types.{$platformName}", array());
+        $customTypes = $this->laravel['config']->get("ide-helper.custom_db_types.{$platformName}", []);
         foreach ($customTypes as $yourTypeName => $doctrineTypeName) {
             $databasePlatform->registerDoctrineTypeMapping($yourTypeName, $doctrineTypeName);
         }
@@ -458,7 +458,7 @@ class ModelsCommand extends Command
                     $this->getClassNameInDestinationFile($model, \Illuminate\Database\Eloquent\Builder::class)
                     . '|'
                     . $this->getClassNameInDestinationFile($model, get_class($model)),
-                    array('$value')
+                    ['$value']
                 );
             }
         }
@@ -552,7 +552,7 @@ class ModelsCommand extends Command
                     $code = substr($code, $begin, strrpos($code, '}') - $begin + 1);
 
                     foreach (
-                        array(
+                        [
                                'hasMany' => '\Illuminate\Database\Eloquent\Relations\HasMany',
                                'hasManyThrough' => '\Illuminate\Database\Eloquent\Relations\HasManyThrough',
                                'hasOneThrough' => '\Illuminate\Database\Eloquent\Relations\HasOneThrough',
@@ -564,7 +564,7 @@ class ModelsCommand extends Command
                                'morphMany' => '\Illuminate\Database\Eloquent\Relations\MorphMany',
                                'morphToMany' => '\Illuminate\Database\Eloquent\Relations\MorphToMany',
                                'morphedByMany' => '\Illuminate\Database\Eloquent\Relations\MorphToMany'
-                             ) as $relation => $impl
+                             ] as $relation => $impl
                     ) {
                         $search = '$this->' . $relation . '(';
                         if (stripos($code, $search) || ltrim($impl, '\\') === ltrim((string)$type, '\\')) {
@@ -688,7 +688,7 @@ class ModelsCommand extends Command
     protected function setProperty($name, $type = null, $read = null, $write = null, $comment = '', $nullable = false)
     {
         if (!isset($this->properties[$name])) {
-            $this->properties[$name] = array();
+            $this->properties[$name] = [];
             $this->properties[$name]['type'] = 'mixed';
             $this->properties[$name]['read'] = false;
             $this->properties[$name]['write'] = false;
@@ -709,12 +709,12 @@ class ModelsCommand extends Command
         }
     }
 
-    protected function setMethod($name, $type = '', $arguments = array())
+    protected function setMethod($name, $type = '', $arguments = [])
     {
         $methods = array_change_key_case($this->methods, CASE_LOWER);
 
         if (!isset($methods[strtolower($name)])) {
-            $this->methods[$name] = array();
+            $this->methods[$name] = [];
             $this->methods[$name]['type'] = $type;
             $this->methods[$name]['arguments'] = $arguments;
         }
@@ -752,8 +752,8 @@ class ModelsCommand extends Command
             $phpdoc->setText($class);
         }
 
-        $properties = array();
-        $methods = array();
+        $properties = [];
+        $methods = [];
         foreach ($phpdoc->getTags() as $tag) {
             $name = $tag->getName();
             if ($name == "property" || $name == "property-read" || $name == "property-write") {
@@ -857,7 +857,7 @@ class ModelsCommand extends Command
     public function getParameters($method)
     {
         //Loop through the default values for parameters, and make the correct output string
-        $paramsWithDefault = array();
+        $paramsWithDefault = [];
         /** @var \ReflectionParameter $param */
         foreach ($method->getParameters() as $param) {
             $paramClass = $param->getClass();

--- a/src/Eloquent.php
+++ b/src/Eloquent.php
@@ -8,12 +8,12 @@
 
 namespace Barryvdh\LaravelIdeHelper;
 
-use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Context;
 use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
 use Barryvdh\Reflection\DocBlock\Tag;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
 
 class Eloquent
 {

--- a/src/Factories.php
+++ b/src/Factories.php
@@ -8,7 +8,6 @@ use ReflectionClass;
 
 class Factories
 {
-
     public static function all()
     {
         $factories = [];

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -40,8 +40,10 @@ class Generator
      * @param string $helpers
      */
     public function __construct(
-        /*ConfigRepository */ $config,
-        /* Illuminate\View\Factory */ $view,
+        /*ConfigRepository */ 
+        $config,
+        /* Illuminate\View\Factory */ 
+        $view,
         OutputInterface $output = null,
         $helpers = ''
     ) {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -11,10 +11,8 @@
 
 namespace Barryvdh\LaravelIdeHelper;
 
-use Illuminate\Foundation\Application;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\Collection;
-use ReflectionClass;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Generator
@@ -40,9 +38,9 @@ class Generator
      * @param string $helpers
      */
     public function __construct(
-        /*ConfigRepository */ 
+        /*ConfigRepository */
         $config,
-        /* Illuminate\View\Factory */ 
+        /* Illuminate\View\Factory */
         $view,
         OutputInterface $output = null,
         $helpers = ''

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -26,9 +26,9 @@ class Generator
     /** @var \Symfony\Component\Console\Output\OutputInterface */
     protected $output;
 
-    protected $extra = array();
-    protected $magic = array();
-    protected $interfaces = array();
+    protected $extra = [];
+    protected $magic = [];
+    protected $interfaces = [];
     protected $helpers;
 
     /**
@@ -93,16 +93,16 @@ class Generator
 
     public function generateJsonHelper()
     {
-        $classes = array();
+        $classes = [];
         foreach ($this->getValidAliases() as $aliases) {
             foreach ($aliases as $alias) {
-                $functions = array();
+                $functions = [];
                 foreach ($alias->getMethods() as $method) {
                     $functions[$method->getName()] = '(' . $method->getParamsWithDefault() . ')';
                 }
-                $classes[$alias->getAlias()] = array(
+                $classes[$alias->getAlias()] = [
                     'functions' => $functions,
-                );
+                ];
             }
         }
 
@@ -111,11 +111,11 @@ class Generator
             $flags |= JSON_PRETTY_PRINT;
         }
 
-        return json_encode(array(
-            'php' => array(
+        return json_encode([
+            'php' => [
                 'classes' => $classes,
-            ),
-        ), $flags);
+            ],
+        ], $flags);
     }
 
     protected function detectDrivers()
@@ -129,7 +129,7 @@ class Generator
                 && app()->bound('auth')
             ) {
                 $class = get_class(\Auth::guard());
-                $this->extra['Auth'] = array($class);
+                $this->extra['Auth'] = [$class];
                 $this->interfaces['\Illuminate\Auth\UserProviderInterface'] = $class;
             }
         } catch (\Exception $e) {
@@ -138,7 +138,7 @@ class Generator
         try {
             if (class_exists('DB') && is_a('DB', '\Illuminate\Support\Facades\DB', true)) {
                 $class = get_class(\DB::connection());
-                $this->extra['DB'] = array($class);
+                $this->extra['DB'] = [$class];
                 $this->interfaces['\Illuminate\Database\ConnectionInterface'] = $class;
             }
         } catch (\Exception $e) {
@@ -148,7 +148,7 @@ class Generator
             if (class_exists('Cache') && is_a('Cache', '\Illuminate\Support\Facades\Cache', true)) {
                 $driver = get_class(\Cache::driver());
                 $store = get_class(\Cache::getStore());
-                $this->extra['Cache'] = array($driver, $store);
+                $this->extra['Cache'] = [$driver, $store];
                 $this->interfaces['\Illuminate\Cache\StoreInterface'] = $store;
             }
         } catch (\Exception $e) {
@@ -157,7 +157,7 @@ class Generator
         try {
             if (class_exists('Queue') && is_a('Queue', '\Illuminate\Support\Facades\Queue', true)) {
                 $class = get_class(\Queue::connection());
-                $this->extra['Queue'] = array($class);
+                $this->extra['Queue'] = [$class];
                 $this->interfaces['\Illuminate\Queue\QueueInterface'] = $class;
             }
         } catch (\Exception $e) {
@@ -166,7 +166,7 @@ class Generator
         try {
             if (class_exists('SSH') && is_a('SSH', '\Illuminate\Support\Facades\SSH', true)) {
                 $class = get_class(\SSH::connection());
-                $this->extra['SSH'] = array($class);
+                $this->extra['SSH'] = [$class];
                 $this->interfaces['\Illuminate\Remote\ConnectionInterface'] = $class;
             }
         } catch (\Exception $e) {
@@ -175,7 +175,7 @@ class Generator
         try {
             if (class_exists('Storage') && is_a('Storage', '\Illuminate\Support\Facades\Storage', true)) {
                 $class = get_class(\Storage::disk());
-                $this->extra['Storage'] = array($class);
+                $this->extra['Storage'] = [$class];
                 $this->interfaces['\Illuminate\Contracts\Filesystem\Filesystem'] = $class;
             }
         } catch (\Exception $e) {
@@ -198,7 +198,7 @@ class Generator
                 continue;
             }
 
-            $magicMethods = array_key_exists($name, $this->magic) ? $this->magic[$name] : array();
+            $magicMethods = array_key_exists($name, $this->magic) ? $this->magic[$name] : [];
             $alias = new Alias($this->config, $name, $facade, $magicMethods, $this->interfaces);
             if ($alias->isValid()) {
                 //Add extra methods, from other classes (magic static calls)

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -24,7 +24,6 @@ use Illuminate\View\FileViewFinder;
 
 class IdeHelperServiceProvider extends ServiceProvider
 {
-
     /**
      * Indicates if loading of the provider is deferred.
      *

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -106,7 +106,7 @@ class IdeHelperServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return array('command.ide-helper.generate', 'command.ide-helper.models');
+        return ['command.ide-helper.generate', 'command.ide-helper.models'];
     }
 
     /**

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -20,7 +20,7 @@ class Macro extends Method
         $alias,
         $class,
         $methodName = null,
-        $interfaces = array()
+        $interfaces = []
     ) {
         parent::__construct($method, $alias, $class, $methodName, $interfaces);
     }

--- a/src/Method.php
+++ b/src/Method.php
@@ -302,7 +302,7 @@ class Method
      */
     public function shouldReturn()
     {
-        if ($this->return !== "void" && $this->method->name !== "__construct") {
+        if ($this->return !== 'void' && $this->method->name !== '__construct') {
             return true;
         }
 

--- a/src/Method.php
+++ b/src/Method.php
@@ -32,9 +32,9 @@ class Method
     protected $declaringClassName;
     protected $name;
     protected $namespace;
-    protected $params = array();
-    protected $params_with_default = array();
-    protected $interfaces = array();
+    protected $params = [];
+    protected $params_with_default = [];
+    protected $interfaces = [];
     protected $real_name;
     protected $return = null;
     protected $root;
@@ -46,7 +46,7 @@ class Method
      * @param string|null $methodName
      * @param array $interfaces
      */
-    public function __construct($method, $alias, $class, $methodName = null, $interfaces = array())
+    public function __construct($method, $alias, $class, $methodName = null, $interfaces = [])
     {
         $this->method = $method;
         $this->interfaces = $interfaces;
@@ -318,8 +318,8 @@ class Method
     public function getParameters($method)
     {
         //Loop through the default values for parameters, and make the correct output string
-        $params = array();
-        $paramsWithDefault = array();
+        $params = [];
+        $paramsWithDefault = [];
         foreach ($method->getParameters() as $param) {
             $paramStr = $param->isVariadic() ? '...$' . $param->getName() : '$' . $param->getName();
             $params[] = $paramStr;

--- a/src/Method.php
+++ b/src/Method.php
@@ -13,10 +13,10 @@ namespace Barryvdh\LaravelIdeHelper;
 
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Context;
-use Barryvdh\Reflection\DocBlock\Tag;
-use Barryvdh\Reflection\DocBlock\Tag\ReturnTag;
-use Barryvdh\Reflection\DocBlock\Tag\ParamTag;
 use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
+use Barryvdh\Reflection\DocBlock\Tag;
+use Barryvdh\Reflection\DocBlock\Tag\ParamTag;
+use Barryvdh\Reflection\DocBlock\Tag\ReturnTag;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 

--- a/src/Method.php
+++ b/src/Method.php
@@ -119,7 +119,7 @@ class Method
      */
     public function isInstanceCall()
     {
-        return ! ($this->method->isClosure() || $this->method->isStatic());
+        return !($this->method->isClosure() || $this->method->isStatic());
     }
 
     /**

--- a/tests/Console/EloquentCommandTest.php
+++ b/tests/Console/EloquentCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Barryvdh\LaravelIdeHelper\Tests\Console;
 
 use Barryvdh\LaravelIdeHelper\Console\EloquentCommand;

--- a/tests/Console/ModelsCommand/CustomCollection/Collections/SimpleCollection.php
+++ b/tests/Console/ModelsCommand/CustomCollection/Collections/SimpleCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomCollection\Collections;
 
 use Illuminate\Database\Eloquent\Collection;

--- a/tests/Console/ModelsCommand/CustomCollection/Collections/SimpleCollection.php
+++ b/tests/Console/ModelsCommand/CustomCollection/Collections/SimpleCollection.php
@@ -6,5 +6,4 @@ use Illuminate\Database\Eloquent\Collection;
 
 class SimpleCollection extends Collection
 {
-
 }

--- a/tests/Console/ModelsCommand/CustomCollection/Test.php
+++ b/tests/Console/ModelsCommand/CustomCollection/Test.php
@@ -6,9 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomCollection
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomCollection\Collections\SimpleCollection;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/CustomDate/Test.php
+++ b/tests/Console/ModelsCommand/CustomDate/Test.php
@@ -7,10 +7,8 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomDate;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
 use Carbon\CarbonImmutable;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/DynamicRelations/OtherModels/Account.php
+++ b/tests/Console/ModelsCommand/DynamicRelations/OtherModels/Account.php
@@ -8,5 +8,4 @@ use Illuminate\Database\Eloquent\Model;
 
 class Account extends Model
 {
-
 }

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdoc/Test.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdoc/Test.php
@@ -6,8 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhp
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdocCamel/Test.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdocCamel/Test.php
@@ -6,8 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhp
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdocFinal/Test.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdocFinal/Test.php
@@ -6,8 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhp
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Casts/CastType.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Casts/CastType.php
@@ -6,5 +6,4 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
 
 final class CastType
 {
-
 }

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Models/Post.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Models/Post.php
@@ -8,9 +8,9 @@ use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqn\
 use Eloquent;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Carbon;
 

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Models/Post.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Models/Post.php
@@ -18,6 +18,18 @@ class Post extends Model
 {
     use SoftDeletes;
 
+    /**
+     * Special hack to avoid code style fixer removing unused imports
+     * which play a role when generating the snapshot
+     */
+    private $hack = [
+        Carbon::class,
+        Collection::class,
+        Eloquent::class,
+        EloquentBuilder::class,
+        QueryBuilder::class,
+    ];
+
     protected $casts = [
         'char_not_nullable' => CastType::class,
     ];

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Models/Post.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Models/Post.php
@@ -6,11 +6,9 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
 
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqn\Casts\CastType;
 use Eloquent;
-use Illuminate\Database\Eloquent\{
-    Builder as EloquentBuilder,
-    Collection,
-    SoftDeletes
-};
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Query\Builder as QueryBuilder;

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Test.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/Test.php
@@ -6,12 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqn\Models\Post;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
@@ -178,6 +178,18 @@ class Post extends Model
 {
     use SoftDeletes;
 
+    /**
+     * Special hack to avoid code style fixer removing unused imports
+     * which play a role when generating the snapshot
+     */
+    private $hack = [
+        Carbon::class,
+        Collection::class,
+        Eloquent::class,
+        EloquentBuilder::class,
+        QueryBuilder::class,
+    ];
+
     protected $casts = [
         'char_not_nullable' => CastType::class,
     ];

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
@@ -8,9 +8,9 @@ use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqn\
 use Eloquent;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Carbon;
 

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
@@ -6,11 +6,9 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
 
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqn\Casts\CastType;
 use Eloquent;
-use Illuminate\Database\Eloquent\{
-    Builder as EloquentBuilder,
-    Collection,
-    SoftDeletes
-};
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Query\Builder as QueryBuilder;

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/Builders/EMaterialQueryBuilder.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/Builders/EMaterialQueryBuilder.php
@@ -8,5 +8,4 @@ use Illuminate\Database\Eloquent\Builder;
 
 class EMaterialQueryBuilder extends Builder
 {
-
 }

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/Test.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/Test.php
@@ -6,12 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqn\Models\Post;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/Getter/Test.php
+++ b/tests/Console/ModelsCommand/Getter/Test.php
@@ -6,8 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Getter;
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/Ignored/Models/Ignored.php
+++ b/tests/Console/ModelsCommand/Ignored/Models/Ignored.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Ignored\Models;
 
-use DateTime;
 use Illuminate\Database\Eloquent\Model;
 
 class Ignored extends Model

--- a/tests/Console/ModelsCommand/Ignored/Test.php
+++ b/tests/Console/ModelsCommand/Ignored/Test.php
@@ -7,8 +7,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Ignored;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Ignored\Models\Ignored;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/Ignored/Test.php
+++ b/tests/Console/ModelsCommand/Ignored/Test.php
@@ -15,7 +15,7 @@ class Test extends AbstractModelsCommand
         parent::getEnvironmentSetUp($app);
 
         $app['config']->set('ide-helper.ignored_models', [
-            Ignored::class
+            Ignored::class,
         ]);
     }
 

--- a/tests/Console/ModelsCommand/Interfaces/Test.php
+++ b/tests/Console/ModelsCommand/Interfaces/Test.php
@@ -6,8 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Interfaces;
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 final class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CastedProperty.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CastedProperty.php
@@ -4,5 +4,4 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCas
 
 class CastedProperty
 {
-
 }

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CastedProperty.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CastedProperty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
 
 class CastedProperty

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithDocblockReturn.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithDocblockReturn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithDocblockReturnFqn.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithDocblockReturnFqn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithNullablePrimitiveReturn.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithNullablePrimitiveReturn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithPrimitiveDocblockReturn.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithPrimitiveDocblockReturn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithPrimitiveReturn.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithPrimitiveReturn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithReturnType.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithReturnType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithoutReturnType.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithoutReturnType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Test.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Test.php
@@ -12,7 +12,6 @@ use Mockery;
 
 class Test extends AbstractModelsCommand
 {
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Test.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Test.php
@@ -6,9 +6,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCas
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/MagicWhere/Test.php
+++ b/tests/Console/ModelsCommand/MagicWhere/Test.php
@@ -6,8 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\MagicWhere;
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/PHPStormNoInspection/Test.php
+++ b/tests/Console/ModelsCommand/PHPStormNoInspection/Test.php
@@ -6,10 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspec
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
-
-use function file_get_contents;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/RelationCountProperties/Test.php
+++ b/tests/Console/ModelsCommand/RelationCountProperties/Test.php
@@ -6,10 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\RelationCountPro
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomCollection\Models\Simple;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/Relations/Test.php
+++ b/tests/Console/ModelsCommand/Relations/Test.php
@@ -6,8 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations;
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/ResetAndSmartReset/Test.php
+++ b/tests/Console/ModelsCommand/ResetAndSmartReset/Test.php
@@ -6,8 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartRes
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/SoftDeletes/Test.php
+++ b/tests/Console/ModelsCommand/SoftDeletes/Test.php
@@ -6,8 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SoftDeletes;
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Illuminate\Filesystem\Filesystem;
-use Mockery;
 
 class Test extends AbstractModelsCommand
 {

--- a/tests/Console/ModelsCommand/migrations/____posts_table.php
+++ b/tests/Console/ModelsCommand/migrations/____posts_table.php
@@ -12,7 +12,7 @@ class PostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
-            
+
             $table->char('char_nullable')->nullable();
             $table->char('char_not_nullable');
 

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Barryvdh\LaravelIdeHelper\Tests;
 
 use Barryvdh\LaravelIdeHelper\Method;

--- a/tests/SnapshotPhpDriver.php
+++ b/tests/SnapshotPhpDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Barryvdh\LaravelIdeHelper\Tests;
 
 use PHPUnit\Framework\Assert;

--- a/tests/SnapshotTxtDriver.php
+++ b/tests/SnapshotTxtDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Barryvdh\LaravelIdeHelper\Tests;
 
 use PHPUnit\Framework\Assert;


### PR DESCRIPTION
This is a re-attempt of https://github.com/barryvdh/laravel-ide-helper/pull/871 based on the plea made in https://github.com/barryvdh/laravel-ide-helper/pull/871#issuecomment-683559682
> PSR-12 is fine by me and if you think php-cs-fixer does a better job then that's also fine with me :)

### Why replace one tool with another when they do the same job?
In my "IMHO" experience, php-cs-fixer is the friendlier tool for multiple reasons:
- better docs what fixers are available, how they're configured
  AFAIK today here's no such thing with php_codesniffer
- I think the out of the box experience is better, when I activated `@PSR2` I immediately got superfluous empty lines removed
- there are more (community velocity, contributions, defaults not to PEAR but PSR2, …)

### "u crazy that diff??"
About that… 😏 

- First, there's not yet a finished `@PSR12` preset so I used what's present from https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4943
  This incremential change to the source tree can be seen in commit https://github.com/barryvdh/laravel-ide-helper/commit/def43165c087393b694b420d41edadbe32aa31b2 and if you look at the changes, it's _mostly_ about redundant whitespace and other slight differences
- The point of a defined code style is to have a homogeneous code base so that certain patterns are equally handled, which wasn't the case so far.
  **Thus additional "fixers" have been enabled:**
  - short array_syntax (reason for most of the "noise" in the PR…)
  - no unused imports
  - trailing comma in multi-line arrays
  - single quotes
  - … and a few more
- I did create two configs, one for tests and the rest, because tests all work with `declare(strict_types=1);` but the rest currently doesn't => so for now we enforce it only for tests, until the rest catches up
- github actions was only slightly improved and grumphp was adapted
  Otherwise no real change here

🤞 