### PR TITLE
Remove format and broken generateJsonHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to this project will be documented in this file.
 - Allow model_locations to have glob patterns [\#1059 / saackearl](https://github.com/barryvdh/laravel-ide-helper/pull/1059)
 - Error when generating helper for macroable classes which are not facades and contain a "fake" method [\#1066 / domkrm] (https://github.com/barryvdh/laravel-ide-helper/pull/1066)
 
+### Removed
+- Removed format and broken generateJsonHelper [\#1053 / mfn](https://github.com/barryvdh/laravel-ide-helper/pull/1053)
+
 2020-09-07, 2.8.1
 -----------------
 ### Added

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -7,12 +7,11 @@ return [
     | Filename & Format
     |--------------------------------------------------------------------------
     |
-    | The default filename (without extension) and the format (php or json)
+    | The default filename
     |
     */
 
-    'filename'  => '_ide_helper',
-    'format'    => 'php',
+    'filename'  => '_ide_helper.php',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Console/GeneratorCommand.php
+++ b/src/Console/GeneratorCommand.php
@@ -89,14 +89,12 @@ class GeneratorCommand extends Command
         }
 
         $filename = $this->argument('filename');
-        $format = $this->option('format');
 
-        // Strip the php extension
-        if (substr($filename, -4, 4) === '.php') {
-            $filename = substr($filename, 0, -4);
+        // Add the php extension if missing
+        // This is a backwards-compatible shim and can be removed in the future
+        if (substr($filename, -4, 4) !== '.php') {
+            $filename .= '.php';
         }
-
-        $filename .= '.' . $format;
 
         if ($this->option('memory')) {
             $this->useMemoryDriver();
@@ -115,7 +113,7 @@ class GeneratorCommand extends Command
         }
 
         $generator = new Generator($this->config, $this->view, $this->getOutput(), $helpers);
-        $content = $generator->generate($format);
+        $content = $generator->generate();
         $written = $this->files->put($filename, $content);
 
         if ($written !== false) {
@@ -165,11 +163,9 @@ class GeneratorCommand extends Command
      */
     protected function getOptions()
     {
-        $format = $this->config->get('ide-helper.format');
         $writeMixins = $this->config->get('ide-helper.write_eloquent_model_mixins');
 
         return [
-            ['format', 'F', InputOption::VALUE_OPTIONAL, 'The format for the IDE Helper', $format],
             ['write_mixins', 'W', InputOption::VALUE_OPTIONAL, 'Write mixins to Laravel Model?', $writeMixins],
             ['helpers', 'H', InputOption::VALUE_NONE, 'Include the helper files'],
             ['memory', 'M', InputOption::VALUE_NONE, 'Use sqlite memory driver'],

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -67,21 +67,9 @@ class Generator
     /**
      * Generate the helper file contents;
      *
-     * @param  string  $format  The format to generate the helper in (php/json)
      * @return string;
      */
-    public function generate($format = 'php')
-    {
-        // Check if the generator for this format exists
-        $method = 'generate' . ucfirst($format) . 'Helper';
-        if (method_exists($this, $method)) {
-            return $this->$method();
-        }
-
-        return $this->generatePhpHelper();
-    }
-
-    public function generatePhpHelper()
+    public function generate()
     {
         $app = app();
         return $this->view->make('helper')
@@ -92,33 +80,6 @@ class Generator
             ->with('include_fluent', $this->config->get('ide-helper.include_fluent', true))
             ->with('factories', $this->config->get('ide-helper.include_factory_builders') ? Factories::all() : [])
             ->render();
-    }
-
-    public function generateJsonHelper()
-    {
-        $classes = [];
-        foreach ($this->getValidAliases() as $aliases) {
-            foreach ($aliases as $alias) {
-                $functions = [];
-                foreach ($alias->getMethods() as $method) {
-                    $functions[$method->getName()] = '(' . $method->getParamsWithDefault() . ')';
-                }
-                $classes[$alias->getAlias()] = [
-                    'functions' => $functions,
-                ];
-            }
-        }
-
-        $flags = JSON_FORCE_OBJECT;
-        if (defined('JSON_PRETTY_PRINT')) {
-            $flags |= JSON_PRETTY_PRINT;
-        }
-
-        return json_encode([
-            'php' => [
-                'classes' => $classes,
-            ],
-        ], $flags);
     }
 
     protected function detectDrivers()


### PR DESCRIPTION
## Summary
The JSON generate doesn't work, always generates an empty list.

I looked a bit around and seems changes around 3 years ago broke it.

Since there was no bug report ever about this, I conclude this feature
isn't used and suggest to remove it.

This also changes the config `filename` as there's no need for the
extension-less version and the format is gone too. This change is
backwards compatible as we just add back the `.php` in case it's missing
though users are encouraged to update it.

### Links
- Fixes https://github.com/barryvdh/laravel-ide-helper/issues/979

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
