### PR TITLE
Support Castables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Add support for cast types `decimal:*`, `encrypted:*`, `immutable_date`, `immutable_datetime`, `custom_datetime`, and `immutable_custom_datetime` [#1262 / miken32](https://github.com/barryvdh/laravel-ide-helper/pull/1262)
+- Add support for custom casts that using `Castable` [#1287 / binotaliu](https://github.com/barryvdh/laravel-ide-helper/pull/1287)
 
 ### Fixed
 - Fix recursively searching for `HasFactory` and `Macroable` traits [\#1216 / daniel-de-wit](https://github.com/barryvdh/laravel-ide-helper/pull/1216)

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CastableReturnsAnonymousCaster.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CastableReturnsAnonymousCaster.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class CastableReturnsAnonymousCaster implements Castable
+{
+    public static function castUsing(array $arguments)
+    {
+        return new class() implements CastsAttributes {
+            /**
+             * @inheritDoc
+             * @return CastedProperty
+             */
+            public function get($model, string $key, $value, array $attributes)
+            {
+                return new CastedProperty();
+            }
+
+            /**
+             * @inheritDoc
+             */
+            public function set($model, string $key, $value, array $attributes)
+            {
+                // TODO: Implement set() method.
+            }
+        };
+    }
+}

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CastableReturnsCustomCaster.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CastableReturnsCustomCaster.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+
+class CastableReturnsCustomCaster implements Castable
+{
+    public static function castUsing(array $arguments)
+    {
+        return CustomCasterWithDocblockReturn::class;
+    }
+}

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Models/CustomCast.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Models/CustomCast.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Models;
 
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableReturnsAnonymousCaster;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableReturnsCustomCaster;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithDocblockReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithDocblockReturnFqn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithNullablePrimitiveReturn;
@@ -31,6 +33,8 @@ class CustomCast extends Model
         'casted_property_with_param' => CustomCasterWithParam::class . ':param',
         'casted_property_with_static_return_docblock' => SelfCastingCasterWithStaticDocblockReturn::class,
         'casted_property_with_this_return_docblock' => SelfCastingCasterWithThisDocblockReturn::class,
+        'casted_property_with_castable' => CastableReturnsCustomCaster::class,
+        'casted_property_with_anonymous_cast' => CastableReturnsAnonymousCaster::class,
         'extended_casted_property_with_static_return_docblock' => ExtendedSelfCastingCasterWithStaticDocblockReturn::class,
         'extended_casted_property_with_this_return_docblock' => ExtendedSelfCastingCasterWithThisDocblockReturn::class,
         'casted_property_with_static_return_docblock_and_param' => SelfCastingCasterWithStaticDocblockReturn::class . ':param',

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/__snapshots__/Test__test__1.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Models;
 
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableReturnsAnonymousCaster;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableReturnsCustomCaster;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithDocblockReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithDocblockReturnFqn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithNullablePrimitiveReturn;
@@ -34,6 +36,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property ExtendedSelfCastingCasterWithStaticDocblockReturn $extended_casted_property_with_static_return_docblock
  * @property ExtendedSelfCastingCasterWithThisDocblockReturn $extended_casted_property_with_this_return_docblock
  * @property SelfCastingCasterWithStaticDocblockReturn $casted_property_with_static_return_docblock_and_param
+ * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $casted_property_with_castable
+ * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $casted_property_with_anonymous_cast
  * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $cast_without_property
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast newQuery()
@@ -66,6 +70,8 @@ class CustomCast extends Model
         'casted_property_with_param' => CustomCasterWithParam::class . ':param',
         'casted_property_with_static_return_docblock' => SelfCastingCasterWithStaticDocblockReturn::class,
         'casted_property_with_this_return_docblock' => SelfCastingCasterWithThisDocblockReturn::class,
+        'casted_property_with_castable' => CastableReturnsCustomCaster::class,
+        'casted_property_with_anonymous_cast' => CastableReturnsAnonymousCaster::class,
         'extended_casted_property_with_static_return_docblock' => ExtendedSelfCastingCasterWithStaticDocblockReturn::class,
         'extended_casted_property_with_this_return_docblock' => ExtendedSelfCastingCasterWithThisDocblockReturn::class,
         'casted_property_with_static_return_docblock_and_param' => SelfCastingCasterWithStaticDocblockReturn::class . ':param',


### PR DESCRIPTION
## Summary

This PR added support for `Castable` interface. See https://github.com/laravel/framework/pull/32129 and [it's documentation](http://laravel.com/docs/8.x/eloquent-mutators#castables) for details about `Castable`.

- `castUsing` method might return an anonymous `CastsAttribute` class. In order to determine the return type, execute `castUsing` is required.
- When using anonymous class, seems like `ContextFactory` won't detect correct context, thus I'm passing the class that implements `Castable` for context detection.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
