### PR TITLE
Fix --no-dev installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,45 @@ You can use an in-memory SQLite driver by adding the `-M` option.
 You can choose to include helper files. This is not enabled by default, but you can override it with the `--helpers (-H)` option.
 The `Illuminate/Support/helpers.php` is already set up, but you can add/remove your own files in the config file.
 
+#### Cooperation with release builds
+Create a file `app/Console/Commands/IdeHelperDoIt.php`:
+```php
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+
+class IdeHelperDoIt extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ide-helper:do-it';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run barryvdh/laravel-ide-helper';
+
+    public function handle()
+    {
+        if ('local' === config('app.env', 'production')) {
+            Artisan::call('ide-helper:generate');
+            Artisan::call('ide-helper:meta');
+            Artisan::call('ide-helper:models', ['--nowrite' => true]);
+        }
+    }
+}
+```
+
+In `composer.json` you can then add `"@php artisan ide-helper:do-it"` that will gracefully work indepent of `--no-dev` composer installs.
+
 ### Automatic PHPDoc generation for macros and mixins
 
 This package can generate PHPDocs for macros and mixins which will be added to the `_ide_helper.php` file.


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->
When barryvdh/laravel-ide-helper is a dev dependency, it is not available with `--no-dev` installs ("release builds"). Which will give errors if you add it as `post-update-cmd` or `post-install-cmd` in `composer.json`.

This fixes that by making an intermediate that checks for `APP_ENV="local"` in `.env`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [x] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
