### PR TITLE
Allow for proper database resolve with schemas

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -484,7 +484,7 @@ class ModelsCommand extends Command
 
         $database = null;
         if (strpos($table, '.')) {
-            [$database, $table] = explode('.', $table);
+            [$database, $table] = explode('.', $table, 2);
         }
 
         $columns = $schema->listTableColumns($table, $database);

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -463,6 +463,7 @@ class ModelsCommand extends Command
      */
     public function getPropertiesFromTable($model)
     {
+        $database = $model->getConnection()->getName();
         $table = $model->getConnection()->getTablePrefix() . $model->getTable();
         $schema = $model->getConnection()->getDoctrineSchemaManager();
         $databasePlatform = $schema->getDatabasePlatform();
@@ -480,11 +481,6 @@ class ModelsCommand extends Command
                 throw $exception;
             }
             $databasePlatform->registerDoctrineTypeMapping($yourTypeName, $doctrineTypeName);
-        }
-
-        $database = null;
-        if (strpos($table, '.')) {
-            [$database, $table] = explode('.', $table, 2);
         }
 
         $columns = $schema->listTableColumns($table, $database);


### PR DESCRIPTION
## Summary
Hello,

Thanks for the package.  It's very helpful.

This PR fixes an issue with the model IDE helper generation command explained in https://github.com/barryvdh/laravel-ide-helper/issues/1120.  The command does not work with databases that use schemas such as postgres.  This is from the way the `explode` is computed to calculate the `database` and `table` name.  The `explode` needs to be restricted to the first instance of `.`.

Old Behavior (Bugged)

| Table String         | Database | Table     |
|----------------------|----------|-----------|
| `cats`               | null     | `cats`    |
| `mysql.cats`         | `mysql`  | `cats`    |
| `pgsql.animals.cats` | `pgsql`  | `animals` |

New Behavior:

| Table String         | Database | Table          |
|----------------------|----------|----------------|
| `cats`               | null     | `cats`         |
| `mysql.cats`         | `mysql`  | `cats`         |
| `pgsql.animals.cats` | `pgsql`  | `animals.cats` |

I'm not sure how to write a test for this as the testing suite uses sqlite and I don't believe schemas operate like this there.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
