### PR TITLE
Continue supporting factory builders on Laravel 8

### DIFF
--- a/src/Factories.php
+++ b/src/Factories.php
@@ -4,6 +4,7 @@ namespace Barryvdh\LaravelIdeHelper;
 
 use Exception;
 use Illuminate\Database\Eloquent\Factory;
+use Illuminate\Support\Facades\App;
 use ReflectionClass;
 
 class Factories
@@ -12,7 +13,7 @@ class Factories
     {
         $factories = [];
 
-        if (static::isLaravelSevenOrLower()) {
+        if (static::factoriesSupported()) {
             $factory = app(Factory::class);
 
             $definitions = (new ReflectionClass(Factory::class))->getProperty('definitions');
@@ -29,8 +30,8 @@ class Factories
         return $factories;
     }
 
-    protected static function isLaravelSevenOrLower()
+    protected static function factoriesSupported()
     {
-        return class_exists('Illuminate\Database\Eloquent\Factory');
+        return App::has(Factory::class);
     }
 }


### PR DESCRIPTION
## Summary
This PR adds support for model factory builders provided by `laravel/legacy-factories` package.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
