### PR TITLE
fix: add additional types for date properties

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -150,9 +150,7 @@ class ModelsCommand extends Command
             }
         }
 
-        $this->dateClass = class_exists(\Illuminate\Support\Facades\Date::class)
-            ? '\\' . get_class(\Illuminate\Support\Facades\Date::now())
-            : '\Illuminate\Support\Carbon';
+        $this->buildDateClass();
 
         $content = $this->generateDocs($model, $ignore);
 
@@ -166,6 +164,27 @@ class ModelsCommand extends Command
         }
     }
 
+    protected function buildDateClass(): void
+    {
+        $dateClass = class_exists(\Illuminate\Support\Facades\Date::class)
+            ? '\\' . get_class(\Illuminate\Support\Facades\Date::now())
+            : '\Illuminate\Support\Carbon';
+
+        $types = array_map(
+            [$this, 'getTypeOverride'],
+            [
+                $dateClass,
+                '\Carbon\CarbonInterface',
+                '\DateTimeInterface',
+                'integer',
+                'string',
+            ]
+        );
+
+        sort($types);
+
+        $this->dateClass = implode('|', array_unique($types));
+    }
 
     /**
      * Get the console command arguments.
@@ -423,7 +442,7 @@ class ModelsCommand extends Command
 
         $database = null;
         if (strpos($table, '.')) {
-            list($database, $table) = explode('.', $table);
+            [$database, $table] = explode('.', $table);
         }
 
         $columns = $schema->listTableColumns($table, $database);

--- a/tests/Console/ModelsCommand/CustomDate/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/CustomDate/__snapshots__/Test__test__1.php
@@ -9,8 +9,8 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomDate\Models\CustomDate
  *
- * @property \Carbon\CarbonImmutable|null $created_at
- * @property \Carbon\CarbonImmutable|null $updated_at
+ * @property \Carbon\CarbonImmutable|\Carbon\CarbonInterface|\DateTimeInterface|integer|string|null $created_at
+ * @property \Carbon\CarbonImmutable|\Carbon\CarbonInterface|\DateTimeInterface|integer|string|null $updated_at
  * @method static \Illuminate\Database\Eloquent\Builder|CustomDate newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|CustomDate newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|CustomDate query()

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdoc/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdoc/__snapshots__/Test__test__1.php
@@ -80,8 +80,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $ipaddress_not_nullable
  * @property string|null $macaddress_nullable
  * @property string $macaddress_not_nullable
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $created_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $updated_at
  * @method static \Illuminate\Database\Eloquent\Builder|Post newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Post newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Post query()

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdocCamel/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdocCamel/__snapshots__/Test__test__1.php
@@ -80,8 +80,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $ipaddressNotNullable
  * @property string|null $macaddressNullable
  * @property string $macaddressNotNullable
- * @property \Illuminate\Support\Carbon|null $createdAt
- * @property \Illuminate\Support\Carbon|null $updatedAt
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $createdAt
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $updatedAt
  * @method static \Illuminate\Database\Eloquent\Builder|Post newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Post newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Post query()

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdocFinal/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdocFinal/__snapshots__/Test__test__1.php
@@ -80,8 +80,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $ipaddress_not_nullable
  * @property string|null $macaddress_nullable
  * @property string $macaddress_not_nullable
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $created_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $updated_at
  * @method static \Illuminate\Database\Eloquent\Builder|Post newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Post newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Post query()

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
@@ -82,8 +82,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $ipaddress_not_nullable
  * @property string|null $macaddress_nullable
  * @property string $macaddress_not_nullable
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $created_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $updated_at
  * @property-read \Illuminate\Database\Eloquent\Collection|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post[] $posts
  * @property-read int|null $posts_count
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post newModelQuery()

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
@@ -88,8 +88,8 @@ use Illuminate\Support\Carbon;
  * @property string $ipaddress_not_nullable
  * @property string|null $macaddress_nullable
  * @property string $macaddress_not_nullable
- * @property Carbon|null $created_at
- * @property Carbon|null $updated_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $created_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $updated_at
  * @property-read Collection|Post[] $posts
  * @property-read int|null $posts_count
  * @method static EloquentBuilder|Post newModelQuery()

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/__snapshots__/Test__test__1.php
@@ -85,8 +85,8 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @property string $ipaddress_not_nullable
  * @property string|null $macaddress_nullable
  * @property string $macaddress_not_nullable
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $created_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $updated_at
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Builders\EMaterialQueryBuilder|Post newModelQuery()
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Builders\EMaterialQueryBuilder|Post newQuery()
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Builders\EMaterialQueryBuilder|Post query()

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/__snapshots__/Test__test__1.php
@@ -103,8 +103,8 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @property string $ipaddress_not_nullable
  * @property string|null $macaddress_nullable
  * @property string $macaddress_not_nullable
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $created_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $updated_at
  * @method static \Illuminate\Database\Eloquent\Builder|Post newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Post newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Post query()

--- a/tests/Console/ModelsCommand/MagicWhere/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/MagicWhere/__snapshots__/Test__test__1.php
@@ -80,8 +80,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $ipaddress_not_nullable
  * @property string|null $macaddress_nullable
  * @property string $macaddress_not_nullable
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $created_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $updated_at
  * @method static \Illuminate\Database\Eloquent\Builder|Post newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Post newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Post query()

--- a/tests/Console/ModelsCommand/RelationCountProperties/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/RelationCountProperties/__snapshots__/Test__test__1.php
@@ -81,8 +81,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string $ipaddress_not_nullable
  * @property string|null $macaddress_nullable
  * @property string $macaddress_not_nullable
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $created_at
+ * @property \Carbon\CarbonInterface|\DateTimeInterface|\Illuminate\Support\Carbon|integer|string|null $updated_at
  * @property-read \Illuminate\Database\Eloquent\Collection|Post[] $relationHasMany
  * @method static \Illuminate\Database\Eloquent\Builder|Post newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Post newQuery()


### PR DESCRIPTION
## Summary

Date properties do not allow additional types supported by Laravel. The $model->asDateTime($value) method ([\Illuminate\Database\Eloquent\Concerns\HasAttributes::asDateTime](https://github.com/laravel/framework/blob/1b83b3c03c9513f2e0d0a80ee8a895b07534237b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L875-L923)) is used when setting a date attribute/property.

Note: based on what the `asDateTime` method expects, it no longer makes sense to type hint against a custom date class because any date value must be "numeric", a `string`, or implement either `\Carbon\CarbonInterface` or `\DateTimeInterface` (`\Carbon\CarbonInterface` implements this interface). `\Illuminate\Support\Carbon` extends `\Carbon\Carbon` which in turn implements `\Carbon\CarbonInterface`. Something to consider.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [X] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [X] Code style has been fixed via `composer fix-style`

I have created this PR in response to @mfn's comments on #989.