### PR TITLE
composer.json: remove --prefer-lowest

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,12 +21,8 @@ jobs:
       matrix:
         php: [8.0, 7.4, 7.3]
         laravel: [8.*]
-        dependency-version: [prefer-lowest, prefer-stable]
-        exclude:
-          - php: 8.0
-            dependency-version: prefer-lowest
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }}
 
     steps:
     - name: Checkout code
@@ -44,7 +40,7 @@ jobs:
         composer remove vimeo/psalm --no-update --dev
         composer remove friendsofphp/php-cs-fixer --no-update --dev
         composer require "laravel/framework:${{ matrix.laravel }}" --no-update --no-progress
-        composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress
+        composer update --prefer-dist --no-progress
 
     - name: Execute Unit Tests
       run: composer test-ci


### PR DESCRIPTION
### Summary
IMHO it's impractical to expect this package to have to work with the
"first release of Laravel for any major release" even when there are
already sever more releases: no one is/should stick to that version.

This is a re-submit of https://github.com/barryvdh/laravel-ide-helper/pull/1076

See also for recent breakaes
- https://github.com/barryvdh/laravel-ide-helper/pull/1216#issuecomment-831029022
- https://github.com/barryvdh/laravel-ide-helper/pull/1185#issuecomment-831029353

Note: PHP8 already didn't include it

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
