### PR TITLE
Apply "@PSR12" in php-cs-fixer

### DIFF
--- a/.php_cs.common.php
+++ b/.php_cs.common.php
@@ -2,12 +2,10 @@
 
 // Share common rules between non-test and test files
 return [
-    // PSR12 from https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4943
-    '@PSR2' => true,
+    '@PSR12' => true,
     'blank_line_after_opening_tag' => true,
     'braces' => [
-        // Not-yet-implemented
-        // 'allow_single_line_anonymous_class_with_empty_body' => true,
+        'allow_single_line_anonymous_class_with_empty_body' => true,
     ],
     'compact_nullable_typehint' => true,
     'declare_equal_normalize' => true,

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -344,7 +344,6 @@ class Alias
      */
     protected function detectMethods()
     {
-
         foreach ($this->classes as $class) {
             $reflection = new \ReflectionClass($class);
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -212,8 +212,6 @@ class ModelsCommand extends Command
 
     protected function generateDocs($loadModels, $ignore = '')
     {
-
-
         $output = "<?php
 
 // @formatter:off
@@ -313,7 +311,6 @@ class ModelsCommand extends Command
 
             $dirs = glob($dir, GLOB_ONLYDIR);
             foreach ($dirs as $dir) {
-
                 if (!is_dir($dir)) {
                     $this->error("Cannot locate directory '{'$dir}'");
                     continue;
@@ -757,7 +754,6 @@ class ModelsCommand extends Command
      */
     protected function createPhpDocs($class)
     {
-
         $reflection = new ReflectionClass($class);
         $namespace = $reflection->getNamespaceName();
         $classname = $reflection->getShortName();
@@ -1019,7 +1015,7 @@ class ModelsCommand extends Command
 
         $type = implode('|', $types);
 
-        if($returnType->allowsNull()){
+        if ($returnType->allowsNull()) {
             $type .='|null';
         }
 
@@ -1050,7 +1046,7 @@ class ModelsCommand extends Command
      */
     protected function getFactoryMethods($model)
     {
-        if(!class_exists(Factory::class)) {
+        if (!class_exists(Factory::class)) {
             return;
         }
 
@@ -1128,7 +1124,7 @@ class ModelsCommand extends Command
             $reflectionType = $this->getReturnTypeFromDocBlock($methodReflection);
         }
 
-        if($reflectionType === 'static' || $reflectionType === '$this') {
+        if ($reflectionType === 'static' || $reflectionType === '$this') {
             $reflectionType = $type;
         }
 
@@ -1217,10 +1213,10 @@ class ModelsCommand extends Command
 
             $type = implode('|', $types);
 
-            if($paramType->allowsNull()){
-                if(count($types)==1){
+            if ($paramType->allowsNull()) {
+                if (count($types)==1) {
                     $type = '?' . $type;
-                }else{
+                } else {
                     $type .='|null';
                 }
             }
@@ -1293,12 +1289,12 @@ class ModelsCommand extends Command
 
     protected function extractReflectionTypes(ReflectionType $reflection_type)
     {
-        if($reflection_type instanceof ReflectionNamedType){
+        if ($reflection_type instanceof ReflectionNamedType) {
             $types[] = $this->getReflectionNamedType($reflection_type);
-        }else{
+        } else {
             $types = [];
-            foreach ($reflection_type->getTypes() as $named_type){
-                if($named_type->getName()==='null'){
+            foreach ($reflection_type->getTypes() as $named_type) {
+                if ($named_type->getName()==='null') {
                     continue;
                 }
 


### PR DESCRIPTION
## Summary

PSR12 ruleset has been added in v2.18.0. https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/tag/v2.18.0

Changed @PSR2 to `@PSR12` in `.php_cs.common.php`.

I also enabled the commented out `allow_single_line_anonymous_class_with_empty_body` as it is already implemented in php-cs-fixer.

----

If you have any problems, you can of course close this PR.

## Type of change

- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist

- [x] Code style has been fixed via `composer fix-style`