### PR TITLE
Auto generate models

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
         "spatie/phpunit-snapshot-assertions": "^3 || ^4",
         "vimeo/psalm": "^3.12"
     },
+    "suggest": {
+        "illuminate/events": "Required for automatic helper generation (^6|^7|^8)."
+    },
     "config": {
         "sort-packages": true
     },

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -280,14 +280,14 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Run artisan command(s) after migrations to generate model helpers
+    | Run artisan commands after migrations to generate model helpers
     |--------------------------------------------------------------------------
     |
-    | Set to false to disable this feature or specify the command(s).
-    | E.g. `ide-helper:models --nowrite`.
-    | If an array is provided each element will be executed in order.
+    | The specified commands should run after migrations are finished running.
     |
     */
-    'post_migrate' => false,
+    'post_migrate' => [
+        // 'ide-helper:models --nowrite',
+    ],
 
 ];

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -278,7 +278,6 @@ return [
     */
     'additional_relation_types' => [],
 
-
     /*
     |--------------------------------------------------------------------------
     | Generate model helpers after migrations
@@ -290,4 +289,5 @@ return [
     |
     */
     'post_migrate' => false,
+
 ];

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -280,12 +280,12 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Generate model helpers after migrations
+    | Run artisan command(s) after migrations to generate model helpers
     |--------------------------------------------------------------------------
     |
