### PR TITLE
Use lower case column name on generated model properties.

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -440,8 +440,7 @@ class ModelsCommand extends Command
             return;
         }
 
-        foreach ($columns as $column) {
-            $name = $column->getName();
+        foreach ($columns as $name => $column) {
             if (in_array($name, $model->getDates())) {
                 $type = $this->dateClass;
             } else {

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -440,7 +440,8 @@ class ModelsCommand extends Command
             return;
         }
 
-        foreach ($columns as $name => $column) {
+        foreach ($columns as $column) {
+            $name = strtolower($column->getName());
             if (in_array($name, $model->getDates())) {
                 $type = $this->dateClass;
             } else {


### PR DESCRIPTION
## Summary

This will fix the generated model properties when using oracle. 

Fixes: https://github.com/yajra/laravel-oci8/issues/641
Related PR: https://github.com/yajra/laravel-oci8/pull/648

Before PR:

```php
namespace App\Models{
/**
 * App\Models\Permission
 *
 * @property int $ID
 * @property string $NAME
```

After PR:

```php
namespace App\Models{
/**
 * App\Models\Permission
 *
 * @property int $id
 * @property string $name
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
