### PR TITLE
Allowing Methods to be set or unset in ModelHooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 [Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.9.3...master)
 --------------
 
+### Added
+- Allowing Methods to be set or unset in ModelHooks [\#1198 / jenga201](https://github.com/barryvdh/laravel-ide-helper/pull/1198)\
+  Note: the visibility of `\Barryvdh\LaravelIdeHelper\Console\ModelsCommand::setMethod` has been changed to **public**!
+
 2021-04-02, 2.9.3
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ class MyCustomHook implements ModelHookInterface
         }
 
         $command->setProperty('custom', 'string', true, false, 'My custom property');
+        $command->unsetMethod('method');
+        $command->setMethod('method', $command->getMethodType($model, '\Some\Class'), ['$param']);
     }
 }
 ```

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -749,7 +749,7 @@ class ModelsCommand extends Command
         }
     }
 
-    protected function setMethod($name, $type = '', $arguments = [], $comment = '')
+    public function setMethod($name, $type = '', $arguments = [], $comment = '')
     {
         $methods = array_change_key_case($this->methods, CASE_LOWER);
 
@@ -759,6 +759,16 @@ class ModelsCommand extends Command
             $this->methods[$name]['arguments'] = $arguments;
             $this->methods[$name]['comment'] = $comment;
         }
+    }
+
+    public function unsetMethod($name) {
+        unset($this->methods[strtolower($name)]);
+    }
+
+    public function getMethodType(Model $model, string $classType) {
+        $modelName = $this->getClassNameInDestinationFile($model, get_class($model));
+        $builder = $this->getClassNameInDestinationFile($model, $classType);
+        return $builder . '|' . $modelName;
     }
 
     /**

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -761,11 +761,13 @@ class ModelsCommand extends Command
         }
     }
 
-    public function unsetMethod($name) {
+    public function unsetMethod($name)
+    {
         unset($this->methods[strtolower($name)]);
     }
 
-    public function getMethodType(Model $model, string $classType) {
+    public function getMethodType(Model $model, string $classType)
+    {
         $modelName = $this->getClassNameInDestinationFile($model, get_class($model));
         $builder = $this->getClassNameInDestinationFile($model, $classType);
         return $builder . '|' . $modelName;

--- a/tests/Console/ModelsCommand/ModelHooks/Hooks/CustomMethod.php
+++ b/tests/Console/ModelsCommand/ModelHooks/Hooks/CustomMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Contracts\ModelHookInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class CustomMethod implements ModelHookInterface
+{
+    public function run(ModelsCommand $command, Model $model): void
+    {
+        $command->setMethod('custom', $command->getMethodType($model, Builder::class), ['$custom']);
+    }
+}

--- a/tests/Console/ModelsCommand/ModelHooks/Hooks/UnsetMethod.php
+++ b/tests/Console/ModelsCommand/ModelHooks/Hooks/UnsetMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Contracts\ModelHookInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class UnsetMethod implements ModelHookInterface
+{
+    public function run(ModelsCommand $command, Model $model): void
+    {
+        $command->unsetMethod('query');
+    }
+}

--- a/tests/Console/ModelsCommand/ModelHooks/Hooks/UnsetMethod.php
+++ b/tests/Console/ModelsCommand/ModelHooks/Hooks/UnsetMethod.php
@@ -6,7 +6,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Contracts\ModelHookInterface;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 class UnsetMethod implements ModelHookInterface

--- a/tests/Console/ModelsCommand/ModelHooks/Test.php
+++ b/tests/Console/ModelsCommand/ModelHooks/Test.php
@@ -7,6 +7,8 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks\CustomProperty;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks\CustomMethod;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks\UnsetMethod;
 use Illuminate\Filesystem\Filesystem;
 use Mockery;
 
@@ -24,6 +26,8 @@ class Test extends AbstractModelsCommand
             ],
             'model_hooks' => [
                 CustomProperty::class,
+                CustomMethod::class,
+                UnsetMethod::class
             ],
         ]);
     }
@@ -71,9 +75,9 @@ use Illuminate\Database\Eloquent\Model;
  *
  * @property int $id
  * @property-read string $custom
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple custom($custom)
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
  * @mixin \Eloquent
  */

--- a/tests/Console/ModelsCommand/ModelHooks/Test.php
+++ b/tests/Console/ModelsCommand/ModelHooks/Test.php
@@ -6,8 +6,8 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks;
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks\CustomProperty;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks\CustomMethod;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks\CustomProperty;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks\UnsetMethod;
 use Illuminate\Filesystem\Filesystem;
 use Mockery;
@@ -27,7 +27,7 @@ class Test extends AbstractModelsCommand
             'model_hooks' => [
                 CustomProperty::class,
                 CustomMethod::class,
-                UnsetMethod::class
+                UnsetMethod::class,
             ],
         ]);
     }


### PR DESCRIPTION
## Summary
Expanding PR #945 to include support in ModelHooks to unset and set Methods.
This can be useful for defining class inheritance properly for the IDE.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
