### PR TITLE
Fix compatibility with Lumen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Implement DeferrableProvider [\#914 / kon-shou](https://github.com/barryvdh/laravel-ide-helper/pull/914)
 
+### Fixed
+- Compatibility with Lumen [\#1043 / mfn](https://github.com/barryvdh/laravel-ide-helper/pull/1043)
+
 2020-09-07, 2.8.1
 -----------------
 ### Added

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper;
+
+class Helpers
+{
+    public static function isLaravel(): bool
+    {
+        return class_exists('Illuminate\Foundation\Application');
+    }
+}

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -110,8 +110,7 @@ class IdeHelperServiceProvider extends ServiceProvider implements DeferrableProv
     {
         $resolver = new EngineResolver();
         $resolver->register('php', function () {
-            // version check is Laravel specific and doesn't work in Lumen
-            if (class_exists(Application::class) && (int) Application::VERSION < 8) {
+            if (Helpers::isLaravel() && (int) Application::VERSION < 8) {
                 return new PhpEngine();
             }
 

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -110,7 +110,8 @@ class IdeHelperServiceProvider extends ServiceProvider implements DeferrableProv
     {
         $resolver = new EngineResolver();
         $resolver->register('php', function () {
-            if ((int) Application::VERSION < 8) {
+            // version check is Laravel specific and doesn't work in Lumen
+            if (class_exists(Application::class) && (int) Application::VERSION < 8) {
                 return new PhpEngine();
             }
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/barryvdh/laravel-ide-helper/issues/1042

Got broken by https://github.com/barryvdh/laravel-ide-helper/pull/1026

TL;DR: can't use anything in the `Illuminate\Foundation` namespace
without safety check, as it doesn't exist in Lumen.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
