### PR TITLE
[2.9] Drop support for: Laravel 6, Laravel 7, PHP 7.2 and add doctrine/dbal ^3

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -18,15 +18,8 @@ jobs:
             COMPOSER_NO_INTERACTION: 1
         strategy:
             matrix:
-                php: [8.0, 7.4, 7.3, 7.2]
-                lumen: [8.*, 7.*, 6.*]
-                exclude:
-                  - lumen: 6.*
-                    php: 8.0
-                  - lumen: 7.*
-                    php: 8.0
-                  - lumen: 8.*
-                    php: 7.2
+                php: [8.0, 7.4, 7.3]
+                lumen: [8.*]
         name: P${{ matrix.php }} - Lumen${{ matrix.lumen }}
         steps:
             - name: Checkout code
@@ -82,11 +75,8 @@ jobs:
             COMPOSER_NO_INTERACTION: 1
         strategy:
             matrix:
-                php: [7.4, 7.3, 7.2]
-                laravel: [8.*, 7.*, 6.*]
-                exclude:
-                  - laravel: 8.*
-                    php: 7.2
+                php: [8.0, 7.4, 7.3]
+                laravel: [8.*]
         name: P${{ matrix.php }} - Laravel${{ matrix.laravel }}
         steps:
             - name: Checkout code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,12 +19,10 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 7.4, 7.3, 7.2]
-        laravel: [8.*, 7.*, 6.*]
+        php: [8.0, 7.4, 7.3]
+        laravel: [8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
-          - laravel: 8.*
-            php: 7.2
           - php: 8.0
             dependency-version: prefer-lowest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 [Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.8.1...master)
 --------------
+### Changed
+- Dropped support for Laravel 6 and Laravel 7, as well as support for PHP 7.2 [\# / mfn]()
 
 ### Added
 - Fix phpdoc generate for custom cast with parameter [\#986 / artelkr](https://github.com/barryvdh/laravel-ide-helper/pull/986)

--- a/composer.json
+++ b/composer.json
@@ -20,25 +20,25 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "barryvdh/reflection-docblock": "^2.0.6",
         "composer/composer": "^1.6 || ^2",
-        "doctrine/dbal": "~2.3",
-        "illuminate/console": "^6 || ^7 || ^8",
-        "illuminate/filesystem": "^6 || ^7 || ^8",
-        "illuminate/support": "^6 || ^7 || ^8",
+        "doctrine/dbal": "^2.6 || ^3",
+        "illuminate/console": "^8",
+        "illuminate/filesystem": "^8",
+        "illuminate/support": "^8",
         "phpdocumentor/type-resolver": "^1.1.0"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "friendsofphp/php-cs-fixer": "^2",
-        "illuminate/config": "^6 || ^7 || ^8",
-        "illuminate/view": "^6 || ^7 || ^8",
-        "mockery/mockery": "^1.3.3",
-        "orchestra/testbench": "^4 || ^5 || ^6",
+        "illuminate/config": "^8",
+        "illuminate/view": "^8",
+        "mockery/mockery": "^1.4",
+        "orchestra/testbench": "^6",
         "phpunit/phpunit": "^8.5 || ^9",
-        "spatie/phpunit-snapshot-assertions": "^1.4 || ^2.2 || ^3 || ^4",
+        "spatie/phpunit-snapshot-assertions": "^3 || ^4",
         "vimeo/psalm": "^3.12"
     },
     "config": {
@@ -46,7 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.8-dev"
+            "dev-master": "2.9-dev"
         },
         "laravel": {
             "providers": [

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Test.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Test.php
@@ -6,19 +6,9 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCas
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Illuminate\Foundation\Application;
 
 class Test extends AbstractModelsCommand
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        if (version_compare(Application::VERSION, '7.0', '<')) {
-            $this->markTestSkipped('This test requires Laravel 7.0 or higher');
-        }
-    }
-
     public function test(): void
     {
         $command = $this->app->make(ModelsCommand::class);

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -6,7 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests;
 
 use Barryvdh\LaravelIdeHelper\Method;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Foundation\Application;
 use PHPUnit\Framework\TestCase;
 
 class MethodTest extends TestCase
@@ -59,10 +58,6 @@ DOC;
      */
     public function testEloquentBuilderOutput()
     {
-        if ((int) Application::VERSION < 8) {
-            $this->markTestSkipped('This test requires Laravel 8.0 or higher');
-        }
-
         $reflectionClass = new \ReflectionClass(Builder::class);
         $reflectionMethod = $reflectionClass->getMethod('with');
 


### PR DESCRIPTION
## Summary
Based on the discussion around https://github.com/barryvdh/laravel-ide-helper/pull/1094#issuecomment-738611427

❗ BLOCKED UNTIL A NEW 2.8 RELEASE WAS MADE AND SOME TIME PASSED (like, a week) ❗ 

- some Laravel framework version checks in the tests are now be able to be removed
- I have not checked in detail, but judging by https://github.com/barryvdh/laravel-ide-helper/blob/db53e8e2b5868fb05019ae20e727be24831b46d8/README.md#auto-completion-for-factory-builders
  > Deprecated for Laravel 8 or latest

  we might be able to remove that part => will be a separate PR anyway, let's keep this one as minimal as possible
## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
