### PR TITLE
`Macro::initPhpDoc()` will save original docblock if present.

### DIFF
--- a/src/Macro.php
+++ b/src/Macro.php
@@ -33,23 +33,25 @@ class Macro extends Method
      */
     protected function initPhpDoc($method)
     {
-        $this->phpdoc = new DocBlock('/** */');
+        $this->phpdoc = new DocBlock($method);
 
         $this->addLocationToPhpDoc();
 
-        // Add macro parameters
-        foreach ($method->getParameters() as $parameter) {
-            $type = $parameter->hasType() ? $parameter->getType()->getName() : 'mixed';
-            $type .= $parameter->hasType() && $parameter->getType()->allowsNull() ? '|null' : '';
+        // Add macro parameters if they are missed in original docblock
+        if (!$this->phpdoc->hasTag('param')) {
+            foreach ($method->getParameters() as $parameter) {
+                $type = $parameter->hasType() ? $parameter->getType()->getName() : 'mixed';
+                $type .= $parameter->hasType() && $parameter->getType()->allowsNull() ? '|null' : '';
 
-            $name = $parameter->isVariadic() ? '...' : '';
-            $name .= '$' . $parameter->getName();
+                $name = $parameter->isVariadic() ? '...' : '';
+                $name .= '$'.$parameter->getName();
 
-            $this->phpdoc->appendTag(Tag::createInstance("@param {$type} {$name}"));
+                $this->phpdoc->appendTag(Tag::createInstance("@param {$type} {$name}"));
+            }
         }
 
-        // Add macro return type
-        if ($method->hasReturnType()) {
+        // Add macro return type if it missed in original docblock
+        if ($method->hasReturnType() && !$this->phpdoc->hasTag('return')) {
             $builder = EloquentBuilder::class;
             $return = $method->getReturnType();
 

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -44,7 +44,7 @@ class Macro extends Method
                 $type .= $parameter->hasType() && $parameter->getType()->allowsNull() ? '|null' : '';
 
                 $name = $parameter->isVariadic() ? '...' : '';
-                $name .= '$'.$parameter->getName();
+                $name .= '$' . $parameter->getName();
 
                 $this->phpdoc->appendTag(Tag::createInstance("@param {$type} {$name}"));
             }

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -23,7 +23,6 @@ use const PHP_EOL;
  */
 class MacroTest extends TestCase
 {
-
     /**
      * @covers ::initPhpDoc
      * @throws \ReflectionException

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -23,31 +23,6 @@ use const PHP_EOL;
  */
 class MacroTest extends TestCase
 {
-    private $macro = null;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->macro = new class() extends Macro {
-            public function __construct()
-            {
-                // no need to call parent
-            }
-
-            public function getPhpDoc(ReflectionFunctionAbstract $method): DocBlock
-            {
-                return (new Macro($method, '', $method->getClosureScopeClass()))->phpdoc;
-            }
-        };
-    }
-
-    public function tearDown(): void
-    {
-        $this->macro = null;
-
-        parent::tearDown();
-    }
 
     /**
      * @covers ::initPhpDoc
@@ -78,7 +53,7 @@ class MacroTest extends TestCase
      */
     public function testInitPhpDocClosureWithoutDocBlock(): void
     {
-        $phpdoc = $this->macro->getPhpDoc(
+        $phpdoc = (new MacroMock())->getPhpDoc(
             new ReflectionFunction(
                 function (int $a = null): int {
                     return 0;
@@ -99,11 +74,11 @@ class MacroTest extends TestCase
      */
     public function testInitPhpDocClosureWithArgsAndReturnType(): void
     {
-        $phpdoc = $this->macro->getPhpDoc(
+        $phpdoc = (new MacroMock())->getPhpDoc(
             new ReflectionFunction(
-            /**
-             * Test docblock.
-             */
+                /**
+                 * Test docblock.
+                 */
                 function (int $a = null): int {
                     return 0;
                 }
@@ -123,11 +98,11 @@ class MacroTest extends TestCase
      */
     public function testInitPhpDocClosureWithArgs(): void
     {
-        $phpdoc = $this->macro->getPhpDoc(
+        $phpdoc = (new MacroMock())->getPhpDoc(
             new ReflectionFunction(
-            /**
-             * Test docblock.
-             */
+                /**
+                 * Test docblock.
+                 */
                 function (int $a = null) {
                     return 0;
                 }
@@ -147,11 +122,11 @@ class MacroTest extends TestCase
      */
     public function testInitPhpDocClosureWithReturnType(): void
     {
-        $phpdoc = $this->macro->getPhpDoc(
+        $phpdoc = (new MacroMock())->getPhpDoc(
             new ReflectionFunction(
-            /**
-             * Test docblock.
-             */
+                /**
+                 * Test docblock.
+                 */
                 function (): int {
                     return 0;
                 }
@@ -170,13 +145,13 @@ class MacroTest extends TestCase
      */
     public function testInitPhpDocParamsAddedOnlyNotPresent(): void
     {
-        $phpdoc = $this->macro->getPhpDoc(
+        $phpdoc = (new MacroMock())->getPhpDoc(
             new ReflectionFunction(
-            /**
-             * Test docblock.
-             *
-             * @param \stdClass|null $a aaaaa
-             */
+                /**
+                 * Test docblock.
+                 *
+                 * @param \stdClass|null $a aaaaa
+                 */
                 function ($a = null): int {
                     return 0;
                 }
@@ -194,13 +169,13 @@ class MacroTest extends TestCase
      */
     public function testInitPhpDocReturnAddedOnlyNotPresent(): void
     {
-        $phpdoc = $this->macro->getPhpDoc(
+        $phpdoc = (new MacroMock())->getPhpDoc(
             new ReflectionFunction(
-            /**
-             * Test docblock.
-             *
-             * @return \stdClass|null rrrrrrr
-             */
+                /**
+                 * Test docblock.
+                 *
+                 * @return \stdClass|null rrrrrrr
+                 */
                 function ($a = null): int {
                     return 0;
                 }

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -76,6 +76,27 @@ class MacroTest extends TestCase
      * @covers ::initPhpDoc
      * @throws \ReflectionException
      */
+    public function testInitPhpDocClosureWithoutDocBlock(): void
+    {
+        $phpdoc = $this->macro->getPhpDoc(
+            new ReflectionFunction(
+                function (int $a = null): int {
+                    return 0;
+                }
+            )
+        );
+
+        $this->assertNotNull($phpdoc);
+        $this->assertEmpty($phpdoc->getText());
+        $this->assertEquals('@param int|null $a', $this->tagsToString($phpdoc, 'param'));
+        $this->assertEquals('@return int', $this->tagsToString($phpdoc, 'return'));
+        $this->assertTrue($phpdoc->hasTag('see'));
+    }
+
+    /**
+     * @covers ::initPhpDoc
+     * @throws \ReflectionException
+     */
     public function testInitPhpDocClosureWithArgsAndReturnType(): void
     {
         $phpdoc = $this->macro->getPhpDoc(

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -23,6 +23,32 @@ use const PHP_EOL;
  */
 class MacroTest extends TestCase
 {
+    private $macro = null;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->macro = new class() extends Macro {
+            public function __construct()
+            {
+                // no need to call parent
+            }
+
+            public function getPhpDoc(ReflectionFunctionAbstract $method): DocBlock
+            {
+                return (new Macro($method, '', $method->getClosureScopeClass()))->phpdoc;
+            }
+        };
+    }
+
+    public function tearDown(): void
+    {
+        $this->macro = null;
+
+        parent::tearDown();
+    }
+
     /**
      * @covers ::initPhpDoc
      * @throws \ReflectionException
@@ -44,6 +70,126 @@ class MacroTest extends TestCase
             '@return \Illuminate\Database\Eloquent\Builder|static',
             $this->tagsToString($phpdoc, 'return')
         );
+    }
+
+    /**
+     * @covers ::initPhpDoc
+     * @throws \ReflectionException
+     */
+    public function testInitPhpDocClosureWithArgsAndReturnType(): void
+    {
+        $phpdoc = $this->macro->getPhpDoc(
+            new ReflectionFunction(
+            /**
+             * Test docblock.
+             */
+                function (int $a = null): int {
+                    return 0;
+                }
+            )
+        );
+
+        $this->assertNotNull($phpdoc);
+        $this->assertStringContainsString('Test docblock', $phpdoc->getText());
+        $this->assertEquals('@param int|null $a', $this->tagsToString($phpdoc, 'param'));
+        $this->assertEquals('@return int', $this->tagsToString($phpdoc, 'return'));
+        $this->assertTrue($phpdoc->hasTag('see'));
+    }
+
+    /**
+     * @covers ::initPhpDoc
+     * @throws \ReflectionException
+     */
+    public function testInitPhpDocClosureWithArgs(): void
+    {
+        $phpdoc = $this->macro->getPhpDoc(
+            new ReflectionFunction(
+            /**
+             * Test docblock.
+             */
+                function (int $a = null) {
+                    return 0;
+                }
+            )
+        );
+
+        $this->assertNotNull($phpdoc);
+        $this->assertStringContainsString('Test docblock', $phpdoc->getText());
+        $this->assertEquals('@param int|null $a', $this->tagsToString($phpdoc, 'param'));
+        $this->assertFalse($phpdoc->hasTag('return'));
+        $this->assertTrue($phpdoc->hasTag('see'));
+    }
+
+    /**
+     * @covers ::initPhpDoc
+     * @throws \ReflectionException
+     */
+    public function testInitPhpDocClosureWithReturnType(): void
+    {
+        $phpdoc = $this->macro->getPhpDoc(
+            new ReflectionFunction(
+            /**
+             * Test docblock.
+             */
+                function (): int {
+                    return 0;
+                }
+            )
+        );
+
+        $this->assertNotNull($phpdoc);
+        $this->assertStringContainsString('Test docblock', $phpdoc->getText());
+        $this->assertFalse($phpdoc->hasTag('param'));
+        $this->assertEquals('@return int', $this->tagsToString($phpdoc, 'return'));
+        $this->assertTrue($phpdoc->hasTag('see'));
+    }
+
+    /**
+     * @covers ::initPhpDoc
+     */
+    public function testInitPhpDocParamsAddedOnlyNotPresent(): void
+    {
+        $phpdoc = $this->macro->getPhpDoc(
+            new ReflectionFunction(
+            /**
+             * Test docblock.
+             *
+             * @param \stdClass|null $a aaaaa
+             */
+                function ($a = null): int {
+                    return 0;
+                }
+            )
+        );
+
+        $this->assertNotNull($phpdoc);
+        $this->assertStringContainsString('Test docblock', $phpdoc->getText());
+        $this->assertEquals('@param \stdClass|null $a aaaaa', $this->tagsToString($phpdoc, 'param'));
+        $this->assertEquals('@return int', $this->tagsToString($phpdoc, 'return'));
+    }
+
+    /**
+     * @covers ::initPhpDoc
+     */
+    public function testInitPhpDocReturnAddedOnlyNotPresent(): void
+    {
+        $phpdoc = $this->macro->getPhpDoc(
+            new ReflectionFunction(
+            /**
+             * Test docblock.
+             *
+             * @return \stdClass|null rrrrrrr
+             */
+                function ($a = null): int {
+                    return 0;
+                }
+            )
+        );
+
+        $this->assertNotNull($phpdoc);
+        $this->assertStringContainsString('Test docblock', $phpdoc->getText());
+        $this->assertEquals('@param mixed $a', $this->tagsToString($phpdoc, 'param'));
+        $this->assertEquals('@return \stdClass|null rrrrrrr', $this->tagsToString($phpdoc, 'return'));
     }
 
     protected function tagsToString(DocBlock $docBlock, string $name)


### PR DESCRIPTION
## Summary

The #1006 added support for macros but lost the content of the original docblock that was useful to provide an actual description, params, and return types. This PR fixes it:

- If the closure has a docblock it will be saved
- `@param`s will be added only when the original docblock doesn't have them
- `@return` will be added only when the original docblock doesn't have it

Fixes #1099

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added

