### PR TITLE
composer.json: remove --prefer-lowest

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,12 +21,11 @@ jobs:
       matrix:
         php: [7.4, 7.3, 7.2]
         laravel: [8.*, 7.*, 6.*]
-        dependency-version: [prefer-lowest, prefer-stable]
         exclude:
           - laravel: 8.*
             php: 7.2
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }}
 
     steps:
     - name: Checkout code
@@ -43,7 +42,7 @@ jobs:
       run: |
         composer remove vimeo/psalm --no-update --dev
         composer require "laravel/framework:${{ matrix.laravel }}" --no-update --no-progress
-        composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress
+        composer update --prefer-dist --no-progress
 
     - name: Execute Unit Tests
       run: composer test-ci


### PR DESCRIPTION
## Summary
IMHO it's impractical to expect this package to have to work with the
"first release of Laravel for any major release" even when there are
already sever more releases: no one is/should stick to that version.

See also  https://github.com/barryvdh/laravel-ide-helper/pull/1074#pullrequestreview-504182121

## Type of change
- [x] Misc. change (internal, infrastructure, maintenance, etc.)
