### PR TITLE
[PSALM] Update baseline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,7 @@
             "php-cs-fixer fix",
             "php-cs-fixer fix --config=.php_cs.tests.php"
         ],
+        "psalm-set-baseline": "psalm --set-baseline=psalm-baseline.xml",
         "test": "phpunit",
         "test-ci": "phpunit -d --without-creating-snapshots",
         "test-regenerate": "phpunit -d --update-snapshots"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.12.0@d46283075d76ed244f7825b378eeb1cee246af73">
+<files psalm-version="3.15@de6e7f324f44dde540ebe7ebd4eb481b97c86f30">
+  <file src="src/Factories.php">
+    <UndefinedClass occurrences="2">
+      <code>Factory</code>
+      <code>Factory</code>
+    </UndefinedClass>
+  </file>
   <file src="src/Generator.php">
-    <UndefinedClass occurrences="8">
-      <code>'\Laravel\Lumen\Application'</code>
+    <UndefinedClass occurrences="7">
       <code>\Auth</code>
       <code>\DB</code>
       <code>\Cache</code>
@@ -11,5 +16,10 @@
       <code>\SSH</code>
       <code>\Storage</code>
     </UndefinedClass>
+  </file>
+  <file src="src/IdeHelperServiceProvider.php">
+    <TooFewArguments occurrences="1">
+      <code>new PhpEngine()</code>
+    </TooFewArguments>
   </file>
 </files>


### PR DESCRIPTION
## Summary
Now that Laravel 8 release, the baseline has to be set again:
- add a composer script to conveniently set the baseline
- run it and thus update the baseline

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
