### PR TITLE
Support Laravel 8.77 Attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 [Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.10.0...master)
 --------------
 ### Added
+- Add support for Laravel 8.77 Attributes [\#1289 / SimonJnsson](https://github.com/barryvdh/laravel-ide-helper/pull/1289)
+
+### Added
 - Add support for cast types `decimal:*`, `encrypted:*`, `immutable_date`, `immutable_datetime`, `custom_datetime`, and `immutable_custom_datetime` [#1262 / miken32](https://github.com/barryvdh/laravel-ide-helper/pull/1262)
 
 ### Fixed

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -21,6 +21,7 @@ use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Types\Type;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -35,6 +36,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use phpDocumentor\Reflection\Types\ContextFactory;
 use ReflectionClass;
@@ -559,6 +561,9 @@ class ModelsCommand extends Command
         if ($methods) {
             sort($methods);
             foreach ($methods as $method) {
+                $reflection = new \ReflectionMethod($model, $method);
+                $type = $this->getReturnType($reflection);
+                $isAttribute = is_a($type,  '\Illuminate\Database\Eloquent\Casts\Attribute', true);
                 if (
                     Str::startsWith($method, 'get') && Str::endsWith(
                         $method,
@@ -568,11 +573,24 @@ class ModelsCommand extends Command
                     //Magic get<name>Attribute
                     $name = Str::snake(substr($method, 3, -9));
                     if (!empty($name)) {
-                        $reflection = new \ReflectionMethod($model, $method);
                         $type = $this->getReturnType($reflection);
                         $type = $this->getTypeInModel($model, $type);
                         $comment = $this->getCommentFromDocBlock($reflection);
                         $this->setProperty($name, $type, true, null, $comment);
+                    }
+                } elseif ($isAttribute) {
+                    $name = Str::snake($method);
+                    $types = $this->getAttributeReturnType($model, $method);
+
+                    if($types->has('get')) {
+                        $type = $this->getTypeInModel($model, $types['get']);
+                        $comment = $this->getCommentFromDocBlock($reflection);
+                        $this->setProperty($name, $type, true, null, $comment);
+                    }
+
+                    if($types->has('set')) {
+                        $comment = $this->getCommentFromDocBlock($reflection);
+                        $this->setProperty($name, null, null, true, $comment);
                     }
                 } elseif (
                     Str::startsWith($method, 'set') && Str::endsWith(
@@ -583,7 +601,6 @@ class ModelsCommand extends Command
                     //Magic set<name>Attribute
                     $name = Str::snake(substr($method, 3, -9));
                     if (!empty($name)) {
-                        $reflection = new \ReflectionMethod($model, $method);
                         $comment = $this->getCommentFromDocBlock($reflection);
                         $this->setProperty($name, null, null, true, $comment);
                     }
@@ -591,7 +608,6 @@ class ModelsCommand extends Command
                     //Magic set<name>Attribute
                     $name = Str::camel(substr($method, 5));
                     if (!empty($name)) {
-                        $reflection = new \ReflectionMethod($model, $method);
                         $comment = $this->getCommentFromDocBlock($reflection);
                         $args = $this->getParameters($reflection);
                         //Remove the first ($query) argument
@@ -622,8 +638,6 @@ class ModelsCommand extends Command
                     && !Str::startsWith($method, 'get')
                 ) {
                     //Use reflection to inspect the code, based on Illuminate/Support/SerializableClosure.php
-                    $reflection = new \ReflectionMethod($model, $method);
-
                     if ($returnType = $reflection->getReturnType()) {
                         $type = $returnType instanceof ReflectionNamedType
                             ? $returnType->getName()
@@ -1054,6 +1068,34 @@ class ModelsCommand extends Command
     protected function hasCamelCaseModelProperties()
     {
         return $this->laravel['config']->get('ide-helper.model_camel_case_properties', false);
+    }
+
+    protected function getAttributeReturnType(Model $model, string $method): Collection
+    {
+        /** @var Attribute $attribute */
+        $attribute = $model->{$method}();
+
+        return collect([
+            'get' => $attribute->get ? optional(new \ReflectionFunction($attribute->get))->getReturnType() : null,
+            'set' => $attribute->set ? optional(new \ReflectionFunction($attribute->set))->getReturnType() : null,
+        ])
+            ->filter()
+            ->map(function ($type) {
+                if($type instanceof \ReflectionUnionType) {
+                    $types =collect($type->getTypes())
+                        ->map(fn(ReflectionType $reflectionType) => collect($this->extractReflectionTypes($reflectionType)))
+                        ->flatten();
+                }
+                else {
+                    $types = collect($this->extractReflectionTypes($type));
+                }
+
+                if($type->allowsNull()) {
+                    $types->push('null');
+                }
+
+                return $types->join('|');
+            });
     }
 
     protected function getReturnType(\ReflectionMethod $reflection): ?string

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1083,7 +1083,10 @@ class ModelsCommand extends Command
             ->map(function ($type) {
                 if ($type instanceof \ReflectionUnionType) {
                     $types =collect($type->getTypes())
-                        ->map(fn (ReflectionType $reflectionType) => collect($this->extractReflectionTypes($reflectionType)))
+                        /** @var ReflectionType $reflectionType */
+                        ->map(function ($reflectionType) {
+                            return collect($this->extractReflectionTypes($reflectionType));
+                        })
                         ->flatten();
                 } else {
                     $types = collect($this->extractReflectionTypes($type));

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -563,7 +563,7 @@ class ModelsCommand extends Command
             foreach ($methods as $method) {
                 $reflection = new \ReflectionMethod($model, $method);
                 $type = $this->getReturnType($reflection);
-                $isAttribute = is_a($type,  '\Illuminate\Database\Eloquent\Casts\Attribute', true);
+                $isAttribute = is_a($type, '\Illuminate\Database\Eloquent\Casts\Attribute', true);
                 if (
                     Str::startsWith($method, 'get') && Str::endsWith(
                         $method,
@@ -582,13 +582,13 @@ class ModelsCommand extends Command
                     $name = Str::snake($method);
                     $types = $this->getAttributeReturnType($model, $method);
 
-                    if($types->has('get')) {
+                    if ($types->has('get')) {
                         $type = $this->getTypeInModel($model, $types['get']);
                         $comment = $this->getCommentFromDocBlock($reflection);
                         $this->setProperty($name, $type, true, null, $comment);
                     }
 
-                    if($types->has('set')) {
+                    if ($types->has('set')) {
                         $comment = $this->getCommentFromDocBlock($reflection);
                         $this->setProperty($name, null, null, true, $comment);
                     }
@@ -1081,16 +1081,15 @@ class ModelsCommand extends Command
         ])
             ->filter()
             ->map(function ($type) {
-                if($type instanceof \ReflectionUnionType) {
+                if ($type instanceof \ReflectionUnionType) {
                     $types =collect($type->getTypes())
-                        ->map(fn(ReflectionType $reflectionType) => collect($this->extractReflectionTypes($reflectionType)))
+                        ->map(fn (ReflectionType $reflectionType) => collect($this->extractReflectionTypes($reflectionType)))
                         ->flatten();
-                }
-                else {
+                } else {
                     $types = collect($this->extractReflectionTypes($type));
                 }
 
-                if($type->allowsNull()) {
+                if ($type->allowsNull()) {
                     $types->push('null');
                 }
 

--- a/tests/Console/ModelsCommand/Attributes/Models/Simple.php
+++ b/tests/Console/ModelsCommand/Attributes/Models/Simple.php
@@ -12,10 +12,10 @@ class Simple extends Model
     public function name(): Attribute
     {
         return new Attribute(
-            get: function(?string $name): ?string {
+            get: function (?string $name): ?string {
                 return $name;
             },
-            set: function(?string $name): ?string {
+            set: function (?string $name): ?string {
                 return $name === null ? null : ucfirst($name);
             }
         );

--- a/tests/Console/ModelsCommand/Attributes/Models/Simple.php
+++ b/tests/Console/ModelsCommand/Attributes/Models/Simple.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Attributes\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+
+class Simple extends Model
+{
+    public function name(): Attribute
+    {
+        return new Attribute(
+            get: function(?string $name): ?string {
+                return $name;
+            },
+            set: function(?string $name): ?string {
+                return $name === null ? null : ucfirst($name);
+            }
+        );
+    }
+}

--- a/tests/Console/ModelsCommand/Attributes/Models/Simple.php
+++ b/tests/Console/ModelsCommand/Attributes/Models/Simple.php
@@ -12,10 +12,10 @@ class Simple extends Model
     public function name(): Attribute
     {
         return new Attribute(
-            get: function (?string $name): ?string {
+            function (?string $name): ?string {
                 return $name;
             },
-            set: function (?string $name): ?string {
+            function (?string $name): ?string {
                 return $name === null ? null : ucfirst($name);
             }
         );

--- a/tests/Console/ModelsCommand/Attributes/Test.php
+++ b/tests/Console/ModelsCommand/Attributes/Test.php
@@ -9,15 +9,6 @@ use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
 
 class Test extends AbstractModelsCommand
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        if (PHP_VERSION_ID < 80000) {
-            $this->markTestSkipped('This test requires PHP 8.0 or higher');
-        }
-    }
-
     public function test(): void
     {
         $command = $this->app->make(ModelsCommand::class);

--- a/tests/Console/ModelsCommand/Attributes/Test.php
+++ b/tests/Console/ModelsCommand/Attributes/Test.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Attributes;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+
+class Test extends AbstractModelsCommand
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('This test requires PHP 8.0 or higher');
+        }
+    }
+
+    public function test(): void
+    {
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--write' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
+        $this->assertMatchesMockedSnapshot();
+    }
+}

--- a/tests/Console/ModelsCommand/Attributes/Test.php
+++ b/tests/Console/ModelsCommand/Attributes/Test.php
@@ -9,6 +9,15 @@ use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
 
 class Test extends AbstractModelsCommand
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!class_exists('\Illuminate\Database\Eloquent\Casts\Attribute')) {
+            $this->markTestSkipped('This test requires Laravel 8.77 or newer');
+        }
+    }
+
     public function test(): void
     {
         $command = $this->app->make(ModelsCommand::class);

--- a/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
@@ -23,10 +23,10 @@ class Simple extends Model
     public function name(): Attribute
     {
         return new Attribute(
-            get: function (?string $name): ?string {
+            function (?string $name): ?string {
                 return $name;
             },
-            set: function (?string $name): ?string {
+            function (?string $name): ?string {
                 return $name === null ? null : ucfirst($name);
             }
         );

--- a/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
@@ -23,10 +23,10 @@ class Simple extends Model
     public function name(): Attribute
     {
         return new Attribute(
-            get: function(?string $name): ?string {
+            get: function (?string $name): ?string {
                 return $name;
             },
-            set: function(?string $name): ?string {
+            set: function (?string $name): ?string {
                 return $name === null ? null : ucfirst($name);
             }
         );

--- a/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Attributes\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Attributes\Models\Simple
+ *
+ * @property integer $id
+ * @property string|null $name
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
+ * @mixin \Eloquent
+ */
+class Simple extends Model
+{
+    public function name(): Attribute
+    {
+        return new Attribute(
+            get: function(?string $name): ?string {
+                return $name;
+            },
+            set: function(?string $name): ?string {
+                return $name === null ? null : ucfirst($name);
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds support for the new Attribute syntax added in Laravel 8.77, added by https://github.com/laravel/framework/pull/40022.

Using Reflection on the get/set method provided to the Attribute, we can determine the return type of the getter and setter.

Below is an example usage (also found in added test).

```php
use Illuminate\Database\Eloquent\Casts\Attribute;

class Users extends Model
{
    public function name(): Attribute
    {
        return new Attribute(
            get: function (?string $name): ?string {
                return $name;
            },
            set: function (?string $name): ?string {
                return $name === null ? null : ucfirst($name);
            }
        );
    }
}

// => after generate models

/**
 * App\Models\Users
 * 
 * @property string|null $name
 * …
 */
```

## Type of change

This PR should be non breaking, but will however require laravel/framework >= 8.77 to work.

- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Code style has been fixed via `composer fix-style`
