### PR TITLE
fix when no enclosingClass can be found

### DIFF
--- a/src/Macro.php
+++ b/src/Macro.php
@@ -98,6 +98,9 @@ class Macro extends Method
             $enclosingClass = $this->method->getClosureScopeClass();
         }
 
+        if (!$enclosingClass) {
+            return;
+        }
         /** @var \ReflectionMethod $enclosingMethod */
         $enclosingMethod = Collection::make($enclosingClass->getMethods())
             ->first(function (\ReflectionMethod $method) {


### PR DESCRIPTION
In certain situations no enclosingClass can be found, quick fix is to just return then.

## Summary
<!-- Please provide an exhaustive description. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
