### PR TITLE
Add comments like table columns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 --------------
 ### Added
 - Generate PHPDoc for Laravel 8.x factories [\#1074 / ahmed-aliraqi](https://github.com/barryvdh/laravel-ide-helper/pull/1074)
+- Add a comment to a property like table columns [\#1168 / biiiiiigmonster](https://github.com/barryvdh/laravel-ide-helper/pull/1168)
 
 ### Fixed
 - Error when generating helper for invokable classes [\#1124 / standaniels](https://github.com/barryvdh/laravel-ide-helper/pull/1124)

--- a/README.md
+++ b/README.md
@@ -216,6 +216,33 @@ You may use the [`::withCount`](https://laravel.com/docs/master/eloquent-relatio
 
 By default, these attributes are generated in the phpdoc. You can turn them off by setting the config `write_model_relation_count_properties` to `false`.
 
+#### Support `@comment` based on DocBlock
+
+In order to better support ide, relations and getters/setters can also add comments like table columns. Only based on DocBlock, use `@comment`. example:
+```php
+class Users extends Model
+{
+    /**
+     * @comment Get User's full name
+     *
+     * @return string
+     */
+    public function getFullNameAttribute(): string
+    {
+        return $this->first_name . ' ' .$this->last_name ;
+    }
+}
+
+// => will become after generate models
+
+/**
+ * App\Models\Users
+ * 
+ * @property-read string $full_name Get User's full name
+ * …
+ */
+```
+
 #### Dedicated Eloquent Builder methods
 
 A new method to the eloquent models was added called `newEloquentBuilder` [Reference](https://timacdonald.me/dedicated-eloquent-model-query-builders/) where we can 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ By default, these attributes are generated in the phpdoc. You can turn them off 
 
 #### Support `@comment` based on DocBlock
 
-In order to better support ide, relations and getters/setters can also add comments like table columns. Only based on DocBlock, use `@comment`. example:
+In order to better support IDEs, relations and getters/setters can also add a comment to a property like table columns. Therefore a custom docblock `@comment` is used:
 ```php
 class Users extends Model
 {

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ class Users extends Model
     }
 }
 
-// => will become after generate models
+// => after generate models
 
 /**
  * App\Models\Users

--- a/tests/Console/ModelsCommand/Comment/Models/Simple.php
+++ b/tests/Console/ModelsCommand/Comment/Models/Simple.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Comment\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Simple extends Model
+{
+    /**
+     * There is not comment.
+     *
+     * @return string
+     */
+    public function getNotCommentAttribute(): string
+    {
+    }
+
+    /**
+     * comment There is not format comment, invalid.
+     *
+     * @return string
+     */
+    public function getFakerCommentAttribute(): string
+    {
+    }
+
+    /**
+     * @comment There is format comment, success.
+     *
+     * @return string
+     */
+    public function getFormatCommentAttribute(): string
+    {
+    }
+
+    /**
+     * @comment There is format comment, success.
+     * This is second line, success too.
+     *
+     * @return string
+     */
+    public function getFormatCommentLineTwoAttribute(): string
+    {
+    }
+
+    /**
+     * @comment There is format comment, success.
+     * @comment This is others format comment, invalid.
+     *
+     * @return string
+     */
+    public function getManyFormatCommentAttribute(): string
+    {
+    }
+
+    /**
+     * @comment Set the user's first name.
+     * @param $value
+     */
+    public function setFirstNameAttribute($value)
+    {
+    }
+
+    /**
+     * @comment Scope a query to only include active users.
+     *
+     * @param $query
+     * @return mixed
+     */
+    public function scopeActive($query)
+    {
+        return $query;
+    }
+
+    /**
+     * @comment HasMany relations.
+     *
+     * @return HasMany
+     */
+    public function relationHasMany(): HasMany
+    {
+        return $this->hasMany(Simple::class);
+    }
+
+    /**
+     * @comment MorphTo relations.
+     * @return MorphTo
+     */
+    public function relationMorphTo(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * @comment Others relations.
+     * @return HasOne
+     */
+    public function relationHasOne(): HasOne
+    {
+        return $this->hasOne(Simple::class);
+    }
+}

--- a/tests/Console/ModelsCommand/Comment/Models/Simple.php
+++ b/tests/Console/ModelsCommand/Comment/Models/Simple.php
@@ -104,4 +104,33 @@ class Simple extends Model
     {
         return $this->hasOne(Simple::class);
     }
+
+    /**
+     * @comment I'm a setter
+     */
+    public function setBothSameNameAttribute(): void
+    {
+    }
+
+    /**
+     * @comment I'm a getter
+     * @return string
+     */
+    public function getBothSameNameAttribute(): string
+    {
+    }
+
+    /**
+     * @comment I'm a setter
+     */
+    public function setBothWithoutGetterCommentAttribute(): void
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function getBothWithoutGetterCommentAttribute(): string
+    {
+    }
 }

--- a/tests/Console/ModelsCommand/Comment/Test.php
+++ b/tests/Console/ModelsCommand/Comment/Test.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Comment;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+
+class Test extends AbstractModelsCommand
+{
+    public function test(): void
+    {
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--write' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
+        $this->assertMatchesMockedSnapshot();
+    }
+}

--- a/tests/Console/ModelsCommand/Comment/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Comment/__snapshots__/Test__test__1.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Comment\Models;
 
-use DateTime;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;

--- a/tests/Console/ModelsCommand/Comment/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Comment/__snapshots__/Test__test__1.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Comment\Models;
+
+use DateTime;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Comment\Models\Simple
+ *
+ * @property integer $id
+ * @property-read string $faker_comment
+ * @property-read string $format_comment There is format comment, success.
+ * @property-read string $format_comment_line_two There is format comment, success.
+ * This is second line, success too.
+ * @property-read string $many_format_comment There is format comment, success.
+ * @property-read string $not_comment
+ * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $relationHasMany HasMany relations.
+ * @property-read int|null $relation_has_many_count
+ * @property-read Simple|null $relationHasOne Others relations.
+ * @property-read Model|\Eloquent $relationMorphTo MorphTo relations.
+ * @property-write mixed $first_name Set the user's first name.
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple active() Scope a query to only include active users.
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
+ * @mixin \Eloquent
+ */
+class Simple extends Model
+{
+    /**
+     * There is not comment.
+     *
+     * @return string
+     */
+    public function getNotCommentAttribute(): string
+    {
+    }
+
+    /**
+     * comment There is not format comment, invalid.
+     *
+     * @return string
+     */
+    public function getFakerCommentAttribute(): string
+    {
+    }
+
+    /**
+     * @comment There is format comment, success.
+     *
+     * @return string
+     */
+    public function getFormatCommentAttribute(): string
+    {
+    }
+
+    /**
+     * @comment There is format comment, success.
+     * This is second line, success too.
+     *
+     * @return string
+     */
+    public function getFormatCommentLineTwoAttribute(): string
+    {
+    }
+
+    /**
+     * @comment There is format comment, success.
+     * @comment This is others format comment, invalid.
+     *
+     * @return string
+     */
+    public function getManyFormatCommentAttribute(): string
+    {
+    }
+
+    /**
+     * @comment Set the user's first name.
+     * @param $value
+     */
+    public function setFirstNameAttribute($value)
+    {
+    }
+
+    /**
+     * @comment Scope a query to only include active users.
+     *
+     * @param $query
+     * @return mixed
+     */
+    public function scopeActive($query)
+    {
+        return $query;
+    }
+
+    /**
+     * @comment HasMany relations.
+     *
+     * @return HasMany
+     */
+    public function relationHasMany(): HasMany
+    {
+        return $this->hasMany(Simple::class);
+    }
+
+    /**
+     * @comment MorphTo relations.
+     * @return MorphTo
+     */
+    public function relationMorphTo(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * @comment Others relations.
+     * @return HasOne
+     */
+    public function relationHasOne(): HasOne
+    {
+        return $this->hasOne(Simple::class);
+    }
+}

--- a/tests/Console/ModelsCommand/Comment/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Comment/__snapshots__/Test__test__1.php
@@ -13,6 +13,8 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Comment\Models\Simple
  *
  * @property integer $id
+ * @property string $both_same_name I'm a getter
+ * @property string $both_without_getter_comment
  * @property-read string $faker_comment
  * @property-read string $format_comment There is format comment, success.
  * @property-read string $format_comment_line_two There is format comment, success.
@@ -125,5 +127,34 @@ class Simple extends Model
     public function relationHasOne(): HasOne
     {
         return $this->hasOne(Simple::class);
+    }
+
+    /**
+     * @comment I'm a setter
+     */
+    public function setBothSameNameAttribute(): void
+    {
+    }
+
+    /**
+     * @comment I'm a getter
+     * @return string
+     */
+    public function getBothSameNameAttribute(): string
+    {
+    }
+
+    /**
+     * @comment I'm a setter
+     */
+    public function setBothWithoutGetterCommentAttribute(): void
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function getBothWithoutGetterCommentAttribute(): string
+    {
     }
 }


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->
In order to better support ide, relations and getters/setters can also add comments like table columns. Only based on DocBlock, use `@comment`.[#1165](https://github.com/barryvdh/laravel-ide-helper/issues/1165#issue-818725732)
### Support list

- getter
- setter
- scope
- relations

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [x] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
