### PR TITLE
Allow table inspection in several database connections at once

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -467,8 +467,9 @@ class ModelsCommand extends Command
             }
             $databasePlatform->registerDoctrineTypeMapping($yourTypeName, $doctrineTypeName);
         }
-
-        $database = null;
+        
+        $connectionName = $model->getConnection()->getName();
+        $database = config("ide-helper.db_mapping.$connectionName");
         if (strpos($table, '.')) {
             [$database, $table] = explode('.', $table);
         }


### PR DESCRIPTION
fixes #1141 and probably fixes #1280 too which looks like a side effect of that original issue.

Currently the package cannot handle schema discovery in more than a single database at once. In multi-tenant applications it is very frequent that there are at least two databases active at some point in time: landlord (data common to all tenants) and tenant (specific to one tenant).

When the configuration variable `db_mapping` is not specified, it defaults to null which then makes the code strictly behave as before. Hence this introduces no breaking change.

## Summary
<!-- Please provide an exhaustive description. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
