### PR TITLE
Consider foreign key constraints with isRelationNullable

### DIFF
--- a/tests/Console/ModelsCommand/Relations/Models/BelongsToVariation.php
+++ b/tests/Console/ModelsCommand/Relations/Models/BelongsToVariation.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BelongsToVariation extends Model
+{
+    public function notNullColumnWithForeignKeyConstraint(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'not_null_column_with_foreign_key_constraint');
+    }
+
+    public function notNullColumnWithNoForeignKeyConstraint(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'not_null_column_with_no_foreign_key_constraint');
+    }
+
+    public function nullableColumnWithForeignKeyConstraint(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'nullable_column_with_foreign_key_constraint');
+    }
+
+    public function nullableColumnWithNoForeignKeyConstraint(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'nullable_column_with_no_foreign_key_constraint');
+    }
+}

--- a/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
@@ -4,6 +4,59 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\BelongsToVariation
+ *
+ * @property integer $id
+ * @property integer $not_null_column_with_foreign_key_constraint
+ * @property integer $not_null_column_with_no_foreign_key_constraint
+ * @property integer|null $nullable_column_with_foreign_key_constraint
+ * @property integer|null $nullable_column_with_no_foreign_key_constraint
+ * @property-read BelongsToVariation $notNullColumnWithForeignKeyConstraint
+ * @property-read BelongsToVariation|null $notNullColumnWithNoForeignKeyConstraint
+ * @property-read BelongsToVariation|null $nullableColumnWithForeignKeyConstraint
+ * @property-read BelongsToVariation|null $nullableColumnWithNoForeignKeyConstraint
+ * @method static \Illuminate\Database\Eloquent\Builder|BelongsToVariation newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|BelongsToVariation newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|BelongsToVariation query()
+ * @method static \Illuminate\Database\Eloquent\Builder|BelongsToVariation whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|BelongsToVariation whereNotNullColumnWithForeignKeyConstraint($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|BelongsToVariation whereNotNullColumnWithNoForeignKeyConstraint($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|BelongsToVariation whereNullableColumnWithForeignKeyConstraint($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|BelongsToVariation whereNullableColumnWithNoForeignKeyConstraint($value)
+ * @mixin \Eloquent
+ */
+class BelongsToVariation extends Model
+{
+    public function notNullColumnWithForeignKeyConstraint(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'not_null_column_with_foreign_key_constraint');
+    }
+
+    public function notNullColumnWithNoForeignKeyConstraint(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'not_null_column_with_no_foreign_key_constraint');
+    }
+
+    public function nullableColumnWithForeignKeyConstraint(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'nullable_column_with_foreign_key_constraint');
+    }
+
+    public function nullableColumnWithNoForeignKeyConstraint(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'nullable_column_with_no_foreign_key_constraint');
+    }
+}
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models;
+
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\ModelsOtherNamespace\AnotherModel;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Traits\HasTestRelations;
 use Illuminate\Database\Eloquent\Model;
@@ -20,15 +73,15 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple
  *
  * @property integer $id
- * @property-read Simple $relationBelongsTo
- * @property-read AnotherModel $relationBelongsToInAnotherNamespace
+ * @property-read Simple|null $relationBelongsTo
+ * @property-read AnotherModel|null $relationBelongsToInAnotherNamespace
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $relationBelongsToMany
  * @property-read int|null $relation_belongs_to_many_count
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $relationBelongsToManyWithSub
  * @property-read int|null $relation_belongs_to_many_with_sub_count
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $relationBelongsToManyWithSubAnother
  * @property-read int|null $relation_belongs_to_many_with_sub_another_count
- * @property-read AnotherModel $relationBelongsToSameNameAsColumn
+ * @property-read AnotherModel|null $relationBelongsToSameNameAsColumn
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $relationHasMany
  * @property-read int|null $relation_has_many_count
  * @property-read Simple|null $relationHasOne

--- a/tests/Console/ModelsCommand/migrations/____belongs_to_variation_table.php
+++ b/tests/Console/ModelsCommand/migrations/____belongs_to_variation_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class BelongsToVariationTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('belongs_to_variations', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->integer('not_null_column_with_foreign_key_constraint');
+            $table->integer('not_null_column_with_no_foreign_key_constraint');
+            $table->integer('nullable_column_with_foreign_key_constraint')->nullable();
+            $table->integer('nullable_column_with_no_foreign_key_constraint')->nullable();
+            $table->foreign('not_null_column_with_foreign_key_constraint')->references('id')->on('belongs_to_variations');
+            $table->foreign('nullable_column_with_foreign_key_constraint')->references('id')->on('belongs_to_variations');
+        });
+    }
+}


### PR DESCRIPTION
## Summary
When we run ide-helper:models on a class that defines a method that uses belongsTo, if the foreign key used for the relation is not null, a doc comment will be generated with the property returned as the relation class.

```php
<?php

use Illuminate\Database\Eloquent\Model;

/**
 * @property-read App\User $user  <- returned type is relation class
 * @mixin \Eloquent
 */
class Phone extends Model
{
    public function user()
    {
        return $this->belongsTo('App\User');
    }
}
```

However, there are times when we want to get the relation class **without using the foreign key constraint**, so we check for the existence of the relation class.
Therefore, static analysis with the current doc comments will fail, with the null check always resulting in false.

```php
$phone = Phone::firstOrFail();
if (is_null($phone->user)) {  // static analysis says 「It's dead code because it's always false」
    throw new RuntimeException('User Not Found');
}
$user = $phone->user
```

This problem can be solved by checking for the presence of foreign key constraints.
Is it possible to import this change?

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
