### PR TITLE
Respect configured filename for models file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,8 @@ All notable changes to this project will be documented in this file.
 [Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.10.0...master)
 --------------
 ### Fixed
+- Respect configured filename for models file [\#1230 / sebastiandedeyne](https://github.com/barryvdh/laravel-ide-helper/pull/1230)
 - Fix recursively searching for `HasFactory` and `Macroable` traits [\#1216 / daniel-de-wit](https://github.com/barryvdh/laravel-ide-helper/pull/1216)
-
-### Fixed
 - Use platformName to determine db type when casting boolean types [\#1212 / stockalexander](https://github.com/barryvdh/laravel-ide-helper/pull/1212)
 
 2021-04-09, 2.10.0

--- a/src/IdeHelperServiceProvider.php
+++ b/src/IdeHelperServiceProvider.php
@@ -76,7 +76,7 @@ class IdeHelperServiceProvider extends ServiceProvider implements DeferrableProv
         $this->app->singleton(
             'command.ide-helper.models',
             function ($app) {
-                return new ModelsCommand($app['files']);
+                return new ModelsCommand($app['config'], $app['files']);
             }
         );
 


### PR DESCRIPTION
## Summary
With this change, the `filename` configuration will also be used for the models file (suffixed by `_models`).

For example:

```php
// config/ide-helpers.php

return [
    'filename' => 'my_ide_helper'
];
```

Will generate `my_ide_helper.php` and `my_ide_helper_models.php`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
