### PR TITLE
Implement new config to specify return type of custom relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Add support for custom casts that using `Castable` [#1287 / binotaliu](https://github.com/barryvdh/laravel-ide-helper/pull/1287)
 - Added Laravel 9 support [#1297 / rcerljenko](https://github.com/barryvdh/laravel-ide-helper/pull/1297)
+- Added option `additional_relation_return_types` for custom relations that don't fit the typical naming scheme
 
 2022-01-03, 2.11.0
 ------------------

--- a/README.md
+++ b/README.md
@@ -278,6 +278,26 @@ For those special cases, you can map them via the config `custom_db_types`. Exam
 ],
 ```
 
+#### Custom Relationship Types
+
+If you are using relationships not built into Laravel you will need to specify the name and returning class in the config to get proper generation.
+
+```php
+'additional_relation_types' => [
+    'externalHasMany' => \My\Package\externalHasMany::class
+],
+```
+
+Found relationships will typically generate a return value based on the name of the relationship.
+
+If your custom relationships don't follow this traditional naming scheme you can define its return type manually. The available options are `many` and `morphTo`.
+
+```php
+'additional_relation_return_types' => [
+    'externalHasMultiple' => 'many'
+],
+```
+
 #### Model Hooks
 
 If you need additional information on your model from sources that are not handled by default, you can hook in to the

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -309,9 +309,9 @@ return [
     | Additional relation return types
     |--------------------------------------------------------------------------
     |
-    | When using custom relation types its possible for the class name to not be
-    | the proper return type of the relation. The key of the array is the Relationship
-    | Method name. The value of the array is the return type of the relation.
+    | When using custom relation types its possible for the class name to not contain
+    | the proper return type of the relation. The key of the array is the relationship
+    | method name. The value of the array is the return type of the relation.
     | e.g. `'relationName' => 'many'`.
     |
     */

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -306,6 +306,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Additional relation return types
+    |--------------------------------------------------------------------------
+    |
+    | When using custom relation types its possible for the class name to not be
+    | the proper return type of the relation. The key of the array is the Relationship
+    | Method name. The value of the array is the return type of the relation.
+    | e.g. `'relationName' => 'many'`.
+    |
+    */
+    'additional_relation_return_types' => [],
+
+    /*
+    |--------------------------------------------------------------------------
     | Run artisan commands after migrations to generate model helpers
     |--------------------------------------------------------------------------
     |

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -700,7 +700,7 @@ class ModelsCommand extends Command
 
                                 if (
                                     strpos(get_class($relationObj), 'Many') !== false ||
-                                    ($this->getRelationReturnTypes()[$relation] ?? '') == 'many'
+                                    ($this->getRelationReturnTypes()[$relation] ?? '') === 'many'
                                 ) {
                                     //Collection or array of models (because Collection is Arrayable)
                                     $relatedClass = '\\' . get_class($relationObj->getRelated());
@@ -727,7 +727,7 @@ class ModelsCommand extends Command
                                     }
                                 } elseif (
                                     $relation === 'morphTo' ||
-                                    ($this->getRelationReturnTypes()[$relation] ?? '') == 'morphTo'
+                                    ($this->getRelationReturnTypes()[$relation] ?? '') === 'morphTo'
                                 ) {
                                     // Model isn't specified because relation is polymorphic
                                     $this->setProperty(

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -698,7 +698,10 @@ class ModelsCommand extends Command
                                     get_class($relationObj->getRelated())
                                 );
 
-                                if (strpos(get_class($relationObj), 'Many') !== false) {
+                                if (
+                                    strpos(get_class($relationObj), 'Many') !== false ||
+                                    ($this->getRelationReturnTypes()[$relation] ?? '') == 'many'
+                                ) {
                                     //Collection or array of models (because Collection is Arrayable)
                                     $relatedClass = '\\' . get_class($relationObj->getRelated());
                                     $collectionClass = $this->getCollectionClass($relatedClass);
@@ -722,7 +725,10 @@ class ModelsCommand extends Command
                                         // What kind of comments should be added to the relation count here?
                                         );
                                     }
-                                } elseif ($relation === 'morphTo') {
+                                } elseif (
+                                    $relation === 'morphTo' ||
+                                    ($this->getRelationReturnTypes()[$relation] ?? '') == 'morphTo'
+                                ) {
                                     // Model isn't specified because relation is polymorphic
                                     $this->setProperty(
                                         $method,
@@ -1068,6 +1074,14 @@ class ModelsCommand extends Command
     {
         $configuredRelations = $this->laravel['config']->get('ide-helper.additional_relation_types', []);
         return array_merge(self::RELATION_TYPES, $configuredRelations);
+    }
+
+    /**
+     * Returns the return types of relations
+     */
+    protected function getRelationReturnTypes(): array
+    {
+        return $this->laravel['config']->get('ide-helper.additional_relation_return_types', []);
     }
 
     /**

--- a/tests/Console/ModelsCommand/Relations/Models/Simple.php
+++ b/tests/Console/ModelsCommand/Relations/Models/Simple.php
@@ -97,4 +97,9 @@ class Simple extends Model
     {
         return $this->testToManyRelation(Simple::class);
     }
+
+    public function relationSampleToAnyRelationType()
+    {
+        return $this->testToAnyRelation(Simple::class);
+    }
 }

--- a/tests/Console/ModelsCommand/Relations/Models/Simple.php
+++ b/tests/Console/ModelsCommand/Relations/Models/Simple.php
@@ -102,4 +102,9 @@ class Simple extends Model
     {
         return $this->testToAnyRelation(Simple::class);
     }
+
+    public function relationSampleToAnyMorphedRelationType()
+    {
+        return $this->testToAnyMorphedRelation(Simple::class);
+    }
 }

--- a/tests/Console/ModelsCommand/Relations/Test.php
+++ b/tests/Console/ModelsCommand/Relations/Test.php
@@ -21,10 +21,12 @@ class Test extends AbstractModelsCommand
             'testToOneRelation' => SampleToOneRelationType::class,
             'testToManyRelation' => SampleToManyRelationType::class,
             'testToAnyRelation' => SampleToAnyRelationType::class,
+            'testToAnyMorphedRelation' => SampleToAnyMorphedRelationType::class,
         ]);
 
         Config::set('ide-helper.additional_relation_return_types', [
             'testToAnyRelation' => 'many',
+            'testToAnyMorphedRelation' => 'morphTo',
         ]);
     }
 

--- a/tests/Console/ModelsCommand/Relations/Test.php
+++ b/tests/Console/ModelsCommand/Relations/Test.php
@@ -6,6 +6,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations;
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Types\SampleToAnyRelationType;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Types\SampleToManyRelationType;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Types\SampleToOneRelationType;
 use Illuminate\Support\Facades\Config;
@@ -19,6 +20,11 @@ class Test extends AbstractModelsCommand
         Config::set('ide-helper.additional_relation_types', [
             'testToOneRelation' => SampleToOneRelationType::class,
             'testToManyRelation' => SampleToManyRelationType::class,
+            'testToAnyRelation' => SampleToAnyRelationType::class,
+        ]);
+
+        Config::set('ide-helper.additional_relation_return_types', [
+            'testToAnyRelation' => 'many',
         ]);
     }
 

--- a/tests/Console/ModelsCommand/Relations/Traits/HasTestRelations.php
+++ b/tests/Console/ModelsCommand/Relations/Traits/HasTestRelations.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Traits;
 
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Types\SampleToAnyRelationType;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Types\SampleToAnyMorphedRelationType;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Types\SampleToManyRelationType;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Types\SampleToOneRelationType;
 
@@ -26,5 +27,11 @@ trait HasTestRelations
     {
         $instance = $this->newRelatedInstance($related);
         return new SampleToAnyRelationType($instance->newQuery(), $this);
+    }
+
+    public function testToAnyMorphedRelation($related)
+    {
+        $instance = $this->newRelatedInstance($related);
+        return new SampleToAnyMorphedRelationType($instance->newQuery(), $this);
     }
 }

--- a/tests/Console/ModelsCommand/Relations/Traits/HasTestRelations.php
+++ b/tests/Console/ModelsCommand/Relations/Traits/HasTestRelations.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Traits;
 
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Types\SampleToAnyRelationType;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Types\SampleToManyRelationType;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Types\SampleToOneRelationType;
 
@@ -19,5 +20,11 @@ trait HasTestRelations
     {
         $instance = $this->newRelatedInstance($related);
         return new SampleToManyRelationType($instance->newQuery(), $this);
+    }
+
+    public function testToAnyRelation($related)
+    {
+        $instance = $this->newRelatedInstance($related);
+        return new SampleToAnyRelationType($instance->newQuery(), $this);
     }
 }

--- a/tests/Console/ModelsCommand/Relations/Types/SampleToAnyMorphedRelationType.php
+++ b/tests/Console/ModelsCommand/Relations/Types/SampleToAnyMorphedRelationType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Types;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+class SampleToAnyMorphedRelationType extends Relation
+{
+    public function addConstraints()
+    {
+        // Fake
+    }
+
+    public function addEagerConstraints(array $models)
+    {
+        // Fake
+    }
+
+    public function initRelation(array $models, $relation)
+    {
+        // Fake
+    }
+
+    public function match(array $models, Collection $results, $relation)
+    {
+        // Fake
+    }
+
+    public function getResults()
+    {
+        // Fake
+    }
+}

--- a/tests/Console/ModelsCommand/Relations/Types/SampleToAnyRelationType.php
+++ b/tests/Console/ModelsCommand/Relations/Types/SampleToAnyRelationType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Types;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+class SampleToAnyRelationType extends Relation
+{
+    public function addConstraints()
+    {
+        // Fake
+    }
+
+    public function addEagerConstraints(array $models)
+    {
+        // Fake
+    }
+
+    public function initRelation(array $models, $relation)
+    {
+        // Fake
+    }
+
+    public function match(array $models, Collection $results, $relation)
+    {
+        // Fake
+    }
+
+    public function getResults()
+    {
+        // Fake
+    }
+}

--- a/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
@@ -94,6 +94,8 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  * @property-read int|null $relation_morphed_by_many_count
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $relationSampleRelationType
  * @property-read int|null $relation_sample_relation_type_count
+ * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $relationSampleToAnyRelationType
+ * @property-read int|null $relation_sample_to_any_relation_type_count
  * @property-read Simple $relationSampleToManyRelationType
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
@@ -181,5 +183,10 @@ class Simple extends Model
     public function relationSampleRelationType()
     {
         return $this->testToManyRelation(Simple::class);
+    }
+
+    public function relationSampleToAnyRelationType()
+    {
+        return $this->testToAnyRelation(Simple::class);
     }
 }

--- a/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
@@ -96,6 +96,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  * @property-read int|null $relation_sample_relation_type_count
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $relationSampleToAnyRelationType
  * @property-read int|null $relation_sample_to_any_relation_type_count
+ * @property-read Model|\Eloquent $relationSampleToAnyMorphedRelationType
  * @property-read Simple $relationSampleToManyRelationType
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
@@ -188,5 +189,10 @@ class Simple extends Model
     public function relationSampleToAnyRelationType()
     {
         return $this->testToAnyRelation(Simple::class);
+    }
+
+    public function relationSampleToAnyMorphedRelationType()
+    {
+        return $this->testToAnyMorphedRelation(Simple::class);
     }
 }

--- a/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
@@ -94,9 +94,9 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  * @property-read int|null $relation_morphed_by_many_count
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $relationSampleRelationType
  * @property-read int|null $relation_sample_relation_type_count
+ * @property-read Model|\Eloquent $relationSampleToAnyMorphedRelationType
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $relationSampleToAnyRelationType
  * @property-read int|null $relation_sample_to_any_relation_type_count
- * @property-read Model|\Eloquent $relationSampleToAnyMorphedRelationType
  * @property-read Simple $relationSampleToManyRelationType
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->

Custom Relation types can be added using the config `additional_relation_types` already, but in the backend the return types for those relations is determined by using a simple check determining if the class name has `Many` in it to decide the return type of the relation.

This works for the built-in Laravel relations where they are named properly but packages like https://github.com/staudenmeir/eloquent-json-relations use a name such as `belongsToJson` to return a many relationship. This change allows a config option to specify the actual return type of the relation such as many or morphTo

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
