### PR TITLE
Fix return type of methods provided by `SoftDeletes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 [Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.12.3...master)
 --------------
 
+### Fixed
+- Fix return type of methods provided by `SoftDeletes` [#1345 / KentarouTakeda](https://github.com/barryvdh/laravel-ide-helper/pull/1345)
+
 2022-03-06, 2.12.3
 ------------------
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1198,7 +1198,7 @@ class ModelsCommand extends Command
         $traits = class_uses_recursive($model);
         if (in_array('Illuminate\\Database\\Eloquent\\SoftDeletes', $traits)) {
             $modelName = $this->getClassNameInDestinationFile($model, get_class($model));
-            $builder = $this->getClassNameInDestinationFile($model, \Illuminate\Database\Query\Builder::class);
+            $builder = $this->getClassNameInDestinationFile($model, \Illuminate\Database\Eloquent\Builder::class);
             $this->setMethod('withTrashed', $builder . '|' . $modelName, []);
             $this->setMethod('withoutTrashed', $builder . '|' . $modelName, []);
             $this->setMethod('onlyTrashed', $builder . '|' . $modelName, []);

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
@@ -89,7 +89,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post null(string $unusedParam)
- * @method static \Illuminate\Database\Query\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post onlyTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post query()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereBigIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereBigIntegerNullable($value)
@@ -164,8 +164,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUuidNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereYearNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereYearNullable($value)
- * @method static \Illuminate\Database\Query\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post withTrashed()
- * @method static \Illuminate\Database\Query\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post withoutTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post withTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post withoutTrashed()
  * @mixin \Eloquent
  */
 class Post extends Model

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
@@ -95,7 +95,7 @@ use Illuminate\Support\Carbon;
  * @method static EloquentBuilder|Post newModelQuery()
  * @method static EloquentBuilder|Post newQuery()
  * @method static EloquentBuilder|Post null(string $unusedParam)
- * @method static QueryBuilder|Post onlyTrashed()
+ * @method static EloquentBuilder|Post onlyTrashed()
  * @method static EloquentBuilder|Post query()
  * @method static EloquentBuilder|Post whereBigIntegerNotNullable($value)
  * @method static EloquentBuilder|Post whereBigIntegerNullable($value)
@@ -170,8 +170,8 @@ use Illuminate\Support\Carbon;
  * @method static EloquentBuilder|Post whereUuidNullable($value)
  * @method static EloquentBuilder|Post whereYearNotNullable($value)
  * @method static EloquentBuilder|Post whereYearNullable($value)
- * @method static QueryBuilder|Post withTrashed()
- * @method static QueryBuilder|Post withoutTrashed()
+ * @method static EloquentBuilder|Post withTrashed()
+ * @method static EloquentBuilder|Post withoutTrashed()
  * @mixin Eloquent
  */
 class Post extends Model

--- a/tests/Console/ModelsCommand/SoftDeletes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/SoftDeletes/__snapshots__/Test__test__1.php
@@ -13,11 +13,11 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property integer $id
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
- * @method static \Illuminate\Database\Query\Builder|Simple onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple onlyTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple whereId($value)
- * @method static \Illuminate\Database\Query\Builder|Simple withTrashed()
- * @method static \Illuminate\Database\Query\Builder|Simple withoutTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple withTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|Simple withoutTrashed()
  * @mixin \Eloquent
  */
 class Simple extends Model


### PR DESCRIPTION
## Summary

Fix return type of methods provided by `SoftDeletes`.

## Detail

The `SoftDeletes` model has three methods available:

* [withTrashed()](https://github.com/illuminate/database/blob/v9.0.0/Eloquent/SoftDeletingScope.php#L85-L91)
* [withoutTrashed()](https://github.com/illuminate/database/blob/v9.0.0/Eloquent/SoftDeletingScope.php#L102-L109)
* [onlyTrashed()](https://github.com/illuminate/database/blob/v9.0.0/Eloquent/SoftDeletingScope.php#L121-L129)

As the linked code shows, they return `\Illuminate\Database\Eloquent\Builder`, but the`ide-helper:models` command generates the annotation `\Illuminate\Database\Query\Builder`. I fixed this difference.

## Notice

Previously there were no issues, but with the fix for [Laravel v9.3.0](https://github.com/laravel/framework/pull/41276) , some static analysis tools such as PHPStan now report errors in the traditional ide-helper process.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
