### PR TITLE
tests: fix assertion

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1057,7 +1057,7 @@ class ModelsCommand extends Command
         }
 
         $traits = class_uses(get_class($model), true);
-        if (! in_array('Illuminate\\Database\\Eloquent\\Factories\\HasFactory', $traits)) {
+        if (!in_array('Illuminate\\Database\\Eloquent\\Factories\\HasFactory', $traits)) {
             return;
         }
 
@@ -1065,7 +1065,7 @@ class ModelsCommand extends Command
         $factory = get_class($modelName::factory());
         $factory = '\\' . trim($factory, '\\');
 
-        if (! class_exists($factory)) {
+        if (!class_exists($factory)) {
             return;
         }
 

--- a/tests/Console/ModelsCommand/Factories/Test.php
+++ b/tests/Console/ModelsCommand/Factories/Test.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories;
 
-use Illuminate\Foundation\Application;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+use Illuminate\Foundation\Application;
 
 class Test extends AbstractModelsCommand
 {
     public function test(): void
     {
-        if (! version_compare(Application::VERSION, '8.2', '>=')) {
+        if (!version_compare(Application::VERSION, '8.2', '>=')) {
             $this->markTestSkipped(
                 'This test only works in Laravel >= 8.2'
             );

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -225,10 +225,10 @@ class MacroTest extends TestCase
 /**
  * 
  *
- * @see \Barryvdh\LaravelIdeHelper\Tests\UrlGeneratorMacroClass::__invoke()
  * @param string $foo
  * @param int $bar
  * @return string 
+ * @see \Barryvdh\LaravelIdeHelper\Tests\UrlGeneratorMacroClass::__invoke()
  * @static 
  */
 DOC;


### PR DESCRIPTION
## Summary
Fixes the ordering of the phpdoc for the test assertion, making master branch green again.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] ~Add a CHANGELOG.md entry~
- [ ] ~Update the README.md~
- [ ] ~Code style has been fixed via `composer fix-style`~
