### PR TITLE
Add support for dedicated eloquent builders and type/doc parameter support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,13 @@ You may use the [`::withCount`](https://laravel.com/docs/master/eloquent-relatio
 
 By default, these attributes are generated in the phpdoc. You can turn them off by setting the config `write_model_relation_count_properties` to `false`.
 
+#### Dedicated Eloquent Builder methods
+
+A new method to the eloquent models was added called `newEloquentBuilder` [Reference](https://timacdonald.me/dedicated-eloquent-model-query-builders/) where we can 
+add support for creating a new dedicated class instead of using local scopes in the model itself.
+
+If for some reason it's undesired to have them generated (one for each column), you can disable this via config `write_model_external_builder_methods` and setting it to `false`.
+
 #### Unsupported or custom database types
 
 Common column types (e.g. varchar, integer) are correctly mapped to PHP types (`string`, `int`).

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -64,6 +64,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Write Model External Eloquent Builder methods
+    |--------------------------------------------------------------------------
+    |
+    | Set to false to disable write external eloquent builder methods
+    |
+    */
+
+    'write_model_external_builder_methods' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Write Model relation count properties
     |--------------------------------------------------------------------------
     |

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -35,7 +35,7 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
             //Method inherited from <?= $method->getDeclaringClass() ?>
          <?php endif; ?>
 
-            <?php if ($method->isInstanceCall()) :?>
+            <?php if ($method->isInstanceCall()) : ?>
             /** @var <?=$method->getRoot()?> $instance */
             <?php endif?>
             <?= $method->shouldReturn() ? 'return ' : '' ?><?= $method->getRootMethodCall() ?>;
@@ -58,7 +58,7 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
                 //Method inherited from <?= $method->getDeclaringClass() ?>
              <?php endif; ?>
 
-                <?php if ($method->isInstanceCall()) :?>
+                <?php if ($method->isInstanceCall()) : ?>
                 /** @var <?=$method->getRoot()?> $instance */
                 <?php endif?>
                 <?= $method->shouldReturn() ? 'return ' : '' ?><?= $method->getRootMethodCall() ?>;

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -923,7 +923,7 @@ class ModelsCommand extends Command
             }
 
             if ($withTypeHint && $paramType = $this->getParamType($method, $param)) {
-                $paramStr = $paramType . ' ' .  $paramStr;
+                $paramStr = $paramType . ' ' . $paramStr;
             }
 
             $paramsWithDefault[] = $paramStr;

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1141,7 +1141,7 @@ class ModelsCommand extends Command
 
     protected function writeModelExternalBuilderMethods(string $builder, Model $model): void
     {
-        if ($builder !== '\Illuminate\Database\Eloquent\Builder') {
+        if (!in_array($builder, ['\Illuminate\Database\Eloquent\Builder', 'EloquentBuilder'])) {
             $newBuilderMethods = get_class_methods($builder);
             $originalBuilderMethods = get_class_methods('\Illuminate\Database\Eloquent\Builder');
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1176,10 +1176,10 @@ class ModelsCommand extends Command
     {
         if ($paramType = $parameter->getType()) {
             if ($paramType->allowsNull()) {
-                return '?' . (string) $paramType;
+                return '?' . $paramType->getName();
             }
 
-            return (string) $paramType;
+            return $paramType->getName();
         }
 
         $docComment = $method->getDocComment();

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1141,24 +1141,25 @@ class ModelsCommand extends Command
 
     protected function writeModelExternalBuilderMethods(string $builder, Model $model): void
     {
-        if (!in_array($builder, ['\Illuminate\Database\Eloquent\Builder', 'EloquentBuilder'])) {
-            $newBuilderMethods = get_class_methods($builder);
-            $originalBuilderMethods = get_class_methods('\Illuminate\Database\Eloquent\Builder');
-
-            // diff the methods between the new builder and original one
-            // and create helpers for the ones that are new
-            $newMethodsFromNewBuilder = array_diff($newBuilderMethods, $originalBuilderMethods);
-
-            foreach ($newMethodsFromNewBuilder as $builderMethod) {
-                $reflection = new \ReflectionMethod($builder, $builderMethod);
-                $args = $this->getParameters($reflection);
-                $this->setMethod(
-                    $builderMethod,
-                    $builder . '|' . $this->getClassNameInDestinationFile($model, get_class($model)),
-                    $args
-                );
-            }
+        if (in_array($builder, ['\Illuminate\Database\Eloquent\Builder', 'EloquentBuilder'])) {
+            return;
         }
 
+        $newBuilderMethods = get_class_methods($builder);
+        $originalBuilderMethods = get_class_methods('\Illuminate\Database\Eloquent\Builder');
+
+        // diff the methods between the new builder and original one
+        // and create helpers for the ones that are new
+        $newMethodsFromNewBuilder = array_diff($newBuilderMethods, $originalBuilderMethods);
+
+        foreach ($newMethodsFromNewBuilder as $builderMethod) {
+            $reflection = new \ReflectionMethod($builder, $builderMethod);
+            $args = $this->getParameters($reflection);
+            $this->setMethod(
+                $builderMethod,
+                $builder . '|' . $this->getClassNameInDestinationFile($model, get_class($model)),
+                $args
+            );
+        }
     }
 }

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1195,7 +1195,7 @@ class ModelsCommand extends Command
         );
         $type = $matches[1] ?? null;
 
-        if (str_contains($type, '|')) {
+        if (strpos($type, '|') !== false) {
             $types = explode('|', $type);
 
             // if we have more than 2 types

--- a/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
+++ b/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Builders;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class PostExternalQueryBuilder extends Builder
+{
+    public function isActive(): self
+    {
+        return $this;
+    }
+
+    public function isStatus(string $status): self
+    {
+        return $this;
+    }
+}

--- a/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/Models/Post.php
+++ b/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/Models/Post.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder;
+
+class Post extends Model
+{
+    public function newEloquentBuilder($query): PostExternalQueryBuilder
+    {
+        return new PostExternalQueryBuilder($query);
+    }
+}

--- a/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/Models/Post.php
+++ b/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/Models/Post.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder;
+use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {

--- a/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/Test.php
+++ b/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/Test.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+
+class Test extends AbstractModelsCommand
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('ide-helper.write_model_external_builder_methods', false);
+    }
+
+    public function test(): void
+    {
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--nowrite' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Model information was written to _ide_helper_models.php', $tester->getDisplay());
+        $this->assertMatchesMockedSnapshot();
+    }
+}

--- a/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
@@ -1,0 +1,169 @@
+<?php
+
+// @formatter:off
+/**
+ * A helper file for your Eloquent Models
+ * Copy the phpDocs from this file to the correct Model,
+ * And remove them from this file, to prevent double declarations.
+ *
+ * @author Barry vd. Heuvel <barryvdh@gmail.com>
+ */
+
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Models{
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Models\Post
+ *
+ * @property integer $id
+ * @property string|null $char_nullable
+ * @property string $char_not_nullable
+ * @property string|null $string_nullable
+ * @property string $string_not_nullable
+ * @property string|null $text_nullable
+ * @property string $text_not_nullable
+ * @property string|null $medium_text_nullable
+ * @property string $medium_text_not_nullable
+ * @property string|null $long_text_nullable
+ * @property string $long_text_not_nullable
+ * @property integer|null $integer_nullable
+ * @property integer $integer_not_nullable
+ * @property integer|null $tiny_integer_nullable
+ * @property integer $tiny_integer_not_nullable
+ * @property integer|null $small_integer_nullable
+ * @property integer $small_integer_not_nullable
+ * @property integer|null $medium_integer_nullable
+ * @property integer $medium_integer_not_nullable
+ * @property integer|null $big_integer_nullable
+ * @property integer $big_integer_not_nullable
+ * @property integer|null $unsigned_integer_nullable
+ * @property integer $unsigned_integer_not_nullable
+ * @property integer|null $unsigned_tiny_integer_nullable
+ * @property integer $unsigned_tiny_integer_not_nullable
+ * @property integer|null $unsigned_small_integer_nullable
+ * @property integer $unsigned_small_integer_not_nullable
+ * @property integer|null $unsigned_medium_integer_nullable
+ * @property integer $unsigned_medium_integer_not_nullable
+ * @property integer|null $unsigned_big_integer_nullable
+ * @property integer $unsigned_big_integer_not_nullable
+ * @property float|null $float_nullable
+ * @property float $float_not_nullable
+ * @property float|null $double_nullable
+ * @property float $double_not_nullable
+ * @property string|null $decimal_nullable
+ * @property string $decimal_not_nullable
+ * @property string|null $unsigned_decimal_nullable
+ * @property string $unsigned_decimal_not_nullable
+ * @property integer|null $boolean_nullable
+ * @property integer $boolean_not_nullable
+ * @property string|null $enum_nullable
+ * @property string $enum_not_nullable
+ * @property string|null $json_nullable
+ * @property string $json_not_nullable
+ * @property string|null $jsonb_nullable
+ * @property string $jsonb_not_nullable
+ * @property string|null $date_nullable
+ * @property string $date_not_nullable
+ * @property string|null $datetime_nullable
+ * @property string $datetime_not_nullable
+ * @property string|null $datetimetz_nullable
+ * @property string $datetimetz_not_nullable
+ * @property string|null $time_nullable
+ * @property string $time_not_nullable
+ * @property string|null $timetz_nullable
+ * @property string $timetz_not_nullable
+ * @property string|null $timestamp_nullable
+ * @property string $timestamp_not_nullable
+ * @property string|null $timestamptz_nullable
+ * @property string $timestamptz_not_nullable
+ * @property integer|null $year_nullable
+ * @property integer $year_not_nullable
+ * @property mixed|null $binary_nullable
+ * @property mixed $binary_not_nullable
+ * @property string|null $uuid_nullable
+ * @property string $uuid_not_nullable
+ * @property string|null $ipaddress_nullable
+ * @property string $ipaddress_not_nullable
+ * @property string|null $macaddress_nullable
+ * @property string $macaddress_not_nullable
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post newModelQuery()
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post newQuery()
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBigIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBigIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBinaryNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBinaryNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBooleanNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBooleanNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereCharNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereCharNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDateNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDateNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDatetimeNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDatetimeNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDatetimetzNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDatetimetzNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDecimalNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDecimalNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDoubleNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDoubleNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereEnumNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereEnumNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereFloatNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereFloatNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereIpaddressNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereIpaddressNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereJsonNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereJsonNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereJsonbNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereJsonbNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereLongTextNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereLongTextNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMacaddressNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMacaddressNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMediumIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMediumIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMediumTextNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMediumTextNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereSmallIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereSmallIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereStringNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereStringNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTextNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTextNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimeNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimeNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimestampNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimestampNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimestamptzNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimestamptzNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimetzNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimetzNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTinyIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTinyIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedMediumIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedMediumIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedSmallIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedSmallIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedTinyIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedTinyIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUuidNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUuidNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNullable($value)
+ */
+	class Post extends \Eloquent {}
+}
+

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class PostExternalQueryBuilder extends Builder
+{
+    public function isActive(): self
+    {
+        return $this;
+    }
+
+    public function isStatus(string $status): self
+    {
+        return $this;
+    }
+}

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
@@ -17,4 +17,27 @@ class PostExternalQueryBuilder extends Builder
     {
         return $this;
     }
+
+    public function isLoadingWith(?string $with): self
+    {
+        return $this;
+    }
+
+    /**
+     * @param int|null $number
+     * @return $this
+     */
+    public function withTheNumber($number): self
+    {
+        return $this;
+    }
+
+    /**
+     * @param int|string $someone
+     * @return $this
+     */
+    public function withSomeone($someone): self
+    {
+        return $this;
+    }
 }

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
@@ -40,4 +40,13 @@ class PostExternalQueryBuilder extends Builder
     {
         return $this;
     }
+
+    /**
+     * @param mixed $option
+     * @return $this
+     */
+    public function withMixedOption($option): self
+    {
+        return $this;
+    }
 }

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Models/Post.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Models/Post.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder;
+
+class Post extends Model
+{
+    public function newEloquentBuilder($query): PostExternalQueryBuilder
+    {
+        return new PostExternalQueryBuilder($query);
+    }
+}

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Models/Post.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Models/Post.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder;
+use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Test.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Test.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+
+class Test extends AbstractModelsCommand
+{
+    public function test(): void
+    {
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--nowrite' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Model information was written to _ide_helper_models.php', $tester->getDisplay());
+        $this->assertMatchesMockedSnapshot();
+    }
+}

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
@@ -88,7 +88,8 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post isActive()
- * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post isStatus($status)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post isLoadingWith(?string $with)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post isStatus(string $status)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post newModelQuery()
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post newQuery()
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post query()
@@ -165,6 +166,8 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUuidNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNullable($value)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withSomeone($someone)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withTheNumber(?int $number)
  */
 	class Post extends \Eloquent {}
 }

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
@@ -1,0 +1,171 @@
+<?php
+
+// @formatter:off
+/**
+ * A helper file for your Eloquent Models
+ * Copy the phpDocs from this file to the correct Model,
+ * And remove them from this file, to prevent double declarations.
+ *
+ * @author Barry vd. Heuvel <barryvdh@gmail.com>
+ */
+
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Models{
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Models\Post
+ *
+ * @property integer $id
+ * @property string|null $char_nullable
+ * @property string $char_not_nullable
+ * @property string|null $string_nullable
+ * @property string $string_not_nullable
+ * @property string|null $text_nullable
+ * @property string $text_not_nullable
+ * @property string|null $medium_text_nullable
+ * @property string $medium_text_not_nullable
+ * @property string|null $long_text_nullable
+ * @property string $long_text_not_nullable
+ * @property integer|null $integer_nullable
+ * @property integer $integer_not_nullable
+ * @property integer|null $tiny_integer_nullable
+ * @property integer $tiny_integer_not_nullable
+ * @property integer|null $small_integer_nullable
+ * @property integer $small_integer_not_nullable
+ * @property integer|null $medium_integer_nullable
+ * @property integer $medium_integer_not_nullable
+ * @property integer|null $big_integer_nullable
+ * @property integer $big_integer_not_nullable
+ * @property integer|null $unsigned_integer_nullable
+ * @property integer $unsigned_integer_not_nullable
+ * @property integer|null $unsigned_tiny_integer_nullable
+ * @property integer $unsigned_tiny_integer_not_nullable
+ * @property integer|null $unsigned_small_integer_nullable
+ * @property integer $unsigned_small_integer_not_nullable
+ * @property integer|null $unsigned_medium_integer_nullable
+ * @property integer $unsigned_medium_integer_not_nullable
+ * @property integer|null $unsigned_big_integer_nullable
+ * @property integer $unsigned_big_integer_not_nullable
+ * @property float|null $float_nullable
+ * @property float $float_not_nullable
+ * @property float|null $double_nullable
+ * @property float $double_not_nullable
+ * @property string|null $decimal_nullable
+ * @property string $decimal_not_nullable
+ * @property string|null $unsigned_decimal_nullable
+ * @property string $unsigned_decimal_not_nullable
+ * @property integer|null $boolean_nullable
+ * @property integer $boolean_not_nullable
+ * @property string|null $enum_nullable
+ * @property string $enum_not_nullable
+ * @property string|null $json_nullable
+ * @property string $json_not_nullable
+ * @property string|null $jsonb_nullable
+ * @property string $jsonb_not_nullable
+ * @property string|null $date_nullable
+ * @property string $date_not_nullable
+ * @property string|null $datetime_nullable
+ * @property string $datetime_not_nullable
+ * @property string|null $datetimetz_nullable
+ * @property string $datetimetz_not_nullable
+ * @property string|null $time_nullable
+ * @property string $time_not_nullable
+ * @property string|null $timetz_nullable
+ * @property string $timetz_not_nullable
+ * @property string|null $timestamp_nullable
+ * @property string $timestamp_not_nullable
+ * @property string|null $timestamptz_nullable
+ * @property string $timestamptz_not_nullable
+ * @property integer|null $year_nullable
+ * @property integer $year_not_nullable
+ * @property mixed|null $binary_nullable
+ * @property mixed $binary_not_nullable
+ * @property string|null $uuid_nullable
+ * @property string $uuid_not_nullable
+ * @property string|null $ipaddress_nullable
+ * @property string $ipaddress_not_nullable
+ * @property string|null $macaddress_nullable
+ * @property string $macaddress_not_nullable
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post isActive()
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post isStatus($status)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post newModelQuery()
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post newQuery()
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBigIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBigIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBinaryNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBinaryNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBooleanNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereBooleanNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereCharNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereCharNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDateNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDateNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDatetimeNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDatetimeNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDatetimetzNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDatetimetzNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDecimalNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDecimalNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDoubleNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereDoubleNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereEnumNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereEnumNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereFloatNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereFloatNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereIpaddressNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereIpaddressNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereJsonNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereJsonNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereJsonbNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereJsonbNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereLongTextNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereLongTextNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMacaddressNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMacaddressNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMediumIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMediumIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMediumTextNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereMediumTextNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereSmallIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereSmallIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereStringNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereStringNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTextNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTextNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimeNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimeNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimestampNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimestampNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimestamptzNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimestamptzNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimetzNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTimetzNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTinyIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereTinyIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedMediumIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedMediumIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedSmallIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedSmallIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedTinyIntegerNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedTinyIntegerNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUuidNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereUuidNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNotNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNullable($value)
+ */
+	class Post extends \Eloquent {}
+}
+

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
@@ -166,6 +166,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUuidNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNullable($value)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withMixedOption($option)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withSomeone($someone)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withTheNumber(?int $number)
  */


### PR DESCRIPTION
#887 

## Summary
Added a new feature where we create a helper file with external eloquent builders [Reference](https://timacdonald.me/dedicated-eloquent-model-query-builders/). 

This is very useful as in my big projects I do use this feature and so does some people -- [Issue](https://github.com/barryvdh/laravel-ide-helper/issues/887).

## Type of change

<!-- Please delete options that are not relevant. -->

- [ x ] New feature (non-breaking change which adds functionality)
- [ x ] This change requires a documentation update 
- [ x ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ x ] Existing tests have been adapted and/or new tests have been added
- [ x ] Update the README.md
- [ x ] Code style has been fixed via `composer fix-style`
- [ x ] Tested
