### PR TITLE
Add extensions for model DocBlocks

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -278,4 +278,14 @@ return [
     */
     'additional_relation_types' => [],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Model extensions
+    |--------------------------------------------------------------------------
+    |
+    | Add ability to write invokable extensions for model DocBlocks.
+    |
+    */
+    'model_extensions' => [],
+
 ];

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -275,6 +275,7 @@ class ModelsCommand extends Command
                         $this->castPropertiesType($model);
                     }
 
+                    $this->getPropertiesFromExtensions($model);
                     $this->getPropertiesFromMethods($model);
                     $this->getSoftDeleteMethods($model);
                     $this->getCollectionMethods($model);
@@ -509,6 +510,17 @@ class ModelsCommand extends Command
     /**
      * @param \Illuminate\Database\Eloquent\Model $model
      */
+    protected function getPropertiesFromExtensions($model)
+    {
+        foreach ($this->laravel['config']->get('ide-helper.model_extensions', []) as $extension) {
+            $plugin = $this->laravel->make($extension);
+            $plugin($model, $this);
+        }
+    }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Model $model
+     */
     protected function getPropertiesFromMethods($model)
     {
         $methods = get_class_methods($model);
@@ -713,7 +725,7 @@ class ModelsCommand extends Command
      * @param string|null $comment
      * @param bool        $nullable
      */
-    protected function setProperty($name, $type = null, $read = null, $write = null, $comment = '', $nullable = false)
+    public function setProperty($name, $type = null, $read = null, $write = null, $comment = '', $nullable = false)
     {
         if (!isset($this->properties[$name])) {
             $this->properties[$name] = [];


### PR DESCRIPTION
## Summary
Add ability to customize the model DocBlocks by registering invokable custom model extensions.

Before completing the checklist, is there any chance of this feature being merged in the future?
It will help us a lot for generating complete model DocBlocks.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`

## Usage
```php
    /*
    |--------------------------------------------------------------------------
    | Model extensions
    |--------------------------------------------------------------------------
    |
    | Add ability to write invokable extensions for model DocBlocks.
    |
    */
    'model_extensions' => [
        \App\Support\IdeHelper\Paperclip::class,
    ],
```

```php
class Paperclip
{
    public function __invoke(Model $model, ModelsCommand $modelsCommand): void
    {
        if (! $model instanceof AttachableInterface) {
            return;
        }

        foreach ($model->getAttachedFiles() as $index => $attachment) {
            $modelsCommand->setProperty($index, Attachment::class, true, true, '', true);
        }
    }
}
```
