### PR TITLE
Update composer/composer to 2.0.23

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "barryvdh/reflection-docblock": "^2.0.6",
-        "composer/composer": "^1.6 || ^2.0.13",
+        "composer/composer": "^1.6 || ^2.0.23",
         "doctrine/dbal": "^2.6 || ^3",
         "illuminate/console": "^8",
         "illuminate/filesystem": "^8",


### PR DESCRIPTION
## Summary
There is a security problem with composer 2.0.13. See https://github.com/composer/composer/security/advisories/GHSA-frqg-7g38-6gcf. This PR updates the required composer to 2.0.23.

## Type of change
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
