### PR TITLE
Fix link to DBAL types

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -206,7 +206,7 @@ return [
     | The value of the array is an array of type mappings. Key is the name of the custom type,
     | (for example, "jsonb" from Postgres 9.4) and the value is the name of the corresponding Doctrine2 type (in
     | our case it is 'json_array'. Doctrine types are listed here:
-    | http://doctrine-dbal.readthedocs.org/en/latest/reference/types.html
+    | https://www.doctrine-project.org/projects/doctrine-dbal/en/2.12/reference/types.html#types
     |
     | So to support jsonb in your models when working with Postgres, just add the following entry to the array below:
     |

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -206,7 +206,7 @@ return [
     | The value of the array is an array of type mappings. Key is the name of the custom type,
     | (for example, "jsonb" from Postgres 9.4) and the value is the name of the corresponding Doctrine2 type (in
     | our case it is 'json_array'. Doctrine types are listed here:
-    | https://www.doctrine-project.org/projects/doctrine-dbal/en/2.12/reference/types.html#types
+    | https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#types
     |
     | So to support jsonb in your models when working with Postgres, just add the following entry to the array below:
     |


### PR DESCRIPTION
Documentation has been moved, old reference landing on 404.
Pointed to 2.x as for the moment we end up with 2.x because of many other package dependencies.

## Summary
Updating old reference to DBAL types in config file
