### PR TITLE
Ignore column properties via config and allow unset properties in hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ Or can be ignored by setting the `ignored_models` config
 ],
 ```
 
+#### Ignore Models Properties
+
+Models properties can be ignored by setting the `ignored_models_properties` config
+
+```php
+'ignored_models_properties' => [
+    App\Post::class => [ 'hash' ],
+],
+```
+
 #### Magic `where*` methods
 
 Eloquent allows calling `where<Attribute>` on your models, e.g. `Post::whereTitle(…)` and automatically translates this to e.g. `Post::where('title', '=', '…')`.
@@ -301,6 +311,7 @@ class MyCustomHook implements ModelHookInterface
             return;
         }
 
+        $command->unsetProperty('hash');
         $command->setProperty('custom', 'string', true, false, 'My custom property');
         $command->unsetMethod('method');
         $command->setMethod('method', $command->getMethodType($model, '\Some\Class'), ['$param']);

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -157,6 +157,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Models properties to ignore
+    |--------------------------------------------------------------------------
+    |
+    | Define which properties should be ignored per model. The key of the array
+    | is the canonical class name of the model and the values the properties
+    | name, e.g. `Model::class => [ 'ignored_column' ]`
+    |
+    */
+
+    'ignored_models_properties' => [
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Models hooks
     |--------------------------------------------------------------------------
     |

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -489,9 +489,14 @@ class ModelsCommand extends Command
             return;
         }
 
+        $ignoredProperties = array_values($this->laravel['config']->get('ide-helper.ignored_models_properties.' . get_class($model), []));
+
         $this->setForeignKeys($schema, $table);
         foreach ($columns as $column) {
             $name = $column->getName();
+            if(in_array($name, $ignoredProperties)){
+                continue;
+            }
             if (in_array($name, $model->getDates())) {
                 $type = $this->dateClass;
             } else {
@@ -816,6 +821,13 @@ class ModelsCommand extends Command
         }
     }
 
+    public function unsetProperty($name)
+    {
+        unset($this->properties[$name]);
+
+        $this->unsetMethod(Str::camel('where_' . $name));
+    }
+
     public function setMethod($name, $type = '', $arguments = [], $comment = '')
     {
         $methods = array_change_key_case($this->methods, CASE_LOWER);
@@ -830,7 +842,7 @@ class ModelsCommand extends Command
 
     public function unsetMethod($name)
     {
-        unset($this->methods[strtolower($name)]);
+        unset($this->methods[$name]);
     }
 
     public function getMethodType(Model $model, string $classType)

--- a/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
@@ -11,11 +11,13 @@ use Illuminate\Database\Eloquent\Model;
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Attributes\Models\Simple
  *
  * @property integer $id
+ * @property string $unset
  * @property string|null $name
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple whereUnset($value)
  * @mixin \Eloquent
  */
 class Simple extends Model

--- a/tests/Console/ModelsCommand/Comment/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Comment/__snapshots__/Test__test__1.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Comment\Models\Simple
  *
  * @property integer $id
+ * @property string $unset
  * @property string $both_same_name I'm a getter
  * @property string $both_without_getter_comment
  * @property-read string $faker_comment
@@ -31,6 +32,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple whereUnset($value)
  * @mixin \Eloquent
  */
 class Simple extends Model

--- a/tests/Console/ModelsCommand/CustomCollection/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/CustomCollection/__snapshots__/Test__test__1.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomCollection\Models\Simple
  *
  * @property integer $id
+ * @property string $unset
  * @property-read SimpleCollection|Simple[] $relationHasMany
  * @property-read int|null $relation_has_many_count
  * @method static SimpleCollection|static[] all($columns = ['*'])
@@ -20,6 +21,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple whereUnset($value)
  * @mixin \Eloquent
  */
 class Simple extends Model

--- a/tests/Console/ModelsCommand/Getter/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Getter/__snapshots__/Test__test__1.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Model;
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Getter\Models\Simple
  *
  * @property integer $id
+ * @property string $unset
  * @property-read int|null $attribute_return_type_int_or_null
  * @property-read array $attribute_returns_array
  * @property-read bool $attribute_returns_bool
@@ -35,6 +36,7 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple whereUnset($value)
  * @mixin \Eloquent
  */
 class Simple extends Model

--- a/tests/Console/ModelsCommand/Ignored/Test.php
+++ b/tests/Console/ModelsCommand/Ignored/Test.php
@@ -7,9 +7,12 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Ignored;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Ignored\Models\Ignored;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Ignored\Models\NotIgnored;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Ignored\Models\Simple;
 
 class Test extends AbstractModelsCommand
 {
+
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);
@@ -17,7 +20,12 @@ class Test extends AbstractModelsCommand
         $app['config']->set('ide-helper.ignored_models', [
             Ignored::class,
         ]);
+
+        $app['config']->set('ide-helper.ignored_models_properties', [
+            NotIgnored::class => ['ignored'],
+        ]);
     }
+
 
     public function test(): void
     {

--- a/tests/Console/ModelsCommand/Ignored/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Ignored/__snapshots__/Test__test__1.php
@@ -9,9 +9,11 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Ignored\Models\NotIgnored
  *
+ * @property integer $id
  * @method static \Illuminate\Database\Eloquent\Builder|NotIgnored newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|NotIgnored newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|NotIgnored query()
+ * @method static \Illuminate\Database\Eloquent\Builder|NotIgnored whereId($value)
  * @mixin \Eloquent
  */
 class NotIgnored extends Model

--- a/tests/Console/ModelsCommand/ModelHooks/Hooks/UnsetProperty.php
+++ b/tests/Console/ModelsCommand/ModelHooks/Hooks/UnsetProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Contracts\ModelHookInterface;
+use Illuminate\Database\Eloquent\Model;
+
+class UnsetProperty implements ModelHookInterface
+{
+    public function run(ModelsCommand $command, Model $model): void
+    {
+        $command->unsetProperty('unset');
+    }
+}

--- a/tests/Console/ModelsCommand/ModelHooks/Test.php
+++ b/tests/Console/ModelsCommand/ModelHooks/Test.php
@@ -9,6 +9,7 @@ use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks\CustomMethod;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks\CustomProperty;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks\UnsetMethod;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Hooks\UnsetProperty;
 use Illuminate\Filesystem\Filesystem;
 use Mockery;
 
@@ -28,6 +29,7 @@ class Test extends AbstractModelsCommand
                 CustomProperty::class,
                 CustomMethod::class,
                 UnsetMethod::class,
+                UnsetProperty::class,
             ],
         ]);
     }

--- a/tests/Console/ModelsCommand/PHPStormNoInspection/__snapshots__/Test__testNoinspectionNotPresent__1.php
+++ b/tests/Console/ModelsCommand/PHPStormNoInspection/__snapshots__/Test__testNoinspectionNotPresent__1.php
@@ -10,10 +10,12 @@ use Illuminate\Database\Eloquent\Model;
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple
  *
  * @property integer $id
+ * @property string $unset
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple whereUnset($value)
  * @mixin \Eloquent
  */
 class Simple extends Model

--- a/tests/Console/ModelsCommand/PHPStormNoInspection/__snapshots__/Test__testNoinspectionPresent__1.php
+++ b/tests/Console/ModelsCommand/PHPStormNoInspection/__snapshots__/Test__testNoinspectionPresent__1.php
@@ -10,10 +10,12 @@ use Illuminate\Database\Eloquent\Model;
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple
  *
  * @property integer $id
+ * @property string $unset
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple whereUnset($value)
  * @mixin \Eloquent
  * @noinspection PhpFullyQualifiedNameUsageInspection
  * @noinspection PhpUnnecessaryFullyQualifiedNameInspection

--- a/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
@@ -73,6 +73,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple
  *
  * @property integer $id
+ * @property string $unset
  * @property-read Simple|null $relationBelongsTo
  * @property-read AnotherModel|null $relationBelongsToInAnotherNamespace
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $relationBelongsToMany
@@ -99,6 +100,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple whereUnset($value)
  * @mixin \Eloquent
  */
 class Simple extends Model

--- a/tests/Console/ModelsCommand/ResetAndSmartReset/__snapshots__/Test__testNoReset__1.php
+++ b/tests/Console/ModelsCommand/ResetAndSmartReset/__snapshots__/Test__testNoReset__1.php
@@ -11,10 +11,12 @@ use Illuminate\Database\Eloquent\Model;
  *
  * @property string $foo
  * @property integer $id
+ * @property string $unset
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple whereUnset($value)
  * @mixin \Eloquent
  */
 class Simple extends Model

--- a/tests/Console/ModelsCommand/ResetAndSmartReset/__snapshots__/Test__testReset__1.php
+++ b/tests/Console/ModelsCommand/ResetAndSmartReset/__snapshots__/Test__testReset__1.php
@@ -10,10 +10,12 @@ use Illuminate\Database\Eloquent\Model;
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple
  *
  * @property integer $id
+ * @property string $unset
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple whereUnset($value)
  * @mixin \Eloquent
  */
 class Simple extends Model

--- a/tests/Console/ModelsCommand/ResetAndSmartReset/__snapshots__/Test__testSmartReset__1.php
+++ b/tests/Console/ModelsCommand/ResetAndSmartReset/__snapshots__/Test__testSmartReset__1.php
@@ -10,10 +10,12 @@ use Illuminate\Database\Eloquent\Model;
  * Text of existing phpdoc
  *
  * @property integer $id
+ * @property string $unset
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple whereUnset($value)
  * @mixin \Eloquent
  */
 class Simple extends Model

--- a/tests/Console/ModelsCommand/SoftDeletes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/SoftDeletes/__snapshots__/Test__test__1.php
@@ -11,11 +11,13 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SoftDeletes\Models\Simple
  *
  * @property integer $id
+ * @property string $unset
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Query\Builder|Simple onlyTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple whereUnset($value)
  * @method static \Illuminate\Database\Query\Builder|Simple withTrashed()
  * @method static \Illuminate\Database\Query\Builder|Simple withoutTrashed()
  * @mixin \Eloquent

--- a/tests/Console/ModelsCommand/Variadic/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Variadic/__snapshots__/Test__test__1.php
@@ -11,11 +11,13 @@ use Illuminate\Database\Eloquent\Model;
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Variadic\Models\Simple
  *
  * @property integer $id
+ * @property string $unset
  * @method static Builder|Simple newModelQuery()
  * @method static Builder|Simple newQuery()
  * @method static Builder|Simple query()
  * @method static Builder|Simple whereId($value)
  * @method static Builder|Simple whereTypedVariadic(int ...$values)
+ * @method static Builder|Simple whereUnset($value)
  * @method static Builder|Simple whereVariadic(...$values)
  * @mixin \Eloquent
  */

--- a/tests/Console/ModelsCommand/migrations/____not_ignored.php
+++ b/tests/Console/ModelsCommand/migrations/____not_ignored.php
@@ -6,13 +6,13 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class SimpleTable extends Migration
+class NotIgnored extends Migration
 {
     public function up(): void
     {
-        Schema::create('simples', function (Blueprint $table) {
+        Schema::create('not_ignoreds', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('unset');
+            $table->string('ignored');
         });
     }
 }


### PR DESCRIPTION
## Summary

This PR add options to ignore some properties : 
- via the config file using a new entry `ignored_models_properties` (applies only to table column)
- via the unsetProperty in a hook

It is useful to prevent PhpDoc generation for properties that should be used via a model cast only through a custom class.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
