### PR TITLE
Fix BadMethodCallException when no fake method is available.

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -222,6 +222,8 @@ class Alias
             if ($fake !== $real) {
                 $this->addClass(get_class($fake));
             }
+        } catch (\Exception $e) {
+            //
         } finally {
             $facade::swap($real);
         }


### PR DESCRIPTION
## Summary
When executing `php artisan ide-helper:generate` it can occur that an object behind an Facade that does not implement the fake() method can trigger an BadMethodCallException in Alias.php.

The corresponding try-catch Block has no catch, so I guess it does not catch anything.
I added a catch for this case.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
