### PR TITLE
Reorganize names (Cleaner and more logical command names and generated file names)

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -40,6 +40,7 @@ jobs:
                   cd sample
                   composer require "league/flysystem" --no-update --no-progress
                   composer update  --prefer-stable --prefer-dist --no-progress
+                  mkdir .ide-helper
 
             - name: Add package from source
               run: |
@@ -99,6 +100,7 @@ jobs:
               run: |
                   composer create-project --prefer-dist laravel/laravel:${{ matrix.laravel }} --no-progress sample
                   cd sample
+                  mkdir .ide-helper
                   composer update --prefer-stable --prefer-dist --no-progress
 
             - name: Add package from source

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -53,12 +53,12 @@ jobs:
             - name: Execute generate run
               run: |
                   cd sample
-                  php artisan ide-helper:generate
+                  php artisan ide-helper:generate-facades
 
             - name: Execute meta run
               run: |
                   cd sample
-                  php artisan ide-helper:meta
+                  php artisan ide-helper:generate-phpstorm
 
             - name: Check file existence
               run: |
@@ -110,12 +110,12 @@ jobs:
             - name: Execute generate run
               run: |
                   cd sample
-                  php artisan ide-helper:generate
+                  php artisan ide-helper:generate-facades
 
             - name: Execute meta run
               run: |
                   cd sample
-                  php artisan ide-helper:meta
+                  php artisan ide-helper:generate-phpstorm
 
             - name: Check file existence
               run: |

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -40,7 +40,6 @@ jobs:
                   cd sample
                   composer require "league/flysystem" --no-update --no-progress
                   composer update  --prefer-stable --prefer-dist --no-progress
-                  mkdir .ide-helper
 
             - name: Add package from source
               run: |
@@ -54,7 +53,7 @@ jobs:
             - name: Execute generate run
               run: |
                   cd sample
-                  mkdir .ide-helper
+                  mkdir .ide_helper
                   php artisan ide-helper:generate-facades
 
             - name: Execute meta run
@@ -101,7 +100,6 @@ jobs:
               run: |
                   composer create-project --prefer-dist laravel/laravel:${{ matrix.laravel }} --no-progress sample
                   cd sample
-                  mkdir .ide-helper
                   composer update --prefer-stable --prefer-dist --no-progress
 
             - name: Add package from source
@@ -113,7 +111,7 @@ jobs:
             - name: Execute generate run
               run: |
                   cd sample
-                  mkdir .ide-helper
+                  mkdir .ide_helper
                   php artisan ide-helper:generate-facades
 
             - name: Execute meta run

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -54,6 +54,7 @@ jobs:
             - name: Execute generate run
               run: |
                   cd sample
+                  mkdir .ide-helper
                   php artisan ide-helper:generate-facades
 
             - name: Execute meta run
@@ -112,6 +113,7 @@ jobs:
             - name: Execute generate run
               run: |
                   cd sample
+                  mkdir .ide-helper
                   php artisan ide-helper:generate-facades
 
             - name: Execute meta run

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -63,7 +63,7 @@ jobs:
 
             - name: Check file existence
               run: |
-                ls sample/.ide_helper/_ide_helper.php
+                ls sample/.ide_helper/.facades.meta.php
                 ls sample/.ide_helper/.phpstorm.meta.php
 
             - name: Check file count in logs
@@ -121,7 +121,7 @@ jobs:
 
             - name: Check file existence
               run: |
-                ls sample/.ide_helper/_ide_helper.php
+                ls sample/.ide_helper/.facades.meta.php
                 ls sample/.ide_helper/.phpstorm.meta.php
 
             - name: Check file count in logs

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -63,8 +63,8 @@ jobs:
 
             - name: Check file existence
               run: |
-                ls sample/_ide_helper.php
-                ls sample/.phpstorm.meta.php
+                ls sample/.ide_helper/_ide_helper.php
+                ls sample/.ide_helper/.phpstorm.meta.php
 
             - name: Check file count in logs
               run: |
@@ -121,8 +121,8 @@ jobs:
 
             - name: Check file existence
               run: |
