### PR TITLE
Skip post_migrate when running tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 [Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.9.2...master)
 --------------
+### Fixed
+- Running tests triggering post_migrate hooks [\#1193 / netpok](https://github.com/barryvdh/laravel-ide-helper/pull/1193)
 
 2021-03-15, 2.9.1
 -----------------

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -17,9 +17,4 @@
       <code>\Storage</code>
     </UndefinedClass>
   </file>
-  <file src="src/IdeHelperServiceProvider.php">
-    <TooFewArguments occurrences="1">
-      <code>new PhpEngine()</code>
-    </TooFewArguments>
-  </file>
 </files>

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -19,7 +19,6 @@ use Barryvdh\LaravelIdeHelper\Listeners\GenerateModelHelper;
 use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Events\MigrationsEnded;
-use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Engines\PhpEngine;

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -35,7 +35,7 @@ class IdeHelperServiceProvider extends ServiceProvider implements DeferrableProv
      */
     public function boot()
     {
-        if ($this->app['config']->get('ide-helper.post_migrate', [])) {
+        if (!$this->app->runningUnitTests() && $this->app['config']->get('ide-helper.post_migrate', [])) {
             $this->app['events']->listen(CommandFinished::class, GenerateModelHelper::class);
             $this->app['events']->listen(MigrationsEnded::class, function () {
                 GenerateModelHelper::$shouldRun = true;


### PR DESCRIPTION
## Summary
This PR skips post migrate hooks when application is running unit tests. This should not cause any problems but it's unnecessary to generate the helpers hundred times. Also test should not have a sideeffect.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] Add a CHANGELOG.md entry
- [x] Code style has been fixed via `composer fix-style`