### PR TITLE
Refactor resolving of null information for custom casted attribute types

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -433,12 +433,44 @@ class ModelsCommand extends Command
             $realType = $this->checkForCastableCasts($realType, $params);
             $realType = $this->checkForCustomLaravelCasts($realType);
             $realType = $this->getTypeOverride($realType);
-            $this->properties[$name]['type'] = $this->getTypeInModel($model, $realType);
+            $realType = $this->getTypeInModel($model, $realType);
+            $realType = $this->applyNullability($realType, isset($this->nullableColumns[$name]));
 
-            if (isset($this->nullableColumns[$name])) {
-                $this->properties[$name]['type'] .= '|null';
-            }
+            $this->properties[$name]['type'] = $realType;
         }
+    }
+
+    protected function applyNullability(?string $type, bool $isNullable): ?string
+    {
+        if (! $type) {
+            return null;
+        }
+
+        $nullString = null;
+
+        // Find instance of:
+        // A) start of string or non-word character (like space or pipe) followed by 'null|'
+        // B) '|null' followed by end of string or non-word character (like space or pipe)
+        // This will find 'or null' instances at the beginning, middle or end of a type string,
+        // but will exclude solo/pure null instances and null being part of a type's name (e.g. class 'Benull').
+        if (preg_match('/(?:(?:^|\W)(null\|))|(\|null(?:$|\W))/', $type, $matches) === 1) {
+            $nullString = array_pop($matches);
+        }
+
+        // Return the current type string if:
+        // A) the type can be null and the type contains a null instance
+        // B) the type can not be null and the type does not contain a null instance
+        if (! ($isNullable xor $nullString)) {
+            return $type;
+        }
+
+        if ($isNullable) {
+            $type .= '|null';
+        } else {
+            $type = str_replace($nullString, '', $type);
+        }
+
+        return $type;
     }
 
     /**

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -442,7 +442,7 @@ class ModelsCommand extends Command
 
     protected function applyNullability(?string $type, bool $isNullable): ?string
     {
-        if (! $type) {
+        if (!$type) {
             return null;
         }
 
@@ -460,7 +460,7 @@ class ModelsCommand extends Command
         // Return the current type string if:
         // A) the type can be null and the type contains a null instance
         // B) the type can not be null and the type does not contain a null instance
-        if (! ($isNullable xor $nullString)) {
+        if (!($isNullable xor $nullString)) {
             return $type;
         }
 

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Models/CustomCast.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Models/CustomCast.php
@@ -30,6 +30,7 @@ class CustomCast extends Model
         'casted_property_with_return_primitive' => CustomCasterWithPrimitiveReturn::class,
         'casted_property_with_return_primitive_docblock' => CustomCasterWithPrimitiveDocblockReturn::class,
         'casted_property_with_return_nullable_primitive' => CustomCasterWithNullablePrimitiveReturn::class,
+        'casted_property_with_return_nullable_primitive_and_nullable_column' => CustomCasterWithNullablePrimitiveReturn::class,
         'casted_property_without_return' => CustomCasterWithoutReturnType::class,
         'casted_property_with_param' => CustomCasterWithParam::class . ':param',
         'casted_property_with_static_return_docblock' => SelfCastingCasterWithStaticDocblockReturn::class,

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/__snapshots__/Test__test__1.php
@@ -28,8 +28,9 @@ use Illuminate\Database\Eloquent\Model;
  * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $casted_property_with_return_docblock
  * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $casted_property_with_return_docblock_fqn
  * @property array $casted_property_with_return_primitive
- * @property array|null $casted_property_with_return_primitive_docblock
- * @property array|null $casted_property_with_return_nullable_primitive
+ * @property array $casted_property_with_return_primitive_docblock
+ * @property array $casted_property_with_return_nullable_primitive
+ * @property array|null $casted_property_with_return_nullable_primitive_and_nullable_column
  * @property $casted_property_without_return
  * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $casted_property_with_param
  * @property SelfCastingCasterWithStaticDocblockReturn $casted_property_with_static_return_docblock
@@ -48,6 +49,7 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereCastedPropertyWithReturnDocblock($value)
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereCastedPropertyWithReturnDocblockFqn($value)
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereCastedPropertyWithReturnNullablePrimitive($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereCastedPropertyWithReturnNullablePrimitiveAndNullableColumn($value)
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereCastedPropertyWithReturnPrimitive($value)
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereCastedPropertyWithReturnPrimitiveDocblock($value)
  * @method static \Illuminate\Database\Eloquent\Builder|CustomCast whereCastedPropertyWithReturnType($value)
@@ -68,6 +70,7 @@ class CustomCast extends Model
         'casted_property_with_return_primitive' => CustomCasterWithPrimitiveReturn::class,
         'casted_property_with_return_primitive_docblock' => CustomCasterWithPrimitiveDocblockReturn::class,
         'casted_property_with_return_nullable_primitive' => CustomCasterWithNullablePrimitiveReturn::class,
+        'casted_property_with_return_nullable_primitive_and_nullable_column' => CustomCasterWithNullablePrimitiveReturn::class,
         'casted_property_without_return' => CustomCasterWithoutReturnType::class,
         'casted_property_with_param' => CustomCasterWithParam::class . ':param',
         'casted_property_with_static_return_docblock' => SelfCastingCasterWithStaticDocblockReturn::class,

--- a/tests/Console/ModelsCommand/migrations/____custom_casts_table.php
+++ b/tests/Console/ModelsCommand/migrations/____custom_casts_table.php
@@ -17,6 +17,7 @@ class CustomCastsTable extends Migration
             $table->string('casted_property_with_return_primitive');
             $table->string('casted_property_with_return_primitive_docblock');
             $table->string('casted_property_with_return_nullable_primitive');
+            $table->string('casted_property_with_return_nullable_primitive_and_nullable_column')->nullable();
             $table->string('casted_property_without_return');
             $table->string('casted_property_with_param');
             $table->string('casted_property_with_static_return_docblock');


### PR DESCRIPTION
## Summary

Let's say we have the following custom cast:

```php
class MyCustomCast implements CastsAttributes
{
    /**
     * @param Model                $model
     * @param string               $key
     * @param mixed                $value
     * @param array<string, mixed> $attributes
     * @return SomeObject|null
     */
    public function get($model, string $key, $value, $attributes): ?SomeObject
    {
        if ($value === null) {
            return null;
        }

        return new SomeObject($value);
    }

    // setter omitted from example for brevity
}
```

 Now suppose we have two pretty much identical models which use this cast:

```php
class ModelA extends Model
{
    protected $table = 'models_a';