-                ls sample/_ide_helper.php
-                ls sample/.phpstorm.meta.php
+                ls sample/.ide_helper/_ide_helper.php
+                ls sample/.ide_helper/.phpstorm.meta.php
 
             - name: Check file count in logs
               run: |

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ If for some reason you want manually control this:
 
 _Check out [this Laracasts video](https://laracasts.com/series/how-to-be-awesome-in-phpstorm/episodes/15) for a quick introduction/explanation!_
 
-- [`php artisan ide-helper:generate` - PHPDoc generation for Laravel Facades ](#automatic-phpdoc-generation-for-laravel-facades)
-- [`php artisan ide-helper:models` - PHPDocs for models](#automatic-PHPDocs-for-models)
-- [`php artisan ide-helper:meta` - PhpStorm Meta file](#phpstorm-meta-for-container-instances)
+- [`php artisan ide-helper:generate-facades` - PHPDoc generation for Laravel Facades ](#automatic-phpdoc-generation-for-laravel-facades)
+- [`php artisan ide-helper:generate-models` - PHPDocs for models](#automatic-PHPDocs-for-models)
+- [`php artisan ide-helper:generate-phpstorm` - PhpStorm Meta file](#phpstorm-meta-for-container-instances)
 
 
 Note: You do need CodeComplice for Sublime Text: https://github.com/spectacles/CodeComplice
@@ -77,7 +77,7 @@ Note: You do need CodeComplice for Sublime Text: https://github.com/spectacles/C
 You can now re-generate the docs yourself (for future updates)
 
 ```bash
-php artisan ide-helper:generate
+php artisan ide-helper:generate-facades
 ```
 
 Note: `bootstrap/compiled.php` has to be cleared first, so run `php artisan clear-compiled` before generating.
@@ -90,8 +90,8 @@ You can configure your `composer.json` to do this each time you update your depe
 "scripts": {
     "post-update-cmd": [
         "Illuminate\\Foundation\\ComposerScripts::postUpdate",
-        "@php artisan ide-helper:generate",
-        "@php artisan ide-helper:meta"
+        "@php artisan ide-helper:generate-facades",
+        "@php artisan ide-helper:generate-phpstorm"
     ]
 },
 ```
@@ -250,7 +250,7 @@ After publishing vendor, simply change the `include_fluent` line your `config/id
 'include_fluent' => true,
 ```
 
-Then run `php artisan ide-helper:generate`, you will now see all Fluent methods recognized by your IDE.
+Then run `php artisan ide-helper:generate-facades`, you will now see all Fluent methods recognized by your IDE.
 
 ### Auto-completion for factory builders
 
@@ -272,7 +272,7 @@ For example, `events` will return an `Illuminate\Events\Dispatcher` object,
 so with the meta file you can call `app('events')` and it will autocomplete the Dispatcher methods.
 
 ```bash
-php artisan ide-helper:meta
+php artisan ide-helper:generate-phpstorm
 ```
 
 ```php
@@ -351,7 +351,7 @@ return [
 ];
 ```
 
-After you run `php artisan ide-helper:generate`, it's recommended (but not mandatory) to rename `config/app.php` to something else,
+After you run `php artisan ide-helper:generate-facades`, it's recommended (but not mandatory) to rename `config/app.php` to something else,
 until you have to re-generate the docs or after passing to production environment.
 Lumen 5.1+ will read this file for configuration parameters if it is present, and may overlap some configurations if it is completely populated.
 

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -43,7 +43,7 @@ return [
     */
 
     'models_filename' => '.models.meta.php',
-    'models_skip_write_ask' => false,
+    'models_skip_write_ask' => true,
 
     /*
     |--------------------------------------------------------------------------

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -2,29 +2,48 @@
 
 return [
 
-    /*
-    |--------------------------------------------------------------------------
-    | Filename & Format
-    |--------------------------------------------------------------------------
-    |
-    | The default filename (without extension) and the format (php or json)
-    |
-    */
-
-    'filename'  => '_ide_helper',
-    'format'    => 'php',
+    'directory' => '.ide_helper/',
+    'format' => 'php',
 
     /*
     |--------------------------------------------------------------------------
-    | Where to write the PhpStorm specific meta file
+    | Ide Helper - Facades
+    |
+    | PHPDoc for Laravel Facades
     |--------------------------------------------------------------------------
     |
-    | PhpStorm also supports the directory `.phpstorm.meta.php/` with arbitrary
-    | files in it, should you need additional files for your project; e.g.
-    | `.phpstorm.meta.php/laravel_ide_Helper.php'.
+    | The default filename
     |
     */
-    'meta_filename' => '.phpstorm.meta.php',
+
+    'facades_filename' => '.facades.meta.php',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Ide Helper - PhpStorm
+    |
+    | PHPDocs for Laravel Models
+    |--------------------------------------------------------------------------
+    |
+    | The default filename
+    |
+    */
+
+    'phpstorm_filename' => '.phpstorm.meta.php',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Ide Helper - Models
+    |
+    | PHPDocs for Laravel Models
+    |--------------------------------------------------------------------------
+    |
+    | The default filename
+    |
+    */
+
+    'models_filename' => '.models.meta.php',
+    'models_skip_write_ask' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -35,7 +35,7 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
             //Method inherited from <?= $method->getDeclaringClass() ?>
          <?php endif; ?>
 
-            <?php if ($method->isInstanceCall()) :?>
+            <?php if ($method->isInstanceCall()) : ?>
             /** @var <?=$method->getRoot()?> $instance */
             <?php endif?>
             <?= $method->shouldReturn() ? 'return ' : '' ?><?= $method->getRootMethodCall() ?>;
@@ -58,7 +58,7 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
                 //Method inherited from <?= $method->getDeclaringClass() ?>
              <?php endif; ?>
 
-                <?php if ($method->isInstanceCall()) :?>
+                <?php if ($method->isInstanceCall()) : ?>
                 /** @var <?=$method->getRoot()?> $instance */
                 <?php endif?>
                 <?= $method->shouldReturn() ? 'return ' : '' ?><?= $method->getRootMethodCall() ?>;

--- a/src/Console/FacadesCommand.php
+++ b/src/Console/FacadesCommand.php
@@ -23,14 +23,14 @@ use Symfony\Component\Console\Input\InputOption;
  *
  * @author Barry vd. Heuvel <barryvdh@gmail.com>
  */
-class GeneratorCommand extends Command
+class FacadesCommand extends Command
 {
     /**
      * The console command name.
      *
      * @var string
      */
-    protected $name = 'ide-helper:generate';
+    protected $name = 'ide-helper:generate-facades';
 
     /**
      * The console command description.
@@ -49,7 +49,6 @@ class GeneratorCommand extends Command
     protected $view;
 
     protected $onlyExtend;
-
 
     /**
      *
@@ -88,20 +87,14 @@ class GeneratorCommand extends Command
             return;
         }
 
-        $filename = $this->argument('filename');
         $format = $this->option('format');
-
-        // Strip the php extension
-        if (substr($filename, -4, 4) === '.php') {
-            $filename = substr($filename, 0, -4);
-        }
-
-        $filename .= '.' . $format;
+        $directory = $this->config->get('ide-helper.directory');
+        $filename = $this->config->get('ide-helper.facades_filename');
+        $filename = $directory . $filename;
 
         if ($this->option('memory')) {
             $this->useMemoryDriver();
         }
-
 
         $helpers = '';
         if ($this->option('helpers') || ($this->config->get('ide-helper.include_helpers'))) {

--- a/src/Console/FacadesCommand.php
+++ b/src/Console/FacadesCommand.php
@@ -13,6 +13,7 @@ namespace Barryvdh\LaravelIdeHelper\Console;
 
 use Barryvdh\LaravelIdeHelper\Eloquent;
 use Barryvdh\LaravelIdeHelper\Generator;
+use Illuminate\Config\Repository;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
@@ -56,16 +57,11 @@ class FacadesCommand extends Command
      * @param \Illuminate\Filesystem\Filesystem $files
      * @param \Illuminate\View\Factory $view
      */
-    public function __construct(
-        /*ConfigRepository */
-        $config,
-        Filesystem $files,
-        /* Illuminate\View\Factory */
-        $view
-    ) {
+    public function __construct(Repository $config, Filesystem $files, \Illuminate\View\Factory $view) {
         $this->config = $config;
         $this->files = $files;
         $this->view = $view;
+
         parent::__construct();
     }
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -111,9 +111,10 @@ class ModelsCommand extends Command
      */
     public function __construct(Repository $config, Filesystem $files)
     {
-        parent::__construct();
         $this->config = $config;
         $this->files = $files;
+
+        parent::__construct();
     }
 
     /**

--- a/src/Console/PhpStormCommand.php
+++ b/src/Console/PhpStormCommand.php
@@ -81,7 +81,7 @@ class PhpStormCommand extends Command
     public function handle()
     {
         $directory = $this->config->get('ide-helper.directory');
-        $filename = $this->config->get('ide-helper.models_filename');
+        $filename = $this->config->get('ide-helper.phpstorm_filename');
         $filename = $directory . $filename;
 
         // Needs to run before exception handler is registered

--- a/src/Console/PhpStormCommand.php
+++ b/src/Console/PhpStormCommand.php
@@ -12,6 +12,7 @@
 namespace Barryvdh\LaravelIdeHelper\Console;
 
 use Barryvdh\LaravelIdeHelper\Factories;
+use Illuminate\Config\Repository;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -65,11 +66,12 @@ class PhpStormCommand extends Command
      * @param \Illuminate\Contracts\Filesystem\Filesystem $files
      * @param \Illuminate\Contracts\View\Factory $view
      */
-    public function __construct($config, $files, $view)
+    public function __construct(Repository $config, $files, $view)
     {
         $this->config = $config;
         $this->files = $files;
         $this->view = $view;
+
         parent::__construct();
     }
 

--- a/src/Console/PhpStormCommand.php
+++ b/src/Console/PhpStormCommand.php
@@ -21,14 +21,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Barry vd. Heuvel <barryvdh@gmail.com>
  */
-class MetaCommand extends Command
+class PhpStormCommand extends Command
 {
     /**
      * The console command name.
      *
      * @var string
      */
-    protected $name = 'ide-helper:meta';
+    protected $name = 'ide-helper:generate-phpstorm';
 
     /**
      * The console command description.
@@ -37,14 +37,14 @@ class MetaCommand extends Command
      */
     protected $description = 'Generate metadata for PhpStorm';
 
+    /** @var \Illuminate\Contracts\Config\Repository */
+    protected $config;
+
     /** @var \Illuminate\Contracts\Filesystem\Filesystem */
     protected $files;
 
     /** @var \Illuminate\Contracts\View\Factory */
     protected $view;
-
-    /** @var \Illuminate\Contracts\Config\Repository */
-    protected $config;
 
     protected $methods = [
       'new \Illuminate\Contracts\Container\Container',
@@ -61,16 +61,15 @@ class MetaCommand extends Command
     ];
 
     /**
-     *
+     * @param \Illuminate\Contracts\Config\Repository $config
      * @param \Illuminate\Contracts\Filesystem\Filesystem $files
      * @param \Illuminate\Contracts\View\Factory $view
-     * @param \Illuminate\Contracts\Config\Repository $config
      */
-    public function __construct($files, $view, $config)
+    public function __construct($config, $files, $view)
     {
+        $this->config = $config;
         $this->files = $files;
         $this->view = $view;
-        $this->config = $config;
         parent::__construct();
     }
 
@@ -81,6 +80,10 @@ class MetaCommand extends Command
      */
     public function handle()
     {
+        $directory = $this->config->get('ide-helper.directory');
+        $filename = $this->config->get('ide-helper.models_filename');
+        $filename = $directory . $filename;
+
         // Needs to run before exception handler is registered
         $factories = $this->config->get('ide-helper.include_factory_builders') ? Factories::all() : [];
 
@@ -114,7 +117,6 @@ class MetaCommand extends Command
           'factories' => $factories,
         ])->render();
 
-        $filename = $this->option('filename');
         $written = $this->files->put($filename, $content);
 
         if ($written !== false) {

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -58,21 +58,21 @@ class IdeHelperServiceProvider extends ServiceProvider implements DeferrableProv
         $localViewFactory = $this->createLocalViewFactory();
 
         $this->app->singleton(
-            'command.ide-helper.generate',
+            'command.ide-helper.generate-facades',
             function ($app) use ($localViewFactory) {
                 return new FacadesCommand($app['config'], $app['files'], $localViewFactory);
             }
         );
 
         $this->app->singleton(
-            'command.ide-helper.models',
+            'command.ide-helper.generate-models',
             function ($app) {
                 return new ModelsCommand($app['config'], $app['files']);
             }
         );
 
         $this->app->singleton(
-            'command.ide-helper.meta',
+            'command.ide-helper.generate-phpstorm',
             function ($app) use ($localViewFactory) {
                 return new PhpStormCommand($app['config'], $app['files'], $localViewFactory);
             }
@@ -86,9 +86,9 @@ class IdeHelperServiceProvider extends ServiceProvider implements DeferrableProv
         );
 
         $this->commands(
-            'command.ide-helper.generate',
-            'command.ide-helper.models',
-            'command.ide-helper.meta',
+            'command.ide-helper.generate-facades',
+            'command.ide-helper.generate-models',
+            'command.ide-helper.generate-phpstorm',
             'command.ide-helper.eloquent'
         );
     }
@@ -100,7 +100,12 @@ class IdeHelperServiceProvider extends ServiceProvider implements DeferrableProv
      */
     public function provides()
     {
-        return ['command.ide-helper.generate', 'command.ide-helper.models'];
+        return [
+            'command.ide-helper.generate-facades',
+            'command.ide-helper.generate-models',
+            'command.ide-helper.generate-phpstorm',
+            'command.ide-helper.eloquent',
+        ];
     }
 
     /**

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -12,9 +12,9 @@
 namespace Barryvdh\LaravelIdeHelper;
 
 use Barryvdh\LaravelIdeHelper\Console\EloquentCommand;
-use Barryvdh\LaravelIdeHelper\Console\GeneratorCommand;
-use Barryvdh\LaravelIdeHelper\Console\MetaCommand;
+use Barryvdh\LaravelIdeHelper\Console\FacadesCommand;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Console\PhpStormCommand;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
@@ -60,21 +60,21 @@ class IdeHelperServiceProvider extends ServiceProvider implements DeferrableProv
         $this->app->singleton(
             'command.ide-helper.generate',
             function ($app) use ($localViewFactory) {
-                return new GeneratorCommand($app['config'], $app['files'], $localViewFactory);
+                return new FacadesCommand($app['config'], $app['files'], $localViewFactory);
             }
         );
 
         $this->app->singleton(
             'command.ide-helper.models',
             function ($app) {
-                return new ModelsCommand($app['files']);
+                return new ModelsCommand($app['config'], $app['files']);
             }
         );
 
         $this->app->singleton(
             'command.ide-helper.meta',
             function ($app) use ($localViewFactory) {
-                return new MetaCommand($app['files'], $localViewFactory, $app['config']);
+                return new PhpStormCommand($app['config'], $app['files'], $localViewFactory);
             }
         );
 

--- a/tests/Console/MetaCommand/MetaCommandTest.php
+++ b/tests/Console/MetaCommand/MetaCommandTest.php
@@ -29,7 +29,7 @@ class MetaCommandTest extends TestCase
                 })();
             });
 
-        $this->artisan('ide-helper:meta');
+        $this->artisan('ide-helper:generate-phpstorm');
 
         // We're not testing the whole file, just some basic structure elements
         self::assertStringContainsString("namespace PHPSTORM_META {\n", $this->mockFilesystemOutput);

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/Test.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/Test.php
@@ -18,7 +18,7 @@ class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertStringContainsString('Model information was written to _ide_helper_models.php', $tester->getDisplay());
+        $this->assertStringContainsString('Model information was written to .ide_helper/.models.meta.php', $tester->getDisplay());
         $this->assertMatchesMockedSnapshot();
     }
 }

--- a/tests/Console/ModelsCommand/Interfaces/Test.php
+++ b/tests/Console/ModelsCommand/Interfaces/Test.php
@@ -18,7 +18,7 @@ final class Test extends AbstractModelsCommand
         ]);
 
         $this->assertSame(0, $tester->getStatusCode());
-        $this->assertStringContainsString('Model information was written to _ide_helper_models.php', $tester->getDisplay());
+        $this->assertStringContainsString('Model information was written to .ide_helper/.models.meta.php', $tester->getDisplay());
         $this->assertMatchesMockedSnapshot();
     }
 }


### PR DESCRIPTION
- Cleaner and more logical command names and generated file names.

- Skip asking overwrite for models

- New commands are :

```
php artisan ide-helper:generate-facades
php artisan ide-helper:generate-models
php artisan ide-helper:generate-phpstorm
```

new files are :

```
.ide_helper/.facades.meta.php
.ide_helper/.models.meta.php
.ide_helper/.phpstorm.meta.php
```

