### PR TITLE
Bugfix/custom types cause exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 [Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.10.0...master)
 --------------
 
+2021-06-18, 2.10.1
+------------------
+### Added
+- Added Type registration according to [Custom Mapping Types documentation](https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#custom-mapping-types)
+
+### Fixed
+- Fixing issue where configured custom_db_types could cause a DBAL exception to be thrown while running `ide-helper:models`
+
 2021-04-09, 2.10.0
 ------------------
 ### Added

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -431,7 +431,9 @@ class ModelsCommand extends Command
         $customTypes = $this->laravel['config']->get("ide-helper.custom_db_types.{$platformName}", []);
         foreach ($customTypes as $yourTypeName => $doctrineTypeName) {
             try {
-                Type::addType($yourTypeName, get_class(Type::getType($doctrineTypeName)));
+                if(!Type::hasType($yourTypeName)) {
+                    Type::addType($yourTypeName, get_class(Type::getType($doctrineTypeName)));
+                }
             } catch (DBALException $exception) {
                 $this->error("Failed registering custom db type \"$yourTypeName\" as \"$doctrineTypeName\"");
                 throw $exception;

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -17,6 +17,8 @@ use Barryvdh\Reflection\DocBlock\Context;
 use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
 use Barryvdh\Reflection\DocBlock\Tag;
 use Composer\Autoload\ClassMapGenerator;
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Types\Type;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -415,6 +417,8 @@ class ModelsCommand extends Command
      * Load the properties from the database table.
      *
      * @param \Illuminate\Database\Eloquent\Model $model
+     *
+     * @throws DBALException If custom field failed to register
      */
     public function getPropertiesFromTable($model)
     {
@@ -426,6 +430,12 @@ class ModelsCommand extends Command
         $platformName = $databasePlatform->getName();
         $customTypes = $this->laravel['config']->get("ide-helper.custom_db_types.{$platformName}", []);
         foreach ($customTypes as $yourTypeName => $doctrineTypeName) {
+            try {
+                Type::addType($yourTypeName, get_class(Type::getType($doctrineTypeName)));
+            } catch (DBALException $exception) {
+                $this->error("Failed registering custom db type \"$yourTypeName\" as \"$doctrineTypeName\"");
+                throw $exception;
+            }
             $databasePlatform->registerDoctrineTypeMapping($yourTypeName, $doctrineTypeName);
         }
 


### PR DESCRIPTION
- Added use statements for DBAL Exception and Type
- Added @throws tag to getPropertiesFromTable method
- Added Type::addType() to properly register types
- Added Try-Catch around Type::addType() to give users a proper error message, then throw the exception up.
- Updated CHANGELOG.MD

## Summary
After digging through some code, and looking up the Doctrine manual, I found [this on registering custom types](https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#custom-mapping-types), where in the bottom-most block it states:

> Now we have to register this type with the Doctrine Type system and hook it into the database platform:

```php
<?php
Type::addType('money', 'My\Project\Types\MoneyType');
$conn->getDatabasePlatform()->registerDoctrineTypeMapping('MyMoney', 'money');
```

Checking the `ModelsCommand` code, I found the foreach where `registerDoctrineTypeMapping` is called. Adding the following line to it solved the issue, and properly registered the `'enum_string_boolean' => 'boolean'` custom type.

```php
Type::addType($yourTypeName, Type::getType($doctrineTypeName));
```

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
