### PR TITLE
Add @see location for macros & mixins to PhpDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Fix phpdoc generate for custom cast with parameter [\#986 / artelkr](https://github.com/barryvdh/laravel-ide-helper/pull/986)
 - Created a possibility to add custom relation type [\#987 / efinder2](https://github.com/barryvdh/laravel-ide-helper/pull/987)
+- Added `@see` with link to macro/mixin definition location to PhpDoc
 
 ### Changed
 - Implement DeferrableProvider [\#914 / kon-shou](https://github.com/barryvdh/laravel-ide-helper/pull/914)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Fix phpdoc generate for custom cast with parameter [\#986 / artelkr](https://github.com/barryvdh/laravel-ide-helper/pull/986)
 - Created a possibility to add custom relation type [\#987 / efinder2](https://github.com/barryvdh/laravel-ide-helper/pull/987)
-- Added `@see` with link to macro/mixin definition location to PhpDoc
+- Added `@see` with macro/mixin definition location to PhpDoc
 
 ### Changed
 - Implement DeferrableProvider [\#914 / kon-shou](https://github.com/barryvdh/laravel-ide-helper/pull/914)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Fix phpdoc generate for custom cast with parameter [\#986 / artelkr](https://github.com/barryvdh/laravel-ide-helper/pull/986)
 - Created a possibility to add custom relation type [\#987 / efinder2](https://github.com/barryvdh/laravel-ide-helper/pull/987)
-- Added `@see` with macro/mixin definition location to PhpDoc
+- Added `@see` with macro/mixin definition location to PhpDoc [\#1054 / riesjart](https://github.com/barryvdh/laravel-ide-helper/pull/1054)
 
 ### Changed
 - Implement DeferrableProvider [\#914 / kon-shou](https://github.com/barryvdh/laravel-ide-helper/pull/914)

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -71,7 +71,8 @@ class Macro extends Method
         if ($enclosingMethod) {
 
             $this->phpdoc->appendTag(Tag::createInstance(
-                '@see \\' . $enclosingClass->getName() . '::' . $enclosingMethod->getName() . '()'));
+                '@see \\' . $enclosingClass->getName() . '::' . $enclosingMethod->getName() . '()'
+            ));
         }
     }
 

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -4,6 +4,7 @@ namespace Barryvdh\LaravelIdeHelper;
 
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Tag;
+use Illuminate\Support\Collection;
 
 class Macro extends Method
 {
@@ -33,6 +34,8 @@ class Macro extends Method
     {
         $this->phpdoc = new DocBlock('/** */');
 
+        $this->addLocationToPhpDoc();
+
         // Add macro parameters
         foreach ($method->getParameters() as $parameter) {
             $type = $parameter->hasType() ? $parameter->getType()->getName() : 'mixed';
@@ -50,6 +53,25 @@ class Macro extends Method
             $type .= $method->getReturnType()->allowsNull() ? '|null' : '';
 
             $this->phpdoc->appendTag(Tag::createInstance("@return {$type}"));
+        }
+    }
+
+    protected function addLocationToPhpDoc()
+    {
+        $enclosingClass = $this->method->getClosureScopeClass();
+
+        /** @var \ReflectionMethod $enclosingMethod */
+        $enclosingMethod = Collection::make($enclosingClass->getMethods())
+            ->first(function (\ReflectionMethod $method) {
+
+                return $method->getStartLine() <= $this->method->getStartLine()
+                    && $method->getEndLine() >= $this->method->getEndLine();
+            });
+
+        if ($enclosingMethod) {
+
+            $this->phpdoc->appendTag(Tag::createInstance(
+                '@see \\' . $enclosingClass->getName() . '::' . $enclosingMethod->getName() . '()'));
         }
     }
 

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -63,13 +63,11 @@ class Macro extends Method
         /** @var \ReflectionMethod $enclosingMethod */
         $enclosingMethod = Collection::make($enclosingClass->getMethods())
             ->first(function (\ReflectionMethod $method) {
-
                 return $method->getStartLine() <= $this->method->getStartLine()
                     && $method->getEndLine() >= $this->method->getEndLine();
             });
 
         if ($enclosingMethod) {
-
             $this->phpdoc->appendTag(Tag::createInstance(
                 '@see \\' . $enclosingClass->getName() . '::' . $enclosingMethod->getName() . '()'
             ));


### PR DESCRIPTION
## Summary

This PR adds an `@see` with the macro/mixin definition location to PhpDoc.

### Macro example

Logic:
```
class CollectionServiceProvider
{
    public function boot(): void
    {
        \Illuminate\Support\Collection::macro('toEloquent', function(): \Illuminate\Database\Eloquent\Collection {

            return \Illuminate\Database\Eloquent\Collection::make($this);
        });
    }
}
```

IDE helper:
```
/**
 * @see \Collection\CollectionServiceProvider::boot()
 * @return \Illuminate\Database\Eloquent\Collection
 * @static
 */
public static function toEloquent()
{
    return \Illuminate\Support\Collection::toEloquent();
}
```

### Mixin example

Logic:
```
/**
 * @mixin \Illuminate\Support\Collection
 */
class CollectionMixin
{
    public function toEloquent(): Closure
    {
        return function(): \Illuminate\Database\Eloquent\Collection {

            return \Illuminate\Database\Eloquent\Collection::make($this);
        };
    }
}
```

IDE helper:
```
/**
 * @see \Collection\CollectionMixin::toEloquent()
 * @return \Illuminate\Database\Eloquent\Collection
 * @static
 */
public static function toEloquent()
{
    return \Illuminate\Support\Collection::toEloquent();
}
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)
