### PR TITLE
Fixing issue where incorrect autoloader unregistered (#1069)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 - Allowing Methods to be set or unset in ModelHooks [\#1198 / jenga201](https://github.com/barryvdh/laravel-ide-helper/pull/1198)\
   Note: the visibility of `\Barryvdh\LaravelIdeHelper\Console\ModelsCommand::setMethod` has been changed to **public**!
 
+### Fixed
+- Fixing issue where incorrect autoloader unregistered [\#1210 / tezhm](https://github.com/barryvdh/laravel-ide-helper/pull/1210)
+
 2021-04-02, 2.9.3
 -----------------
 

--- a/tests/Console/MetaCommand/MetaCommandTest.php
+++ b/tests/Console/MetaCommand/MetaCommandTest.php
@@ -8,6 +8,7 @@ use Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider;
 use Barryvdh\LaravelIdeHelper\Tests\TestCase;
 use Illuminate\Filesystem\Filesystem;
 use Mockery\MockInterface;
+use stdClass;
 
 class MetaCommandTest extends TestCase
 {
@@ -35,6 +36,38 @@ class MetaCommandTest extends TestCase
         self::assertStringContainsString("namespace PHPSTORM_META {\n", $this->mockFilesystemOutput);
         self::assertStringContainsString("PhpStorm Meta file, to provide autocomplete information for PhpStorm\n", $this->mockFilesystemOutput);
         self::assertStringContainsString('override(', $this->mockFilesystemOutput);
+    }
+
+    public function testUnregisterAutoloader(): void
+    {
+        $current = spl_autoload_functions();
+        $appended = function () { };
+
+        $this->app->bind('registers-autoloader', function () use ($appended)
+        {
+            spl_autoload_register($appended);
+            return new stdClass();
+        });
+
+        $this->mockFilesystem();
+
+        /** @var Filesystem|MockInterface $mockFileSystem */
+        $mockFileSystem = $this->app->make(Filesystem::class);
+        $this->instance('files', $mockFileSystem);
+
+        $mockFileSystem
+            ->shouldReceive('getRequire')
+            ->andReturnUsing(function ($__path, $__data) {
+                return (static function () use ($__path, $__data) {
+                    extract($__data, EXTR_SKIP);
+
+                    return require $__path;
+                })();
+            });
+
+        $this->artisan('ide-helper:meta');
+
+        self::assertSame(array_merge($current, [$appended]), spl_autoload_functions());
     }
 
     /**


### PR DESCRIPTION
## Summary

Bug fix for #1069.

Unregisters the autoloader registered via `MetaCommand->registerClassAutoloadExceptions` by reference instead of assuming it is the last registered autoloader.

I'm marking this as a "breaking change" because the `MetaCommand->registerClassAutoloadExceptions` is protected and I've changed the return type from void to callable (which is the registered autoloader). If you'd prefer, can solve without modifying method definition. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
