### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -35,7 +35,7 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
             //Method inherited from <?= $method->getDeclaringClass() ?>
          <?php endif; ?>
 
-            <?php if ($method->isInstanceCall()) :?>
+            <?php if ($method->isInstanceCall()) : ?>
             /** @var <?=$method->getRoot()?> $instance */
             <?php endif?>
             <?= $method->shouldReturn() ? 'return ' : '' ?><?= $method->getRootMethodCall() ?>;
@@ -58,7 +58,7 @@ namespace <?= $namespace == '__root' ? '' : trim($namespace, '\\') ?> {
                 //Method inherited from <?= $method->getDeclaringClass() ?>
              <?php endif; ?>
 
-                <?php if ($method->isInstanceCall()) :?>
+                <?php if ($method->isInstanceCall()) : ?>
                 /** @var <?=$method->getRoot()?> $instance */
                 <?php endif?>
                 <?= $method->shouldReturn() ? 'return ' : '' ?><?= $method->getRootMethodCall() ?>;

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -51,7 +51,7 @@ DOC;
         $this->assertSame(['$last', '$first', '...$middle'], $method->getParams(false));
         $this->assertSame('$last, $first = \'Barry\', ...$middle', $method->getParamsWithDefault(true));
         $this->assertSame(['$last', '$first = \'Barry\'', '...$middle'], $method->getParamsWithDefault(false));
-        $this->assertSame(true, $method->shouldReturn());
+        $this->assertTrue($method->shouldReturn());
     }
 
     /**
@@ -85,7 +85,7 @@ DOC;
         $this->assertSame(['$relations', '$callback'], $method->getParams(false));
         $this->assertSame('$relations, $callback = null', $method->getParamsWithDefault(true));
         $this->assertSame(['$relations', '$callback = null'], $method->getParamsWithDefault(false));
-        $this->assertSame(true, $method->shouldReturn());
+        $this->assertTrue($method->shouldReturn());
     }
 
     /**


### PR DESCRIPTION
## Summary
- Test improvements.

## Type of change

- [X] Test improvements.

## Changed log

- Using the `assertTrue` to assert expected is same as `true`.