### PR TITLE
changelog: re-order entry after recent merges in master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 [Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.9.1...master)
 --------------
+### Added
+- Generate PHPDoc for Laravel 8.x factories [\#1074 / ahmed-aliraqi](https://github.com/barryvdh/laravel-ide-helper/pull/1074)
+
+### Fixed
+- Error when generating helper for invokable classes [\#1124 / standaniels](https://github.com/barryvdh/laravel-ide-helper/pull/1124)
 
 2020-12-30, 2.9.0
 -----------------
@@ -21,7 +26,6 @@ All notable changes to this project will be documented in this file.
 - Created a possibility to add custom relation type [\#987 / efinder2](https://github.com/barryvdh/laravel-ide-helper/pull/987)
 - Added `@see` with macro/mixin definition location to PhpDoc [\#1054 / riesjart](https://github.com/barryvdh/laravel-ide-helper/pull/1054)
 - Initial compatibility for PHP8 [\#1106 / mfn](https://github.com/barryvdh/laravel-ide-helper/pull/1106)
-- Generate PHPDoc for laravel 8.x factories [\#1074 / ahmed-aliraqi](https://github.com/barryvdh/laravel-ide-helper/pull/1074)
 
 ### Changed
 - Implement DeferrableProvider [\#914 / kon-shou](https://github.com/barryvdh/laravel-ide-helper/pull/914)
@@ -31,7 +35,6 @@ All notable changes to this project will be documented in this file.
 - Allow model_locations to have glob patterns [\#1059 / saackearl](https://github.com/barryvdh/laravel-ide-helper/pull/1059)
 - Error when generating helper for macroable classes which are not facades and contain a "fake" method [\#1066 / domkrm] (https://github.com/barryvdh/laravel-ide-helper/pull/1066)
 - Casts with a return type of `static` or `$this` now resolve to an instance of the cast [\#1103 / riesjart](https://github.com/barryvdh/laravel-ide-helper/pull/1103)
-- Error when generating helper for invokable classes [\#1124 / standaniels](https://github.com/barryvdh/laravel-ide-helper/pull/1124)
 
 ### Removed
 - Removed format and broken generateJsonHelper [\#1053 / mfn](https://github.com/barryvdh/laravel-ide-helper/pull/1053)

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1057,7 +1057,7 @@ class ModelsCommand extends Command
         }
 
         $traits = class_uses(get_class($model), true);
-        if (! in_array('Illuminate\\Database\\Eloquent\\Factories\\HasFactory', $traits)) {
+        if (!in_array('Illuminate\\Database\\Eloquent\\Factories\\HasFactory', $traits)) {
             return;
         }
 
@@ -1065,7 +1065,7 @@ class ModelsCommand extends Command
         $factory = get_class($modelName::factory());
         $factory = '\\' . trim($factory, '\\');
 
-        if (! class_exists($factory)) {
+        if (!class_exists($factory)) {
             return;
         }
 

--- a/tests/Console/ModelsCommand/Factories/Test.php
+++ b/tests/Console/ModelsCommand/Factories/Test.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories;
 
-use Illuminate\Foundation\Application;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+use Illuminate\Foundation\Application;
 
 class Test extends AbstractModelsCommand
 {
     public function test(): void
     {
-        if (! version_compare(Application::VERSION, '8.2', '>=')) {
+        if (!version_compare(Application::VERSION, '8.2', '>=')) {
             $this->markTestSkipped(
                 'This test only works in Laravel >= 8.2'
             );


### PR DESCRIPTION
## Summary
As the title says. Just a minor thing to keep the changelog in order so it's correct for the next release and can be copy pasted.