### PR TITLE
Add scope enum parameter default value support

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1029,6 +1029,8 @@ class ModelsCommand extends Command
                     $default = 'null';
                 } elseif (is_int($default)) {
                     //$default = $default;
+                } elseif (\PHP_VERSION_ID >= 80100 && enum_exists($enumClass = get_class($default))) {
+                    $default = '\\' . $enumClass . '::' . $default->name;
                 } else {
                     $default = "'" . trim($default) . "'";
                 }


### PR DESCRIPTION
## Summary
Add scope enum parameter default value support


`ScheduleMode` is an enum(PHP 8.1+)

```php
public function scopeMode(Builder $builder, ScheduleMode $mode = ScheduleMode::CRONTAB)
{
    return $builder->where('mode', $mode->value);
}
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
