### PR TITLE
Fix invalid phpdoc for casted property without return (#1236)

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -403,7 +403,7 @@ class ModelsCommand extends Command
             $realType = $this->getTypeOverride($realType);
             $this->properties[$name]['type'] = $this->getTypeInModel($model, $realType);
 
-            if (isset($this->nullableColumns[$name])) {
+            if (isset($this->nullableColumns[$name]) && $this->properties[$name]['type']) {
                 $this->properties[$name]['type'] .= '|null';
             }
         }


### PR DESCRIPTION
## Summary
Fix invalid phpdoc for casted property without return type

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
