### PR TITLE
Improve casts support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 [Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.10.0...master)
 --------------
+### Added
+- Add support for casts `decimal:*`, `encrypted:*`, `immutable_date`, `immutable_datetime`, `custom_datetime`, and `immutable_custom_datetime` [#1262 / miken32](https://github.com/barryvdh/laravel-ide-helper/pull/1262)
+
 ### Fixed
 - Fix recursively searching for `HasFactory` and `Macroable` traits [\#1216 / daniel-de-wit](https://github.com/barryvdh/laravel-ide-helper/pull/1216)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 [Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.10.0...master)
 --------------
 ### Added
-- Add support for casts `decimal:*`, `encrypted:*`, `immutable_date`, `immutable_datetime`, `custom_datetime`, and `immutable_custom_datetime` [#1262 / miken32](https://github.com/barryvdh/laravel-ide-helper/pull/1262)
+- Add support for cast types `decimal:*`, `encrypted:*`, `immutable_date`, `immutable_datetime`, `custom_datetime`, and `immutable_custom_datetime` [#1262 / miken32](https://github.com/barryvdh/laravel-ide-helper/pull/1262)
 
 ### Fixed
 - Fix recursively searching for `HasFactory` and `Macroable` traits [\#1216 / daniel-de-wit](https://github.com/barryvdh/laravel-ide-helper/pull/1216)

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -355,11 +355,24 @@ class ModelsCommand extends Command
     {
         $casts = $model->getCasts();
         foreach ($casts as $name => $type) {
+            if (Str::startsWith($type, 'decimal:')) {
+                $type = 'decimal';
+            } elseif (Str::startsWith($type, 'custom_datetime:')) {
+                $type = 'date';
+            } elseif (Str::startsWith($type, 'immutable_custom_datetime:')) {
+                $type = 'immutable_date';
+            } elseif (Str::startsWith($type, 'encrypted:')) {
+                $type = Str::after($type, ':');
+            }
             switch ($type) {
+                case 'encrypted':
+                    $realType = 'mixed';
+                    break;
                 case 'boolean':
                 case 'bool':
                     $realType = 'boolean';
                     break;
+                case 'decimal':
                 case 'string':
                     $realType = 'string';
                     break;
@@ -383,6 +396,10 @@ class ModelsCommand extends Command
                 case 'date':
                 case 'datetime':
                     $realType = $this->dateClass;
+                    break;
+                case 'immutable_date':
+                case 'immutable_datetime':
+                    $realType = '\Carbon\CarbonImmutable';
                     break;
                 case 'collection':
                     $realType = '\Illuminate\Support\Collection';

--- a/tests/Console/ModelsCommand/SimpleCasts/Models/SimpleCast.php
+++ b/tests/Console/ModelsCommand/SimpleCasts/Models/SimpleCast.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SimpleCast extends Model
+{
+    protected $casts = [
+        'cast_to_int' => 'int',
+        'cast_to_integer' => 'integer',
+        'cast_to_real' => 'real',
+        'cast_to_float' => 'float',
+        'cast_to_double' => 'double',
+        'cast_to_decimal' => 'decimal:4',
+        'cast_to_string' => 'string',
+        'cast_to_bool' => 'bool',
+        'cast_to_boolean' => 'boolean',
+        'cast_to_object' => 'object',
+        'cast_to_array' => 'array',
+        'cast_to_json' => 'json',
+        'cast_to_collection' => 'collection',
+        'cast_to_date' => 'date',
+        'cast_to_datetime' => 'datetime',
+        'cast_to_custom_datetime' => 'custom_datetime:Y-m-d H:i:s',
+        'cast_to_immutable_date' => 'immutable_date',
+        'cast_to_immutable_custom_datetime' => 'immutable_custom_datetime:Y-m-d H:i:s',
+        'cast_to_immutable_datetime' => 'immutable_datetime',
+        'cast_to_timestamp' => 'timestamp',
+        'cast_to_encrypted' => 'encrypted',
+        'cast_to_encrypted_array' => 'encrypted:array',
+        'cast_to_encrypted_collection' => 'encrypted:collection',
+        'cast_to_encrypted_json' => 'encrypted:json',
+        'cast_to_encrypted_object' => 'encrypted:object',
+    ];
+}

--- a/tests/Console/ModelsCommand/SimpleCasts/Test.php
+++ b/tests/Console/ModelsCommand/SimpleCasts/Test.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+
+class Test extends AbstractModelsCommand
+{
+    public function test(): void
+    {
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--write' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
+        $this->assertMatchesMockedSnapshot();
+    }
+}

--- a/tests/Console/ModelsCommand/SimpleCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/SimpleCasts/__snapshots__/Test__test__1.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Models\SimpleCast
+ *
+ * @property integer $cast_to_int
+ * @property integer $cast_to_integer
+ * @property float $cast_to_real
+ * @property float $cast_to_float
+ * @property float $cast_to_double
+ * @property string $cast_to_decimal
+ * @property string $cast_to_string
+ * @property boolean $cast_to_bool
+ * @property boolean $cast_to_boolean
+ * @property object $cast_to_object
+ * @property array $cast_to_array
+ * @property array $cast_to_json
+ * @property \Illuminate\Support\Collection $cast_to_collection
+ * @property \Illuminate\Support\Carbon $cast_to_date
+ * @property \Illuminate\Support\Carbon $cast_to_datetime
+ * @property \Illuminate\Support\Carbon $cast_to_custom_datetime
+ * @property \Carbon\CarbonImmutable $cast_to_immutable_date
+ * @property \Carbon\CarbonImmutable $cast_to_immutable_custom_datetime
+ * @property \Carbon\CarbonImmutable $cast_to_immutable_datetime
+ * @property integer $cast_to_timestamp
+ * @property mixed $cast_to_encrypted
+ * @property array $cast_to_encrypted_array
+ * @property \Illuminate\Support\Collection $cast_to_encrypted_collection
+ * @property array $cast_to_encrypted_json
+ * @property object $cast_to_encrypted_object
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast query()
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToArray($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToBool($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToBoolean($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToCollection($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToCustomDatetime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToDate($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToDatetime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToDecimal($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToDouble($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToEncrypted($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToEncryptedArray($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToEncryptedCollection($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToEncryptedJson($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToEncryptedObject($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToFloat($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToImmutableCustomDatetime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToImmutableDate($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToImmutableDatetime($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToInt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToInteger($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToJson($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToObject($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToReal($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToString($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast whereCastToTimestamp($value)
+ * @mixin \Eloquent
+ */
+class SimpleCast extends Model
+{
+    protected $casts = [
+        'cast_to_int' => 'int',
+        'cast_to_integer' => 'integer',
+        'cast_to_real' => 'real',
+        'cast_to_float' => 'float',
+        'cast_to_double' => 'double',
+        'cast_to_decimal' => 'decimal:4',
+        'cast_to_string' => 'string',
+        'cast_to_bool' => 'bool',
+        'cast_to_boolean' => 'boolean',
+        'cast_to_object' => 'object',
+        'cast_to_array' => 'array',
+        'cast_to_json' => 'json',
+        'cast_to_collection' => 'collection',
+        'cast_to_date' => 'date',
+        'cast_to_datetime' => 'datetime',
+        'cast_to_custom_datetime' => 'custom_datetime:Y-m-d H:i:s',
+        'cast_to_immutable_date' => 'immutable_date',
+        'cast_to_immutable_custom_datetime' => 'immutable_custom_datetime:Y-m-d H:i:s',
+        'cast_to_immutable_datetime' => 'immutable_datetime',
+        'cast_to_timestamp' => 'timestamp',
+        'cast_to_encrypted' => 'encrypted',
+        'cast_to_encrypted_array' => 'encrypted:array',
+        'cast_to_encrypted_collection' => 'encrypted:collection',
+        'cast_to_encrypted_json' => 'encrypted:json',
+        'cast_to_encrypted_object' => 'encrypted:object',
+    ];
+}

--- a/tests/Console/ModelsCommand/migrations/____simple_casts_table.php
+++ b/tests/Console/ModelsCommand/migrations/____simple_casts_table.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class SimpleCastsTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('simple_casts', static function (Blueprint $table) {
+            $table->string('cast_to_int');
+            $table->string('cast_to_integer');
+            $table->string('cast_to_real');
+            $table->string('cast_to_float');
+            $table->string('cast_to_double');
+            $table->string('cast_to_decimal');
+            $table->string('cast_to_string');
+            $table->string('cast_to_bool');
+            $table->string('cast_to_boolean');
+            $table->string('cast_to_object');
+            $table->string('cast_to_array');
+            $table->string('cast_to_json');
+            $table->string('cast_to_collection');
+            $table->string('cast_to_date');
+            $table->string('cast_to_datetime');
+            $table->string('cast_to_custom_datetime');
+            $table->string('cast_to_immutable_date');
+            $table->string('cast_to_immutable_custom_datetime');
+            $table->string('cast_to_immutable_datetime');
+            $table->string('cast_to_timestamp');
+            $table->string('cast_to_encrypted');
+            $table->string('cast_to_encrypted_array');
+            $table->string('cast_to_encrypted_collection');
+            $table->string('cast_to_encrypted_json');
+            $table->string('cast_to_encrypted_object');
+        });
+    }
+}


### PR DESCRIPTION
## Summary
Provides support for all missing types for `Model::$casts` including `decimal:*`, `custom_datetime`, `encrypted:*`, `immutable_date`, and `immutable_custom_datetime`. Resolves #1257 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ n/a ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
