### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-[Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.8.0...master)
+[Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.8.1...master)
 --------------
+
+2020-09-07, 2.8.1
+-----------------
 ### Added
 - Support Laravel 8 [\#1022 / barryvdh](https://github.com/barryvdh/laravel-ide-helper/pull/1022)
 - Add option to force usage of FQN [\#1031 / edvordo](https://github.com/barryvdh/laravel-ide-helper/pull/1031)


### PR DESCRIPTION
I also took the liberty and changed the release at https://github.com/barryvdh/laravel-ide-helper/releases/tag/v2.8.1

The idea of the changelog is to keep it updated with the commits/PRs as they come in so in the end it's a copypaste to the changelog release tag with a) minimal effort and b) notable / relevant changes (see screenshot, don't think it would be worth mentioning the internal infrastructure changes for end user releases).

### Before
![Snip20200907_140](https://user-images.githubusercontent.com/87493/92405152-4f0c7a80-f135-11ea-9d33-52aad806c97d.png)


### After
![Snip20200907_141](https://user-images.githubusercontent.com/87493/92405164-53389800-f135-11ea-88e5-fa1674ed8ad8.png)

Hope that's fine!