### PR TITLE
Update composer scripts to run only in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,19 @@ Note: `bootstrap/compiled.php` has to be cleared first, so run `php artisan clea
 
 This will generate the file `_ide_helper.php` which is expected to be additionally parsed by your IDE for autocomplete. You can use the config `filename` to change its name.
 
-You can configure your `composer.json` to do this each time you update your dependencies:
+You can configure your `composer.json` to do this each time you update or install your dependencies in dev environment:
 
 ```js
 "scripts": {
     "post-update-cmd": [
         "Illuminate\\Foundation\\ComposerScripts::postUpdate",
-        "@php artisan ide-helper:generate",
-        "@php artisan ide-helper:meta"
+        "[ $COMPOSER_DEV_MODE -eq 0 ] || $PHP_BINARY artisan ide-helper:generate",
+        "[ $COMPOSER_DEV_MODE -eq 0 ] || $PHP_BINARY artisan ide-helper:meta"
+    ],
+    "post-install-cmd": [
+        "Illuminate\\Foundation\\ComposerScripts::postInstall",
+        "[ $COMPOSER_DEV_MODE -eq 0 ] || $PHP_BINARY artisan ide-helper:generate",
+        "[ $COMPOSER_DEV_MODE -eq 0 ] || $PHP_BINARY artisan ide-helper:meta"
     ]
 },
 ```


### PR DESCRIPTION
## Summary
This PR updates the suggested composer integration to run only in dev environment. This should do the same as #1067 without introducing a new command.

Also the PR suggest executing the same commands in the post-install section, which can be helpful if repository is access from multiple locations or have different branches with different composer.json

The command:
`[ $COMPOSER_DEV_MODE -eq 0 ] || $PHP_BINARY artisan ide-helper:generate`: test that composer is not in dev mode or execute ide-helper:generate if it is.

If more readable the following is the same:
`test $COMPOSER_DEV_MODE -eq 0 || $PHP_BINARY artisan ide-helper:generate`

This should work under Linux, Mac and WSL (Windows).

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
