### PR TITLE
add config option to remove the overwrite models file prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 [Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.10.0...master)
+### Added
+- New configuration option `always_overwrite_model_files` to default to writing the PHP doc bloc comment (unless overridden with a switch)
+  Note: If set to false, or omitted, the previous BC functionality occurs
 --------------
 
 2021-04-09, 2.10.0

--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ Alternatively using the `--write-mixin (-M)` option will only add a mixin tag to
 writing the rest in (`_ide_helper_models.php`).
 The class name will be different from the model, avoiding the IDE duplicate annoyance.
 
+Alternately, you can set the `always_overwrite_model_files` flag to true, which is identical to using `--write` above
+
+```php
+'always_overwrite_model_files' => true,
+```
+Setting this to `false` has no effect
+
 > Please make sure to back up your models, before writing the info.
 
 Writing to the models should keep the existing comments and only append new properties/methods.

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -74,6 +74,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Always Overwrite Model Files
+    |--------------------------------------------------------------------------
+    |
+    | Set to true to force 'yes' as an answer to 'Do you want to overwrite the existing model files?'
+    |
+    */
+    'always_overwrite_model_files' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Write Model relation count properties
     |--------------------------------------------------------------------------
     |

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -130,8 +130,7 @@ class ModelsCommand extends Command
         // If neither write or write_mixin are set to true, fall back to config
         if ($this->option('write') || $this->write_mixin) {
             $this->write = $this->option('write');
-        }
-        else {
+        } else {
             $this->write = $this->laravel['config']->get('ide-helper.always_overwrite_model_files', false);
         }
         $this->dirs = array_merge(

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -126,8 +126,14 @@ class ModelsCommand extends Command
     public function handle()
     {
         $filename = $this->option('filename');
-        $this->write = $this->option('write');
         $this->write_mixin = $this->option('write-mixin');
+        // If neither write or write_mixin are set to true, fall back to config
+        if ($this->option('write') || $this->write_mixin) {
+            $this->write = $this->option('write');
+        }
+        else {
+            $this->write = $this->laravel['config']->get('ide-helper.always_overwrite_model_files', false);
+        }
         $this->dirs = array_merge(
             $this->laravel['config']->get('ide-helper.model_locations', []),
             $this->option('dir')
@@ -143,6 +149,7 @@ class ModelsCommand extends Command
         $this->write_model_external_builder_methods = $this->laravel['config']->get('ide-helper.write_model_external_builder_methods', true);
         $this->write_model_relation_count_properties =
             $this->laravel['config']->get('ide-helper.write_model_relation_count_properties', true);
+
 
         $this->write = $this->write_mixin ? true : $this->write;
         //If filename is default and Write is not specified, ask what to do
@@ -196,7 +203,7 @@ class ModelsCommand extends Command
           ['filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the helper file', $this->filename],
           ['dir', 'D', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
               'The model dir, supports glob patterns', [], ],
-          ['write', 'W', InputOption::VALUE_NONE, 'Write to Model file'],
+          ['write', 'W', InputOption::VALUE_NONE, 'Write to Model file', null],
           ['write-mixin', 'M', InputOption::VALUE_NONE,
               "Write models to {$this->filename} and adds @mixin to each model, avoiding IDE duplicate declaration warnings",
           ],

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -203,7 +203,7 @@ class ModelsCommand extends Command
           ['filename', 'F', InputOption::VALUE_OPTIONAL, 'The path to the helper file', $this->filename],
           ['dir', 'D', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
               'The model dir, supports glob patterns', [], ],
-          ['write', 'W', InputOption::VALUE_NONE, 'Write to Model file', null],
+          ['write', 'W', InputOption::VALUE_NONE, 'Write to Model file'],
           ['write-mixin', 'M', InputOption::VALUE_NONE,
               "Write models to {$this->filename} and adds @mixin to each model, avoiding IDE duplicate declaration warnings",
           ],

--- a/tests/Console/ModelsCommand/DoesNotPromptToWriteMetaIfConfigSet/Models/Post.php
+++ b/tests/Console/ModelsCommand/DoesNotPromptToWriteMetaIfConfigSet/Models/Post.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Models;
+
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    public function newEloquentBuilder($query): PostExternalQueryBuilder
+    {
+        return new PostExternalQueryBuilder($query);
+    }
+}

--- a/tests/Console/ModelsCommand/DoesNotPromptToWriteMetaIfConfigSet/Test.php
+++ b/tests/Console/ModelsCommand/DoesNotPromptToWriteMetaIfConfigSet/Test.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotPromptToWriteMetaIfConfigSet;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+
+class Test extends AbstractModelsCommand
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('ide-helper.always_overwrite_model_files', true);
+    }
+
+    public function test(): void
+    {
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Written new phpDocBlock to ', $tester->getDisplay());
+        $this->assertMatchesMockedSnapshot();
+    }
+}

