### PR TITLE
`Alias` will grab macros from `\Illuminate\Database\Eloquent\Builder` too

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -17,6 +17,7 @@ use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
 use Barryvdh\Reflection\DocBlock\Tag\MethodTag;
 use Closure;
 use Illuminate\Config\Repository as ConfigRepository;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Support\Facades\Facade;
 use ReflectionClass;
 
@@ -368,8 +369,9 @@ class Alias
             }
 
             // Check if the class is macroable
+            // (Eloquent\Builder is also macroable but doesn't use Macroable trait)
             $traits = collect($reflection->getTraitNames());
-            if ($traits->contains('Illuminate\Support\Traits\Macroable')) {
+            if ($traits->contains('Illuminate\Support\Traits\Macroable') || $class === EloquentBuilder::class) {
                 $properties = $reflection->getStaticProperties();
                 $macros = isset($properties['macros']) ? $properties['macros'] : [];
                 foreach ($macros as $macro_name => $macro_func) {

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -4,6 +4,7 @@ namespace Barryvdh\LaravelIdeHelper;
 
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Tag;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Support\Collection;
 
 class Macro extends Method
@@ -49,8 +50,12 @@ class Macro extends Method
 
         // Add macro return type
         if ($method->hasReturnType()) {
-            $type = $method->getReturnType()->getName();
-            $type .= $method->getReturnType()->allowsNull() ? '|null' : '';
+            $builder = EloquentBuilder::class;
+            $return = $method->getReturnType();
+
+            $type = $return->getName();
+            $type .= $this->root === "\\{$builder}" && $return->getName() === $builder ? '|static' : '';
+            $type .= $return->allowsNull() ? '|null' : '';
 
             $this->phpdoc->appendTag(Tag::createInstance("@return {$type}"));
         }

--- a/tests/AliasTest.php
+++ b/tests/AliasTest.php
@@ -23,7 +23,7 @@ class AliasTest extends TestCase
     {
         // Mock
         $macro = __FUNCTION__;
-        $alias = new AliasDetectMethods;
+        $alias = new AliasMock();
 
         // Macros
         Builder::macro(
@@ -48,7 +48,7 @@ class AliasTest extends TestCase
     {
         // Mock
         $macro = __FUNCTION__;
-        $alias = new AliasDetectMethods;
+        $alias = new AliasMock();
 
         // Macros
         EloquentBuilder::macro(
@@ -83,7 +83,7 @@ class AliasTest extends TestCase
  * @internal
  * @noinspection PhpMultipleClassesDeclarationsInOneFile
  */
-class AliasDetectMethods extends Alias
+class AliasMock extends Alias
 {
     public function __construct()
     {

--- a/tests/AliasTest.php
+++ b/tests/AliasTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests;
+
+use Barryvdh\LaravelIdeHelper\Alias;
+use Barryvdh\LaravelIdeHelper\Macro;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Arr;
+
+/**
+ * @internal
+ * @coversDefaultClass \Barryvdh\LaravelIdeHelper\Alias
+ */
+class AliasTest extends TestCase
+{
+    /**
+     * @covers ::detectMethods
+     */
+    public function testDetectMethodsMacroableMacros(): void
+    {
+        // Mock
+        $macro = __FUNCTION__;
+        $alias = new AliasDetectMethods;
+
+        // Macros
+        Builder::macro(
+            $macro,
+            function () {
+                // empty
+            }
+        );
+
+        // Prepare
+        $alias->setClasses([Builder::class]);
+        $alias->detectMethods();
+
+        // Test
+        $this->assertNotNull($this->getAliasMacro($alias, Builder::class, $macro));
+    }
+
+    /**
+     * @covers ::detectMethods
+     */
+    public function testDetectMethodsEloquentBuilderMacros(): void
+    {
+        // Mock
+        $macro = __FUNCTION__;
+        $alias = new AliasDetectMethods;
+
+        // Macros
+        EloquentBuilder::macro(
+            $macro,
+            function () {
+                // empty
+            }
+        );
+
+        // Prepare
+        $alias->setClasses([EloquentBuilder::class]);
+        $alias->detectMethods();
+
+        // Test
+        $this->assertNotNull($this->getAliasMacro($alias, EloquentBuilder::class, $macro));
+    }
+
+    protected function getAliasMacro(Alias $alias, string $class, string $method): ?Macro
+    {
+        return Arr::first(
+            $alias->getMethods(),
+            function ($macro) use ($class, $method) {
+                return $macro instanceof Macro
+                    && $macro->getDeclaringClass() === "\\{$class}"
+                    && $macro->getName() === $method;
+            }
+        );
+    }
+}
+
+/**
+ * @internal
+ * @noinspection PhpMultipleClassesDeclarationsInOneFile
+ */
+class AliasDetectMethods extends Alias
+{
+    public function __construct()
+    {
+        // no need to call parent
+    }
+
+    /**
+     * @param string[] $classes
+     */
+    public function setClasses(array $classes)
+    {
+        $this->classes = $classes;
+    }
+
+    public function detectMethods()
+    {
+        parent::detectMethods();
+    }
+}

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests;
+
+use Barryvdh\LaravelIdeHelper\Macro;
+use Barryvdh\Reflection\DocBlock;
+use Barryvdh\Reflection\DocBlock\Tag;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use ReflectionClass;
+use ReflectionFunction;
+use ReflectionFunctionAbstract;
+
+use function array_map;
+use function implode;
+
+use const PHP_EOL;
+
+/**
+ * @internal
+ * @coversDefaultClass \Barryvdh\LaravelIdeHelper\Macro
+ */
+class MacroTest extends TestCase
+{
+    private $macro = null;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->macro = new class() extends Macro {
+            public function __construct()
+            {
+                // no need to call parent
+            }
+
+            public function getPhpDoc(ReflectionFunctionAbstract $method, ReflectionClass $class = null): DocBlock
+            {
+                return (new Macro($method, '', $class ?? $method->getClosureScopeClass()))->phpdoc;
+            }
+        };
+    }
+
+    public function tearDown(): void
+    {
+        $this->macro = null;
+
+        parent::tearDown();
+    }
+
+    /**
+     * @covers ::initPhpDoc
+     * @throws \ReflectionException
+     */
+    public function testInitPhpDocEloquentBuilderHasStaticInReturnType(): void
+    {
+        $class  = new ReflectionClass(EloquentBuilder::class);
+        $phpdoc = $this->macro->getPhpDoc(
+            new ReflectionFunction(
+                function (): EloquentBuilder {
+                    return $this;
+                }
+            ),
+            $class
+        );
+
+        $this->assertNotNull($phpdoc);
+        $this->assertEquals('@return \Illuminate\Database\Eloquent\Builder|static', $this->tagsToString($phpdoc, 'return'));
+    }
+
+    protected function tagsToString(DocBlock $docBlock, string $name)
+    {
+        $tags = $docBlock->getTagsByName($name);
+        $tags = array_map(
+            function (Tag $tag) {
+                return trim((string)$tag);
+            },
+            $tags
+        );
+        $tags = implode(PHP_EOL, $tags);
+
+        return $tags;
+    }
+}


### PR DESCRIPTION
## Summary

The `\Illuminate\Database\Eloquent\Builder` is also `Macroable` but doesn't use the standard `Macroable` trait and for this reason, its macros are not included in `helper.php`. This PR fixes it.

Fixes: #1070

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
