### PR TITLE
Fix #1173 Use FQN for write-mixin

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1152,7 +1152,7 @@ class ModelsCommand extends Command
         ;
 
         $className = trim($className, '\\');
-        $writingToExternalFile = !$this->write;
+        $writingToExternalFile = !$this->write || $this->write_mixin;
         $classIsNotInExternalFile = $reflection->getName() !== $className;
         $forceFQCN = $this->laravel['config']->get('ide-helper.force_fqn', false);
 

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/Models/Post.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/Models/Post.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithMixin\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * @property $someProp

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/__snapshots__/Test__test__1.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithMixin\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * @property $someProp


### PR DESCRIPTION
## Summary
When using write-mixin, FQN is not generated for classes used in the Model. #1173

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
