### PR TITLE
Fix broken ReflectionUnionTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 - Allow model_locations to have glob patterns [\#1059 / saackearl](https://github.com/barryvdh/laravel-ide-helper/pull/1059)
 - Error when generating helper for macroable classes which are not facades and contain a "fake" method [\#1066 / domkrm] (https://github.com/barryvdh/laravel-ide-helper/pull/1066)
 - Casts with a return type of `static` or `$this` now resolve to an instance of the cast [\#1103 / riesjart](https://github.com/barryvdh/laravel-ide-helper/pull/1103)
-
+- Broken ReflectionUnionTypes [\#1132 / def-studio](https://github.com/barryvdh/laravel-ide-helper/pull/1132)
 ### Removed
 - Removed format and broken generateJsonHelper [\#1053 / mfn](https://github.com/barryvdh/laravel-ide-helper/pull/1053)
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -36,7 +36,7 @@ use phpDocumentor\Reflection\Types\ContextFactory;
 use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionObject;
-use ReflectionUnionType;
+use ReflectionType;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -1258,9 +1258,11 @@ class ModelsCommand extends Command
         return $type;
     }
 
-    protected function extractReflectionTypes(\ReflectionType $reflection_type)
+    protected function extractReflectionTypes(ReflectionType $reflection_type)
     {
-        if(PHP_VERSION_ID>= 80000 && $reflection_type instanceof ReflectionUnionType){
+        if($reflection_type instanceof ReflectionNamedType){
+            $types[] = $this->getReflectionNamedType($reflection_type);
+        }else{
             foreach ($reflection_type->getTypes() as $named_type){
                 if($named_type->getName()==='null'){
                     continue;
@@ -1268,8 +1270,6 @@ class ModelsCommand extends Command
 
                 $types[] = $this->getReflectionNamedType($named_type);
             }
-        }else{
-            $types[] = $this->getReflectionNamedType($reflection_type);
         }
 
         return $types;

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -34,7 +34,9 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use phpDocumentor\Reflection\Types\ContextFactory;
 use ReflectionClass;
+use ReflectionNamedType;
 use ReflectionObject;
+use ReflectionUnionType;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -576,7 +578,7 @@ class ModelsCommand extends Command
                     $reflection = new \ReflectionMethod($model, $method);
 
                     if ($returnType = $reflection->getReturnType()) {
-                        $type = $returnType instanceof \ReflectionNamedType
+                        $type = $returnType instanceof ReflectionNamedType
                             ? $returnType->getName()
                             : (string)$returnType;
                     } else {
@@ -1011,16 +1013,12 @@ class ModelsCommand extends Command
             return null;
         }
 
-        $type = $returnType instanceof \ReflectionNamedType
-            ? $returnType->getName()
-            : (string)$returnType;
+        $types = $this->extractReflectionTypes($returnType);
 
-        if (!$returnType->isBuiltin()) {
-            $type = '\\' . $type;
-        }
+        $type = implode("|", $types);
 
-        if ($returnType->allowsNull()) {
-            $type .= '|null';
+        if($returnType->allowsNull()){
+            $type .="|null";
         }
 
         return $type;
@@ -1186,17 +1184,15 @@ class ModelsCommand extends Command
     protected function getParamType(\ReflectionMethod $method, \ReflectionParameter $parameter): ?string
     {
         if ($paramType = $parameter->getType()) {
-            $parameterName = $paramType->getName();
+            $types = $this->extractReflectionTypes($paramType);
 
-            if (!$paramType->isBuiltin()) {
-                $parameterName = '\\' . $parameterName;
+            $type = implode("|", $types);
+
+            if($paramType->allowsNull()){
+                $type .="|null";
             }
 
-            if ($paramType->allowsNull()) {
-                return '?' . $parameterName;
-            }
-
-            return $parameterName;
+            return $type;
         }
 
         $docComment = $method->getDocComment();
@@ -1260,5 +1256,32 @@ class ModelsCommand extends Command
         // if we have a match on index 1
         // then we have found the type of the variable if not we return null
         return $type;
+    }
+
+    protected function extractReflectionTypes(\ReflectionType $reflection_type)
+    {
+        if($reflection_type instanceof ReflectionUnionType){
+            foreach ($reflection_type->getTypes() as $named_type){
+                if($named_type->getName()==='null'){
+                    continue;
+                }
+
+                $types[] = $this->getReflectionNamedType($named_type);
+            }
+        }else{
+            $types[] = $this->getReflectionNamedType($reflection_type);
+        }
+
+        return $types;
+    }
+
+    protected function getReflectionNamedType(ReflectionNamedType $paramType): string
+    {
+        $parameterName = $paramType->getName();
+        if (!$paramType->isBuiltin()) {
+            $parameterName = '\\' . $parameterName;
+        }
+
+        return $parameterName;
     }
 }

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1260,7 +1260,7 @@ class ModelsCommand extends Command
 
     protected function extractReflectionTypes(\ReflectionType $reflection_type)
     {
-        if($reflection_type instanceof ReflectionUnionType){
+        if(PHP_VERSION_ID>= 80000 && $reflection_type instanceof ReflectionUnionType){
             foreach ($reflection_type->getTypes() as $named_type){
                 if($named_type->getName()==='null'){
                     continue;

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1018,11 +1018,7 @@ class ModelsCommand extends Command
         $type = implode("|", $types);
 
         if($returnType->allowsNull()){
-            if(count($types)==1){
-                $type = "?" . $type;
-            }else{
-                $type .="|null";
-            }
+            $type .="|null";
         }
 
         return $type;

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1263,6 +1263,7 @@ class ModelsCommand extends Command
         if($reflection_type instanceof ReflectionNamedType){
             $types[] = $this->getReflectionNamedType($reflection_type);
         }else{
+            $types = [];
             foreach ($reflection_type->getTypes() as $named_type){
                 if($named_type->getName()==='null'){
                     continue;

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1015,10 +1015,10 @@ class ModelsCommand extends Command
 
         $types = $this->extractReflectionTypes($returnType);
 
-        $type = implode("|", $types);
+        $type = implode('|', $types);
 
         if($returnType->allowsNull()){
-            $type .="|null";
+            $type .='|null';
         }
 
         return $type;
@@ -1186,13 +1186,13 @@ class ModelsCommand extends Command
         if ($paramType = $parameter->getType()) {
             $types = $this->extractReflectionTypes($paramType);
 
-            $type = implode("|", $types);
+            $type = implode('|', $types);
 
             if($paramType->allowsNull()){
                 if(count($types)==1){
-                    $type = "?" . $type;
+                    $type = '?' . $type;
                 }else{
-                    $type .="|null";
+                    $type .='|null';
                 }
             }
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1018,7 +1018,11 @@ class ModelsCommand extends Command
         $type = implode("|", $types);
 
         if($returnType->allowsNull()){
-            $type .="|null";
+            if(count($types)==1){
+                $type = "?" . $type;
+            }else{
+                $type .="|null";
+            }
         }
 
         return $type;
@@ -1189,7 +1193,11 @@ class ModelsCommand extends Command
             $type = implode("|", $types);
 
             if($paramType->allowsNull()){
-                $type .="|null";
+                if(count($types)==1){
+                    $type = "?" . $type;
+                }else{
+                    $type .="|null";
+                }
             }
 
             return $type;

--- a/tests/Console/ModelsCommand/UnionTypes/Models/UnionTypeModel.php
+++ b/tests/Console/ModelsCommand/UnionTypes/Models/UnionTypeModel.php
@@ -15,8 +15,18 @@ class UnionTypeModel extends Model
         return $query->where('foo', $bar);
     }
 
+    public function scopeWithNullableUnionTypeParameter(Builder $query, null|string|int $bar): Builder
+    {
+        return $query->where('foo', $bar);
+    }
+
     public function withUnionTypeReturn(): HasMany|UnionTypeModel
     {
         return $this->hasMany(UnionTypeModel::class);
+    }
+
+    public function getFooAttribute(): string|int|null
+    {
+        return $this->getAttribute('foo');
     }
 }

--- a/tests/Console/ModelsCommand/UnionTypes/Models/UnionTypeModel.php
+++ b/tests/Console/ModelsCommand/UnionTypes/Models/UnionTypeModel.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\UnionTypes\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Query\Builder;
+
+class UnionTypeModel extends Model
+{
+    public function scopeWithUnionTypeParameter(Builder $query, string|int $bar): Builder
+    {
+        return $query->where('foo', $bar);
+    }
+
+    public function withUnionTypeReturn(): HasMany|UnionTypeModel
+    {
+        return $this->hasMany(UnionTypeModel::class);
+    }
+}

--- a/tests/Console/ModelsCommand/UnionTypes/Test.php
+++ b/tests/Console/ModelsCommand/UnionTypes/Test.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\UnionTypes;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+use Illuminate\Foundation\Application;
+
+class Test extends AbstractModelsCommand
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('This test requires PHP 8.0 or higher');
+        }
+    }
+
+    public function test(): void
+    {
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--write' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
+        $this->assertMatchesMockedSnapshot();
+    }
+}

--- a/tests/Console/ModelsCommand/UnionTypes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/UnionTypes/__snapshots__/Test__test__1.php
@@ -11,11 +11,13 @@ use Illuminate\Database\Query\Builder;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\UnionTypes\Models\UnionTypeModel
  *
+ * @property-read string|int|null $foo
  * @property-read \Illuminate\Database\Eloquent\Collection|UnionTypeModel[] $withUnionTypeReturn
  * @property-read int|null $with_union_type_return_count
  * @method static \Illuminate\Database\Eloquent\Builder|UnionTypeModel newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|UnionTypeModel newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|UnionTypeModel query()
+ * @method static \Illuminate\Database\Eloquent\Builder|UnionTypeModel withNullableUnionTypeParameter(string|int|null $bar)
  * @method static \Illuminate\Database\Eloquent\Builder|UnionTypeModel withUnionTypeParameter(string|int $bar)
  * @mixin \Eloquent
  */
@@ -26,8 +28,18 @@ class UnionTypeModel extends Model
         return $query->where('foo', $bar);
     }
 
+    public function scopeWithNullableUnionTypeParameter(Builder $query, null|string|int $bar): Builder
+    {
+        return $query->where('foo', $bar);
+    }
+
     public function withUnionTypeReturn(): HasMany|UnionTypeModel
     {
         return $this->hasMany(UnionTypeModel::class);
+    }
+
+    public function getFooAttribute(): string|int|null
+    {
+        return $this->getAttribute('foo');
     }
 }

--- a/tests/Console/ModelsCommand/UnionTypes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/UnionTypes/__snapshots__/Test__test__1.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\UnionTypes\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Query\Builder;
+
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\UnionTypes\Models\UnionTypeModel
+ *
+ * @property-read \Illuminate\Database\Eloquent\Collection|UnionTypeModel[] $withUnionTypeReturn
+ * @property-read int|null $with_union_type_return_count
+ * @method static \Illuminate\Database\Eloquent\Builder|UnionTypeModel newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|UnionTypeModel newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|UnionTypeModel query()
+ * @method static \Illuminate\Database\Eloquent\Builder|UnionTypeModel withUnionTypeParameter(string|int $bar)
+ * @mixin \Eloquent
+ */
+class UnionTypeModel extends Model
+{
+    public function scopeWithUnionTypeParameter(Builder $query, string|int $bar): Builder
+    {
+        return $query->where('foo', $bar);
+    }
+
+    public function withUnionTypeReturn(): HasMany|UnionTypeModel
+    {
+        return $this->hasMany(UnionTypeModel::class);
+    }
+}


### PR DESCRIPTION
## Summary
This PR addresses issue #1129 , fixing exceptions thrown when a union type is present both in return type and parameter types

In php 8 ReflectionType class is subclassed by ReflectionUnionType , which is missing getName() and isBuiltin() methods. This code changes aim at defining an intermediary function that:

- handles ReflectionUnionTypes by splitting them in an array of ReflectionNamedTypes.
- handles single ReflectionNamedTypes, wrapping them in an array in order to handle the same data type

```php
protected function extractReflectionTypes(\ReflectionType $reflection_type)
{
    if($reflection_type instanceof \ReflectionUnionType){
        foreach ($reflection_type->getTypes() as $named_type){
            if($named_type->getName()==='null'){
                continue;
            }

            $types[] = $this->getReflectionNamedType($named_type);
        }
    }else{
        $types[] = $this->getReflectionNamedType($reflection_type);
    }

    return $types;
}
```

the `getReflectionNamedType()` function wraps the old code for extracting the parameter name and adding `\\` in case of builtin type:

```php
protected function getReflectionNamedType(\ReflectionNamedType $paramType): string
{
    $parameterName = $paramType->getName();
    if (!$paramType->isBuiltin()) {
        $parameterName = '\\' . $parameterName;
    }

    return $parameterName;
}
```

These two functions are used to convert the two subclasses of ReflectionTypes to their respective dockblock strings


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] _Update the README.md (no changes needed)_
- [x] Code style has been fixed via `composer fix-style`
