### PR TITLE
Add default values to array_merge

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -54,9 +54,9 @@ class Generator
         // Find the drivers to add to the extra/interfaces
         $this->detectDrivers();
 
-        $this->extra = array_merge($this->extra, $this->config->get('ide-helper.extra'));
-        $this->magic = array_merge($this->magic, $this->config->get('ide-helper.magic'));
-        $this->interfaces = array_merge($this->interfaces, $this->config->get('ide-helper.interfaces'));
+        $this->extra = array_merge($this->extra, $this->config->get('ide-helper.extra'), []);
+        $this->magic = array_merge($this->magic, $this->config->get('ide-helper.magic'), []);
+        $this->interfaces = array_merge($this->interfaces, $this->config->get('ide-helper.interfaces'), []);
         // Make all interface classes absolute
         foreach ($this->interfaces as &$interface) {
             $interface = '\\' . ltrim($interface, '\\');


### PR DESCRIPTION
## Summary
This PR adds default values so array_merge does not break when config values are missing. This should not happen unless the package is freshly installed and config is cached.

Fixes #1180

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
