### PR TITLE
Use platformName to determine db type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 [Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.10.0...master)
 --------------
 
+### Fixed
+- Use platformName to determine db type when casting boolean types [\#1212 / stockalexander](https://github.com/barryvdh/laravel-ide-helper/pull/1212)
+
 2021-04-09, 2.10.0
 ------------------
 ### Added

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -463,7 +463,7 @@ class ModelsCommand extends Command
                         $type = 'integer';
                         break;
                     case 'boolean':
-                        switch (config('database.default')) {
+                        switch ($platformName) {
                             case 'sqlite':
                             case 'mysql':
                                 $type = 'integer';


### PR DESCRIPTION
Use platformName instead of default connection name to determine used dbms. Previous solution isn't working, when custom names are used.

This should fix the problem mentioned in https://github.com/barryvdh/laravel-ide-helper/issues/480 for custom connection names, too. Example config/database.php section:


    'default' => env('DB_CONNECTION', 'main_db'),
    'connections' => [
        'main_db' => [
            'driver' => 'mysql',
            'host' => env('DB_HOST_MAIN', '127.0.0.1'),
            'port' => env('DB_PORT_MAIN', '3306'),
            'database' => env('DB_DATABASE_MAIN', ''),
...

