### PR TITLE
Disabled PHPCS

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -9,6 +9,7 @@
 ?>
 
 // @formatter:off
+// phpcs:ignoreFile
 
 /**
  * A helper file for Laravel, to provide autocomplete information to your IDE


### PR DESCRIPTION
## Summary
PHPCS is a common development tool. It makes sense to disable it in addition to Eclipse/IntelliJ formatting disable


## Type of change

- [ ] New feature (non-breaking change which adds functionality)

### Checklist
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