--- a/tests/Console/ModelsCommand/DoesNotPromptToWriteMetaIfConfigSet/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/DoesNotPromptToWriteMetaIfConfigSet/__snapshots__/Test__test__1.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Models;
+
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Models\Post
+ *
+ * @property integer $id
+ * @property string|null $char_nullable
+ * @property string $char_not_nullable
+ * @property string|null $string_nullable
+ * @property string $string_not_nullable
+ * @property string|null $text_nullable
+ * @property string $text_not_nullable
+ * @property string|null $medium_text_nullable
+ * @property string $medium_text_not_nullable
+ * @property string|null $long_text_nullable
+ * @property string $long_text_not_nullable
+ * @property integer|null $integer_nullable
+ * @property integer $integer_not_nullable
+ * @property integer|null $tiny_integer_nullable
+ * @property integer $tiny_integer_not_nullable
+ * @property integer|null $small_integer_nullable
+ * @property integer $small_integer_not_nullable
+ * @property integer|null $medium_integer_nullable
+ * @property integer $medium_integer_not_nullable
+ * @property integer|null $big_integer_nullable
+ * @property integer $big_integer_not_nullable
+ * @property integer|null $unsigned_integer_nullable
+ * @property integer $unsigned_integer_not_nullable
+ * @property integer|null $unsigned_tiny_integer_nullable
+ * @property integer $unsigned_tiny_integer_not_nullable
+ * @property integer|null $unsigned_small_integer_nullable
+ * @property integer $unsigned_small_integer_not_nullable
+ * @property integer|null $unsigned_medium_integer_nullable
+ * @property integer $unsigned_medium_integer_not_nullable
+ * @property integer|null $unsigned_big_integer_nullable
+ * @property integer $unsigned_big_integer_not_nullable
+ * @property float|null $float_nullable
+ * @property float $float_not_nullable
+ * @property float|null $double_nullable
+ * @property float $double_not_nullable
+ * @property string|null $decimal_nullable
+ * @property string $decimal_not_nullable
+ * @property string|null $unsigned_decimal_nullable
+ * @property string $unsigned_decimal_not_nullable
+ * @property integer|null $boolean_nullable
+ * @property integer $boolean_not_nullable
+ * @property string|null $enum_nullable
+ * @property string $enum_not_nullable
+ * @property string|null $json_nullable
+ * @property string $json_not_nullable
+ * @property string|null $jsonb_nullable
+ * @property string $jsonb_not_nullable
+ * @property string|null $date_nullable
+ * @property string $date_not_nullable
+ * @property string|null $datetime_nullable
+ * @property string $datetime_not_nullable
+ * @property string|null $datetimetz_nullable
+ * @property string $datetimetz_not_nullable
+ * @property string|null $time_nullable
+ * @property string $time_not_nullable
+ * @property string|null $timetz_nullable
+ * @property string $timetz_not_nullable
+ * @property string|null $timestamp_nullable
+ * @property string $timestamp_not_nullable
+ * @property string|null $timestamptz_nullable
+ * @property string $timestamptz_not_nullable
+ * @property integer|null $year_nullable
+ * @property integer $year_not_nullable
+ * @property mixed|null $binary_nullable
+ * @property mixed $binary_not_nullable
+ * @property string|null $uuid_nullable
+ * @property string $uuid_not_nullable
+ * @property string|null $ipaddress_nullable
+ * @property string $ipaddress_not_nullable
+ * @property string|null $macaddress_nullable
+ * @property string $macaddress_not_nullable
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @method static PostExternalQueryBuilder|Post isActive()
+ * @method static PostExternalQueryBuilder|Post isStatus(string $status)
+ * @method static PostExternalQueryBuilder|Post newModelQuery()
+ * @method static PostExternalQueryBuilder|Post newQuery()
+ * @method static PostExternalQueryBuilder|Post query()
+ * @method static PostExternalQueryBuilder|Post whereBigIntegerNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereBigIntegerNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereBinaryNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereBinaryNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereBooleanNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereBooleanNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereCharNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereCharNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereCreatedAt($value)
+ * @method static PostExternalQueryBuilder|Post whereDateNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereDateNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereDatetimeNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereDatetimeNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereDatetimetzNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereDatetimetzNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereDecimalNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereDecimalNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereDoubleNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereDoubleNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereEnumNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereEnumNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereFloatNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereFloatNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereId($value)
+ * @method static PostExternalQueryBuilder|Post whereIntegerNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereIntegerNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereIpaddressNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereIpaddressNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereJsonNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereJsonNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereJsonbNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereJsonbNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereLongTextNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereLongTextNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereMacaddressNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereMacaddressNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereMediumIntegerNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereMediumIntegerNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereMediumTextNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereMediumTextNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereSmallIntegerNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereSmallIntegerNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereStringNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereStringNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereTextNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereTextNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereTimeNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereTimeNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereTimestampNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereTimestampNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereTimestamptzNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereTimestamptzNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereTimetzNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereTimetzNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereTinyIntegerNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereTinyIntegerNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereUnsignedBigIntegerNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereUnsignedBigIntegerNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereUnsignedDecimalNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereUnsignedDecimalNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereUnsignedIntegerNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereUnsignedIntegerNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereUnsignedMediumIntegerNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereUnsignedMediumIntegerNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereUnsignedSmallIntegerNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereUnsignedSmallIntegerNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereUnsignedTinyIntegerNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereUnsignedTinyIntegerNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereUpdatedAt($value)
+ * @method static PostExternalQueryBuilder|Post whereUuidNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereUuidNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereYearNotNullable($value)
+ * @method static PostExternalQueryBuilder|Post whereYearNullable($value)
+ * @mixin \Eloquent
+ */
+class Post extends Model
+{
+    public function newEloquentBuilder($query): PostExternalQueryBuilder
+    {
+        return new PostExternalQueryBuilder($query);
+    }
+}

