### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -95,7 +95,7 @@ class MetaCommand extends Command
 
             try {
                 $concrete = $this->laravel->make($abstract);
-                $reflectionClass = new \ReflectionClass($concrete);
+                $reflectionClass = new \ReflectionClass($concrete ?? '');
                 if (is_object($concrete) && !$reflectionClass->isAnonymous()) {
                     $bindings[$abstract] = get_class($concrete);
                 }


### PR DESCRIPTION
## Summary
Fixed a deprecation warning because of a nullable parameter to the reflection class constructor by adding and emtyp string as a default.

ReflectionClass::__construct(): Passing null to parameter #1 ($objectOrClass) of type object|string is deprecated

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
