### PR TITLE
Fix for when factory class does not exist

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1093,7 +1093,11 @@ class ModelsCommand extends Command
         }
 
         $modelName = get_class($model);
-        $factory = get_class($modelName::factory());
+        try {
+            $factory = get_class($modelName::factory());
+        } catch (\Error $error) {
+            return;
+        }
         $factory = '\\' . trim($factory, '\\');
 
         if (!class_exists($factory)) {

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1095,7 +1095,9 @@ class ModelsCommand extends Command
         $modelName = get_class($model);
         try {
             $factory = get_class($modelName::factory());
-        } catch (\Error $error) {
+        } catch (\Throwable $t) {
+            $this->warn(sprintf('Error resolving factory from model %s: %s', $modelName, $t->getMessage()));
+
             return;
         }
         $factory = '\\' . trim($factory, '\\');


### PR DESCRIPTION
## Summary
Laravel artisan make:model generates a model which is automatically given the HasFactory trait.

If the Factory class has not also been created, an error is thrown causing model analysis to stop. This pull request checks if an error is thrown when looking for the factory class, and returns if one is found.

Not sure if you require a test for this or not. Let me know and I will look at adding one.

## Type of change
[ x ] Bug fix (non-breaking change which fixes an issue)