### PR TITLE
Fix broken test "GeneratePhpdocWithExternalEloquentBuilder"

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1234,8 +1234,7 @@ class ModelsCommand extends Command
         }
 
         // convert to proper type hint types in php
-        $type = str_replace('boolean', 'bool', $type);
-        $type = str_replace('integer', 'int', $type);
+        $type = str_replace(['boolean', 'integer'], ['bool', 'int'], $type);
 
         $allowedTypes = [
             'int',

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1233,14 +1233,19 @@ class ModelsCommand extends Command
             $type = '?' . $type;
         }
 
-        $typesThatAreNotAllowed = [
-            'null',
-            'mixed',
-            'nullable',
+        // convert to proper type hint types in php
+        $type = str_replace('boolean', 'bool', $type);
+        $type = str_replace('integer', 'int', $type);
+
+        $allowedTypes = [
+            'int',
+            'bool',
+            'string',
+            'float',
         ];
 
         // we replace the ? with an empty string so we can check the actual type
-        if (in_array(str_replace('?', '', $type), $typesThatAreNotAllowed)) {
+        if (!in_array(str_replace('?', '', $type), $allowedTypes)) {
             return null;
         }
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -903,7 +903,7 @@ class ModelsCommand extends Command
         /** @var \ReflectionParameter $param */
         foreach ($method->getParameters() as $param) {
             $paramStr = '$' . $param->getName();
-            if ($paramType = $this->getParamType($method, $param)) {
+            if ($paramType = $this->getParamType($param)) {
                 $paramStr = $paramType . ' ' . $paramStr;
             }
 
@@ -1174,78 +1174,22 @@ class ModelsCommand extends Command
         }
     }
 
-    protected function getParamType(\ReflectionMethod $method, \ReflectionParameter $parameter): ?string
+    protected function getParamType(\ReflectionParameter $parameter): ?string
     {
-        if ($paramType = $parameter->getType()) {
-            $parameterName = $paramType->getName();
-
-            if (!$paramType->isBuiltin()) {
-                $parameterName = '\\' . $parameterName;
-            }
-
-            if ($paramType->allowsNull()) {
-                return '?' . $parameterName;
-            }
-
-            return $parameterName;
-        }
-
-        $docComment = $method->getDocComment();
-
-        if (!$docComment) {
+        if (!$paramType = $parameter->getType()) {
             return null;
         }
 
-        preg_match(
-            '/@param ((?:(?:[\w?|\\\\<>])+(?:\[])?)+)/',
-            $docComment ?? '',
-            $matches
-        );
-        $type = $matches[1] ?? null;
+        $parameterName = $paramType->getName();
 
-        if (strpos($type, '|') !== false) {
-            $types = explode('|', $type);
-
-            // if we have more than 2 types
-            // we return null as we cannot use unions in php yet
-            if (count($types) > 2) {
-                return null;
-            }
-
-            $hasNull = false;
-
-            foreach ($types as $currentType) {
-                if ($currentType === 'null') {
-                    $hasNull = true;
-                    continue;
-                }
-
-                // if we didn't find null assign the current type to the type we want
-                $type = $currentType;
-            }
-
-            // if we haven't found null type set
-            // we return null as we cannot use unions with different types yet
-            if (!$hasNull) {
-                return null;
-            }
-
-            $type = '?' . $type;
+        if (!$paramType->isBuiltin()) {
+            $parameterName = '\\' . $parameterName;
         }
 
-        $typesThatAreNotAllowed = [
-            'null',
-            'mixed',
-            'nullable',
-        ];
-
-        // we replace the ? with an empty string so we can check the actual type
-        if (in_array(str_replace('?', '', $type), $typesThatAreNotAllowed)) {
-            return null;
+        if ($paramType->allowsNull()) {
+            return '?' . $parameterName;
         }
 
-        // if we have a match on index 1
-        // then we have found the type of the variable if not we return null
-        return $type;
+        return $parameterName;
     }
 }

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -893,26 +893,18 @@ class ModelsCommand extends Command
      * Get the parameters and format them correctly
      *
      * @param $method
-     * @param bool $withTypeHint
      * @return array
      * @throws \ReflectionException
      */
-    public function getParameters($method, bool $withTypeHint = false)
+    public function getParameters($method)
     {
         //Loop through the default values for parameters, and make the correct output string
         $paramsWithDefault = [];
         /** @var \ReflectionParameter $param */
         foreach ($method->getParameters() as $param) {
-            $paramType = $param->getType();
-
             $paramStr = '$' . $param->getName();
-            if ($paramType) {
-                $paramTypeStr = $paramType->getName();
-                if (!$paramType->isBuiltin()) {
-                    $paramTypeStr = '\\' . $paramTypeStr;
-                }
-
-                $paramStr = $paramTypeStr . ' ' . $paramStr;
+            if ($paramType = $this->getParamType($method, $param)) {
+                $paramStr = $paramType . ' ' . $paramStr;
             }
 
             if ($param->isOptional() && $param->isDefaultValueAvailable()) {
@@ -930,10 +922,6 @@ class ModelsCommand extends Command
                 }
 
                 $paramStr .= " = $default";
-            }
-
-            if ($withTypeHint && $paramType = $this->getParamType($method, $param)) {
-                $paramStr = $paramType . ' ' . $paramStr;
             }
 
             $paramsWithDefault[] = $paramStr;
@@ -1176,7 +1164,7 @@ class ModelsCommand extends Command
 
         foreach ($newMethodsFromNewBuilder as $builderMethod) {
             $reflection = new \ReflectionMethod($builder, $builderMethod);
-            $args = $this->getParameters($reflection, true);
+            $args = $this->getParameters($reflection);
 
             $this->setMethod(
                 $builderMethod,
@@ -1189,11 +1177,17 @@ class ModelsCommand extends Command
     protected function getParamType(\ReflectionMethod $method, \ReflectionParameter $parameter): ?string
     {
         if ($paramType = $parameter->getType()) {
-            if ($paramType->allowsNull()) {
-                return '?' . $paramType->getName();
+            $parameterName = $paramType->getName();
+
+            if (!$paramType->isBuiltin()) {
+                $parameterName = '\\' . $parameterName;
             }
 
-            return $paramType->getName();
+            if ($paramType->allowsNull()) {
+                return '?' . $parameterName;
+            }
+
+            return $parameterName;
         }
 
         $docComment = $method->getDocComment();

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders;
 
-use Illuminate\Database\Eloquent\Builder;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Illuminate\Database\Eloquent\Builder;
 
 class PostExternalQueryBuilder extends Builder
 {

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
@@ -34,6 +34,38 @@ class PostExternalQueryBuilder extends Builder
     }
 
     /**
+     * @param integer|null $number
+     * @return $this
+     */
+    public function withTheNumberDifferently($number): self
+    {
+        return $this;
+    }
+
+    /**
+     * @param bool|null $number
+     * @return $this
+     */
+    public function withBool($booleanVar): self
+    {
+        return $this;
+    }
+
+    /**
+     * @param bool|null $number
+     * @return $this
+     */
+    public function withBoolDifferently($booleanVar): self
+    {
+        return $this;
+    }
+
+    public function withBoolTypeHinted(bool $booleanVar): self
+    {
+        return $this;
+    }
+
+    /**
      * @param int|string $someone
      * @return $this
      */

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
@@ -61,7 +61,16 @@ class PostExternalQueryBuilder extends Builder
         return $this;
     }
 
-    public function withNullAndAssignementTestCommand(?ModelsCommand $testCommand = null): self
+    public function withNullAndAssignmentTestCommand(?ModelsCommand $testCommand = null): self
+    {
+        return $this;
+    }
+
+    /**
+     * @param ModelsCommand $testCommand
+     * @return $this
+     */
+    public function withNullTestCommandInDocBlock($testCommand): self
     {
         return $this;
     }

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/Builders/PostExternalQueryBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders;
 
 use Illuminate\Database\Eloquent\Builder;
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 
 class PostExternalQueryBuilder extends Builder
 {
@@ -46,6 +47,21 @@ class PostExternalQueryBuilder extends Builder
      * @return $this
      */
     public function withMixedOption($option): self
+    {
+        return $this;
+    }
+
+    public function withTestCommand(ModelsCommand $testCommand): self
+    {
+        return $this;
+    }
+
+    public function withNullTestCommand(?ModelsCommand $testCommand): self
+    {
+        return $this;
+    }
+
+    public function withNullAndAssignementTestCommand(?ModelsCommand $testCommand = null): self
     {
         return $this;
     }

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
@@ -169,10 +169,10 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withMixedOption($option)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withNullAndAssignmentTestCommand(?\Barryvdh\LaravelIdeHelper\Console\ModelsCommand $testCommand = null)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withNullTestCommand(?\Barryvdh\LaravelIdeHelper\Console\ModelsCommand $testCommand)
- * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withNullTestCommandInDocBlock($testCommand)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withNullTestCommandInDocBlock(ModelsCommand $testCommand)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withSomeone($someone)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withTestCommand(\Barryvdh\LaravelIdeHelper\Console\ModelsCommand $testCommand)
- * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withTheNumber($number)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withTheNumber(?int $number)
  */
 	class Post extends \Eloquent {}
 }

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
@@ -166,13 +166,17 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUuidNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNullable($value)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withBool(?bool $booleanVar)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withBoolDifferently(?bool $booleanVar)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withBoolTypeHinted(bool $booleanVar)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withMixedOption($option)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withNullAndAssignmentTestCommand(?\Barryvdh\LaravelIdeHelper\Console\ModelsCommand $testCommand = null)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withNullTestCommand(?\Barryvdh\LaravelIdeHelper\Console\ModelsCommand $testCommand)
- * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withNullTestCommandInDocBlock(ModelsCommand $testCommand)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withNullTestCommandInDocBlock($testCommand)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withSomeone($someone)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withTestCommand(\Barryvdh\LaravelIdeHelper\Console\ModelsCommand $testCommand)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withTheNumber(?int $number)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withTheNumberDifferently(?int $number)
  */
 	class Post extends \Eloquent {}
 }

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
@@ -167,7 +167,10 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNullable($value)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withMixedOption($option)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withNullAndAssignementTestCommand(?\Barryvdh\LaravelIdeHelper\Console\ModelsCommand $testCommand = null)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withNullTestCommand(?\Barryvdh\LaravelIdeHelper\Console\ModelsCommand $testCommand)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withSomeone($someone)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withTestCommand(\Barryvdh\LaravelIdeHelper\Console\ModelsCommand $testCommand)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withTheNumber(?int $number)
  */
 	class Post extends \Eloquent {}

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
@@ -167,11 +167,12 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNullable($value)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withMixedOption($option)
- * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withNullAndAssignementTestCommand(?\Barryvdh\LaravelIdeHelper\Console\ModelsCommand $testCommand = null)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withNullAndAssignmentTestCommand(?\Barryvdh\LaravelIdeHelper\Console\ModelsCommand $testCommand = null)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withNullTestCommand(?\Barryvdh\LaravelIdeHelper\Console\ModelsCommand $testCommand)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withNullTestCommandInDocBlock($testCommand)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withSomeone($someone)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withTestCommand(\Barryvdh\LaravelIdeHelper\Console\ModelsCommand $testCommand)
- * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withTheNumber(?int $number)
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post withTheNumber($number)
  */
 	class Post extends \Eloquent {}
 }


### PR DESCRIPTION
## Summary
Since both [Pull request 1106](https://github.com/barryvdh/laravel-ide-helper/pull/1106) and [Pull Request 1089](https://github.com/barryvdh/laravel-ide-helper/pull/1089) created retrieving type in a different manner therefore the type of a variable was put twice as a type hint. In the [Pull Request 1089](https://github.com/barryvdh/laravel-ide-helper/pull/1089) the type hinting is added, along with checking if there is a supported type hint inside of a doc block.  

## Type of change
Merged the two type fetching methods and combined them along with the dock block type fetching.

<!-- Please delete options that are not relevant. -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)

### Checklist
- [ x ] Existing tests have been adapted and/or new tests have been added
- [ x ] Code style has been fixed via `composer fix-style`
