### PR TITLE
bug-fix : Call to a member function getMethods() on null

### DIFF
--- a/src/Macro.php
+++ b/src/Macro.php
@@ -61,11 +61,11 @@ class Macro extends Method
         $enclosingClass = $this->method->getClosureScopeClass();
 
         /** @var \ReflectionMethod $enclosingMethod */
-        $enclosingMethod = Collection::make($enclosingClass->getMethods())
+        $enclosingMethod = $enclosingClass ? Collection::make($enclosingClass->getMethods())
             ->first(function (\ReflectionMethod $method) {
                 return $method->getStartLine() <= $this->method->getStartLine()
                     && $method->getEndLine() >= $this->method->getEndLine();
-            });
+            }) : null;
 
         if ($enclosingMethod) {
             $this->phpdoc->appendTag(Tag::createInstance(


### PR DESCRIPTION
## Summary
This pull request fixes the issue #1084 and
prevent the exception when enclosingClass is null.



## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
