### PR TITLE
Allow casts with a return type of static or this to reference themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Compatibility with Lumen [\#1043 / mfn](https://github.com/barryvdh/laravel-ide-helper/pull/1043)
 - Allow model_locations to have glob patterns [\#1059 / saackearl](https://github.com/barryvdh/laravel-ide-helper/pull/1059)
 - Error when generating helper for macroable classes which are not facades and contain a "fake" method [\#1066 / domkrm] (https://github.com/barryvdh/laravel-ide-helper/pull/1066)
+- Casts with a return type of `static` or `$this` now resolve to an instance of the cast [\#1103 / riesjart](https://github.com/barryvdh/laravel-ide-helper/pull/1103)
 
 2020-09-07, 2.8.1
 -----------------

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1079,13 +1079,17 @@ class ModelsCommand extends Command
 
         $methodReflection = new \ReflectionMethod($type, 'get');
 
-        $type = $this->getReturnTypeFromReflection($methodReflection);
+        $reflectionType = $this->getReturnTypeFromReflection($methodReflection);
 
-        if ($type === null) {
-            $type = $this->getReturnTypeFromDocBlock($methodReflection);
+        if ($reflectionType === null) {
+            $reflectionType = $this->getReturnTypeFromDocBlock($methodReflection);
+        }
+        
+        if($reflectionType === 'static' || $reflectionType === '$this') {
+            $reflectionType = $type;
         }
 
-        return $type;
+        return $reflectionType;
     }
 
     protected function getTypeInModel(object $model, ?string $type): ?string

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/ExtendedSelfCastingCasterWithStaticDocblockReturn.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/ExtendedSelfCastingCasterWithStaticDocblockReturn.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class ExtendedSelfCastingCasterWithStaticDocblockReturn extends SelfCastingCasterWithStaticDocblockReturn
+{
+
+}

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/ExtendedSelfCastingCasterWithThisDocblockReturn.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/ExtendedSelfCastingCasterWithThisDocblockReturn.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class ExtendedSelfCastingCasterWithThisDocblockReturn extends SelfCastingCasterWithStaticDocblockReturn
+{
+    
+}

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/SelfCastingCasterWithStaticDocblockReturn.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/SelfCastingCasterWithStaticDocblockReturn.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class SelfCastingCasterWithStaticDocblockReturn implements CastsAttributes
+{
+    /**
+     * @return static
+     */
+    public function get($model, string $key, $value, array $attributes)
+    {
+        return new static();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        // TODO: Implement set() method.
+    }
+}

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/SelfCastingCasterWithThisDocblockReturn.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/SelfCastingCasterWithThisDocblockReturn.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class SelfCastingCasterWithThisDocblockReturn implements CastsAttributes
+{
+    /**
+     * @return $this
+     */
+    public function get($model, string $key, $value, array $attributes)
+    {
+        return new static();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        // TODO: Implement set() method.
+    }
+}

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Models/CustomCast.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Models/CustomCast.php
@@ -12,6 +12,10 @@ use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Cas
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithPrimitiveDocblockReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithPrimitiveReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithReturnType;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\ExtendedSelfCastingCasterWithStaticDocblockReturn;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\ExtendedSelfCastingCasterWithThisDocblockReturn;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\SelfCastingCasterWithStaticDocblockReturn;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\SelfCastingCasterWithThisDocblockReturn;
 use Illuminate\Database\Eloquent\Model;
 
 class CustomCast extends Model
@@ -25,5 +29,10 @@ class CustomCast extends Model
         'casted_property_with_return_nullable_primitive' => CustomCasterWithNullablePrimitiveReturn::class,
         'casted_property_without_return' => CustomCasterWithoutReturnType::class,
         'casted_property_with_param' => CustomCasterWithParam::class . ':param',
+        'casted_property_with_static_return_docblock' => SelfCastingCasterWithStaticDocblockReturn::class,
+        'casted_property_with_this_return_docblock' => SelfCastingCasterWithThisDocblockReturn::class,
+        'extended_casted_property_with_static_return_docblock' => ExtendedSelfCastingCasterWithStaticDocblockReturn::class,
+        'extended_casted_property_with_this_return_docblock' => ExtendedSelfCastingCasterWithThisDocblockReturn::class,
+        'casted_property_with_static_return_docblock_and_param' => SelfCastingCasterWithStaticDocblockReturn::class .':param',
     ];
 }

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/__snapshots__/Test__test__1.php
@@ -12,6 +12,10 @@ use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Cas
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithPrimitiveDocblockReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithPrimitiveReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithReturnType;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\ExtendedSelfCastingCasterWithStaticDocblockReturn;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\ExtendedSelfCastingCasterWithThisDocblockReturn;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\SelfCastingCasterWithStaticDocblockReturn;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\SelfCastingCasterWithThisDocblockReturn;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -25,6 +29,11 @@ use Illuminate\Database\Eloquent\Model;
  * @property array|null $casted_property_with_return_nullable_primitive
  * @property $casted_property_without_return
  * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $casted_property_with_param
+ * @property SelfCastingCasterWithStaticDocblockReturn $casted_property_with_static_return_docblock
+ * @property SelfCastingCasterWithThisDocblockReturn $casted_property_with_this_return_docblock
+ * @property ExtendedSelfCastingCasterWithStaticDocblockReturn $extended_casted_property_with_static_return_docblock
+ * @property ExtendedSelfCastingCasterWithThisDocblockReturn $extended_casted_property_with_this_return_docblock
+ * @property SelfCastingCasterWithStaticDocblockReturn $casted_property_with_static_return_docblock_and_param
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast query()
@@ -35,7 +44,12 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereCastedPropertyWithReturnPrimitive($value)
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereCastedPropertyWithReturnPrimitiveDocblock($value)
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereCastedPropertyWithReturnType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereCastedPropertyWithStaticReturnDocblock($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereCastedPropertyWithStaticReturnDocblockAndParam($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereCastedPropertyWithThisReturnDocblock($value)
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereCastedPropertyWithoutReturn($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereExtendedCastedPropertyWithStaticReturnDocblock($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereExtendedCastedPropertyWithThisReturnDocblock($value)
  * @mixin \Eloquent
  */
 class CustomCast extends Model
@@ -49,5 +63,10 @@ class CustomCast extends Model
         'casted_property_with_return_nullable_primitive' => CustomCasterWithNullablePrimitiveReturn::class,
         'casted_property_without_return' => CustomCasterWithoutReturnType::class,
         'casted_property_with_param' => CustomCasterWithParam::class . ':param',
+        'casted_property_with_static_return_docblock' => SelfCastingCasterWithStaticDocblockReturn::class,
+        'casted_property_with_this_return_docblock' => SelfCastingCasterWithThisDocblockReturn::class,
+        'extended_casted_property_with_static_return_docblock' => ExtendedSelfCastingCasterWithStaticDocblockReturn::class,
+        'extended_casted_property_with_this_return_docblock' => ExtendedSelfCastingCasterWithThisDocblockReturn::class,
+        'casted_property_with_static_return_docblock_and_param' => SelfCastingCasterWithStaticDocblockReturn::class .':param',
     ];
 }

--- a/tests/Console/ModelsCommand/migrations/____custom_casts_table.php
+++ b/tests/Console/ModelsCommand/migrations/____custom_casts_table.php
@@ -19,6 +19,11 @@ class CustomCastsTable extends Migration
             $table->string('casted_property_with_return_nullable_primitive');
             $table->string('casted_property_without_return');
             $table->string('casted_property_with_param');
+            $table->string('casted_property_with_static_return_docblock');
+            $table->string('casted_property_with_this_return_docblock');
+            $table->string('extended_casted_property_with_static_return_docblock');
+            $table->string('extended_casted_property_with_this_return_docblock');
+            $table->string('casted_property_with_static_return_docblock_and_param');
         });
     }
 }


### PR DESCRIPTION
Right now a cast cannot specify that it returns static or this.
Allowing so would mean a new cast can extend the old one without having to redefine the get method (e.g. an Enum)
Presently if you specify static/this in the return type then those values are literally used which makes a property look like it returns an instance of the model itself.