    /**
     * @var array<string, string>
     */
    protected $casts = [
        'casted_column' => MyCustomCast::class,
    ];
}
```

```php
class ModelB extends Model
{
    protected $table = 'models_b';

    /**
     * @var array<string, string>
     */
    protected $casts = [
        'casted_column' => MyCustomCast::class,
    ];
}
```

These models have tables created with the following migrations:

```php
Schema::create('models_a', function (Blueprint $table) {
	$table->id();
	$table->string('casted_column');
	$table->timestamps();
});
```

```php
Schema::create('models_b', function (Blueprint $table) {
	$table->id();
	$table->string('casted_column')->nullable();
	$table->timestamps();
});
```

The only difference between A and B is the `nullable()` setting on the column. Based on that difference I would expect the following properties to be written by the IDE helper:

```php
/**
 * @property SomeObject $casted_column
 */
class ModelA extends Model
```

```php
/**
 * @property SomeObject|null $casted_column
 */
class ModelB extends Model
```

However, both models will receive `SomeObject|null` as the property type, because currently the IDE helper only check the cast class without taking the migration into account. In my opinion the migration should inform the possibility of a `null` value and not the cast, because the cast doesn't know anything about the column it's going to be used for and should always implement `X|null`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

In my opnion this is a fix for behaviour that was always incorrect, but because it changes behaviour (and outcome), I do consider it a breaking change. I'll let it up to the maintainers how they want to deal with this.

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