--- a/tests/Console/ModelsCommand/PromptsToWriteMetaIfConfigSetToFalse/Models/Post.php
+++ b/tests/Console/ModelsCommand/PromptsToWriteMetaIfConfigSetToFalse/Models/Post.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Models;
+
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    public function newEloquentBuilder($query): PostExternalQueryBuilder
+    {
+        return new PostExternalQueryBuilder($query);
+    }
+}

--- a/tests/Console/ModelsCommand/PromptsToWriteMetaIfConfigSetToFalse/Test.php
+++ b/tests/Console/ModelsCommand/PromptsToWriteMetaIfConfigSetToFalse/Test.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PromptsToWriteMetaIfConfigSetToFalse;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+
+class Test extends AbstractModelsCommand
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('ide-helper.always_overwrite_model_files', false);
+    }
+
+    public function test(): void
+    {
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, []);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Do you want to overwrite the existing model files? Choose no to write to _ide_helper_models.php instead', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
## Summary
This adds a config option called `` that removes the `Do you want to overwrite the existing model files?` prompt and always answers "yes" when running the command.  
This is backwards compatible, as omitting the config or setting it false leaves exactly as it was

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

### Checklist
- [X] Existing tests have been adapted and/or new tests have been added
- [X] Add a CHANGELOG.md entry
- [X] Update the README.md
- [X] Code style has been fixed via `composer fix-style`
