### PR TITLE
Give feedback when a relation can't be resolved

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -38,6 +38,7 @@ use ReflectionObject;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 /**
  * A command to generate autocomplete information for your IDE
@@ -277,7 +278,7 @@ class ModelsCommand extends Command
                     $output                .= $this->createPhpDocs($name);
                     $ignore[]              = $name;
                     $this->nullableColumns = [];
-                } catch (\Throwable $e) {
+                } catch (Throwable $e) {
                     $this->error('Exception: ' . $e->getMessage() .
                         "\nCould not analyze class $name.\n\nTrace:\n" .
                         $e->getTraceAsString());
@@ -601,7 +602,9 @@ class ModelsCommand extends Command
                             $relationObj = Relation::noConstraints(function () use ($model, $method) {
                                 try {
                                     return $model->$method();
-                                } catch (\Throwable $e) {
+                                } catch (Throwable $e) {
+                                    $this->warn(sprintf('Error resolving relation model of %s:%s() : %s', get_class($model), $method, $e->getMessage()));
+
                                     return null;
                                 }
                             });

--- a/tests/Console/ModelsCommand/DynamicRelations/Test.php
+++ b/tests/Console/ModelsCommand/DynamicRelations/Test.php
@@ -17,8 +17,15 @@ class Test extends AbstractModelsCommand
             '--write' => true,
         ]);
 
+        $errors = <<<TXT
+Error resolving relation model of Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DynamicRelations\Models\Dynamic:dynamicBelongsTo() : Trying to get property 'created_at' of non-object
+Error resolving relation model of Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DynamicRelations\Models\Dynamic:dynamicHasMany() : Trying to get property 'created_at' of non-object
+Error resolving relation model of Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DynamicRelations\Models\Dynamic:dynamicHasOne() : Trying to get property 'created_at' of non-object
+TXT;
+
         $this->assertSame(0, $tester->getStatusCode());
         $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
+        $this->assertStringContainsString($errors, $tester->getDisplay());
         $this->assertMatchesMockedSnapshot();
     }
 }


### PR DESCRIPTION
## Summary
Improves https://github.com/barryvdh/laravel-ide-helper/pull/1017 slightly

Instead of swallowing any error, we give visible feedback so users are actually aware why we skipped relations.

Inspired from analyzing https://github.com/barryvdh/laravel-ide-helper/issues/724

## Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [ ] ~Add a CHANGELOG.md entry~
  Not necessary, it's a minor thing
