### PR TITLE
[TESTS] Running in CI should not create but rather fail on missing snapshots

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,4 +45,4 @@ jobs:
         composer update --${{ matrix.dependency-version }} --prefer-dist --no-suggest --no-progress
 
     - name: Execute Unit Tests
-      run: composer test
+      run: composer test-ci

--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,7 @@
             "php-cs-fixer fix --config=.php_cs.tests.php"
         ],
         "test": "phpunit",
+        "test-ci": "phpunit -d --without-creating-snapshots",
         "test-regenerate": "phpunit -d --update-snapshots"
     }
 }


### PR DESCRIPTION
## Summary

Otherwise they get created on the CI infrastructure but that's it, the
build won't fail although it was forgotten to add the snapshot.