### PR TITLE
Update dependency composer/composer to 1.10.23 and 2.1.9 due to security issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "barryvdh/reflection-docblock": "^2.0.6",
-        "composer/composer": "^1.6 || ^2.1.9",
+        "composer/composer": "^1.10.23 || ^2.1.9",
         "doctrine/dbal": "^2.6 || ^3",
         "illuminate/console": "^8",
         "illuminate/filesystem": "^8",


### PR DESCRIPTION
## Summary
There is a security problem with composer 2.0.13. See GHSA-frqg-7g38-6gcf. This PR updates the required composer to the minimum versions 1.10.23 and 2.1.9.

## Type of change
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