-    | Set to false to disable running ide-helper:models after a successful
-    | migration command or specify the parameters in either string or array form.
-    | e.g, specifying `--nowrite` will execute `php artisan ide-helper:models --nowrite`
+    | Set to false to disable this feature or specify the command(s).
+    | E.g. `ide-helper:models --nowrite`.
+    | If an array is provided each element will be executed in order.
     |
     */
     'post_migrate' => false,

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -278,4 +278,16 @@ return [
     */
     'additional_relation_types' => [],
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Generate model helpers after migrations
+    |--------------------------------------------------------------------------
+    |
+    | Set to false to disable running ide-helper:models after a successful
+    | migration command or specify the parameters in either string or array form.
+    | e.g, specifying `--nowrite` will execute `php artisan ide-helper:models --nowrite`
+    |
+    */
+    'post_migrate' => false,
 ];

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -35,7 +35,7 @@ class IdeHelperServiceProvider extends ServiceProvider implements DeferrableProv
      */
     public function boot()
     {
-        if ($this->app['config']->get('ide-helper.post_migrate', false)) {
+        if ($this->app['config']->get('ide-helper.post_migrate', [])) {
             $this->app['events']->listen(CommandFinished::class, GenerateModelHelper::class);
             $this->app['events']->listen(MigrationsEnded::class, function () {
                 GenerateModelHelper::$shouldRun = true;

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -15,7 +15,10 @@ use Barryvdh\LaravelIdeHelper\Console\EloquentCommand;
 use Barryvdh\LaravelIdeHelper\Console\GeneratorCommand;
 use Barryvdh\LaravelIdeHelper\Console\MetaCommand;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Listeners\GenerateModelHelper;
+use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Database\Events\MigrationsEnded;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Engines\EngineResolver;
@@ -32,6 +35,13 @@ class IdeHelperServiceProvider extends ServiceProvider implements DeferrableProv
      */
     public function boot()
     {
+        if ($this->app['config']->get('ide-helper.post_migrate', false)) {
+            $this->app['events']->listen(CommandFinished::class, GenerateModelHelper::class);
+            $this->app['events']->listen(MigrationsEnded::class, function () {
+                GenerateModelHelper::$shouldRun = true;
+            });
+        }
+
         if ($this->app->has('view')) {
             $viewPath = __DIR__ . '/../resources/views';
             $this->loadViewsFrom($viewPath, 'ide-helper');

--- a/src/Listeners/GenerateModelHelper.php
+++ b/src/Listeners/GenerateModelHelper.php
@@ -5,6 +5,7 @@ namespace Barryvdh\LaravelIdeHelper\Listeners;
 use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Console\Kernel as Artisan;
+use Illuminate\Support\Arr;
 
 class GenerateModelHelper
 {
@@ -45,11 +46,10 @@ class GenerateModelHelper
 
         self::$shouldRun = false;
 
-        $parameters = $this->config->get('ide-helper.post_migrate');
-        $this->artisan->call(
-            is_array($parameters) ? 'ide-helper:models' : 'ide-helper:models ' . $parameters,
-            is_array($parameters) ? $parameters : [],
-            $event->output,
-        );
+        $commands = $this->config->get('ide-helper.post_migrate');
+
+        foreach (Arr::wrap($commands) as $command) {
+            $this->artisan->call($command, [], $event->output);
+        }
     }
 }

--- a/src/Listeners/GenerateModelHelper.php
+++ b/src/Listeners/GenerateModelHelper.php
@@ -5,7 +5,6 @@ namespace Barryvdh\LaravelIdeHelper\Listeners;
 use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Console\Kernel as Artisan;
-use Illuminate\Support\Arr;
 
 class GenerateModelHelper
 {
@@ -46,9 +45,7 @@ class GenerateModelHelper
 
         self::$shouldRun = false;
 
-        $commands = $this->config->get('ide-helper.post_migrate');
-
-        foreach (Arr::wrap($commands) as $command) {
+        foreach ($this->config->get('ide-helper.post_migrate', []) as $command) {
             $this->artisan->call($command, [], $event->output);
         }
     }

--- a/src/Listeners/GenerateModelHelper.php
+++ b/src/Listeners/GenerateModelHelper.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper\Listeners;
+
+use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Contracts\Console\Kernel as Artisan;
+
+class GenerateModelHelper
+{
+    /** @var bool */
+    public static $shouldRun = false;
+
+    /** @var \Illuminate\Contracts\Console\Kernel */
+    protected $artisan;
+
+    /** @var \Illuminate\Contracts\Config\Repository */
+    protected $config;
+
+    /**
+     * @param  \Illuminate\Contracts\Console\Kernel  $artisan
+     * @param  \Illuminate\Contracts\Config\Repository  $config
+     */
+    public function __construct(Artisan $artisan, Config $config)
+    {
+        $this->artisan = $artisan;
+        $this->config = $config;
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  CommandFinished  $event
+     */
+    public function handle(CommandFinished $event)
+    {
+        if (!self::$shouldRun) {
+            return;
+        }
+
+        self::$shouldRun = false;
+
+        $parameters = $this->config->get('ide-helper.post_migrate');
+        $this->artisan->call(
+            is_array($parameters) ? 'ide-helper:models' : 'ide-helper:models ' . $parameters,
+            is_array($parameters) ? $parameters : [],
+            $event->output,
+        );
+    }
+}

--- a/src/Listeners/GenerateModelHelper.php
+++ b/src/Listeners/GenerateModelHelper.php
@@ -8,7 +8,12 @@ use Illuminate\Contracts\Console\Kernel as Artisan;
 
 class GenerateModelHelper
 {
-    /** @var bool */
+    /**
+     * Tracks whether we should run the models command on the CommandFinished event or not.
+     * Set to true by the MigrationsEnded event, needs to be cleared before artisan call to prevent infinite loop.
+     *
+     * @var bool
+     */
     public static $shouldRun = false;
 
     /** @var \Illuminate\Contracts\Console\Kernel */


### PR DESCRIPTION
This pull request allows generating model helpers automatically after migrations executed.

Basically a newer version of #842, started from the current master branch.

Based on the comment by barryvdh the config option is simplified it is named `post_migrate` and it is either false to disable this feature or sets the parameters for the "ide-helper:model" command. It supports both `"--nowrite"` and the `["--nowrite" => true]` format.

The trigger was updated to use the MigrationsEnded event because Laravel will run "incomplete" commands like `migrate:roll` as `migrate:rollback`.

The other helper file generation was dropped in favor of composer post update commands.