### PR TITLE
Fix integration tests by fixing a PHP 8.1+ deprecation warnings in ReflectionClass

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -57,7 +57,7 @@ jobs:
             - name: Execute meta run
               run: |
                   cd sample
-                  php artisan ide-helper:meta
+                  php artisan ide-helper:meta -v
 
             - name: Check file existence
               run: |
@@ -121,7 +121,7 @@ jobs:
             - name: Execute meta run
               run: |
                   cd sample
-                  php artisan ide-helper:meta
+                  php artisan ide-helper:meta -v
 
             - name: Check file existence
               run: |

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -64,9 +64,15 @@ jobs:
                 ls sample/_ide_helper.php
                 ls sample/.phpstorm.meta.php
 
-            - name: Check file count in logs
+            - name: Check logs
               run: |
-                if [ `ls -1q "sample/storage/logs/" | wc -l` -gt 0 ];then exit 1;fi
+                if [ `ls -1q "sample/storage/logs/" | wc -l` -gt 0 ]; then
+                  for logfile in sample/storage/logs/*; do
+                    echo "-- $logfile --"
+                    cat $logfile
+                  done
+                  exit 1
+                fi
 
     php-laravel-integration-tests:
         runs-on: ubuntu-20.04
@@ -122,6 +128,13 @@ jobs:
                 ls sample/_ide_helper.php
                 ls sample/.phpstorm.meta.php
 
-            - name: Check file count in logs
+
+            - name: Check logs
               run: |
-                if [ `ls -1q "sample/storage/logs/" | wc -l` -gt 0 ];then exit 1;fi
+                if [ `ls -1q "sample/storage/logs/" | wc -l` -gt 0 ]; then
+                  for logfile in sample/storage/logs/*; do
+                    echo "-- $logfile --"
+                    cat $logfile
+                  done
+                  exit 1
+                fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 [Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v2.12.3...master)
 --------------
 
+### Fixes
+- Handle PHP 8.1 deprecation warnings when passing `null` to `new \ReflectionClass` [#1351 / mfn](https://github.com/barryvdh/laravel-ide-helper/pull/1351)
+
 2022-03-06, 2.12.3
 ------------------
 

--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -13,6 +13,7 @@ namespace Barryvdh\LaravelIdeHelper\Console;
 
 use Barryvdh\LaravelIdeHelper\Factories;
 use Illuminate\Console\Command;
+use RuntimeException;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -95,6 +96,11 @@ class MetaCommand extends Command
 
             try {
                 $concrete = $this->laravel->make($abstract);
+
+                if ($concrete === null) {
+                    throw new RuntimeException("Cannot create instance for '$abstract', received 'null'");
+                }
+
                 $reflectionClass = new \ReflectionClass($concrete);
                 if (is_object($concrete) && !$reflectionClass->isAnonymous()) {
                     $bindings[$abstract] = get_class($concrete);


### PR DESCRIPTION
## Summary
- [x] Let's debug why the action fails, e.g. https://github.com/barryvdh/laravel-ide-helper/runs/6533389349?check_suite_focus=true#step:9:1
- The issue was that on PHP 8.1, `new ReflectClass` does not silently swallow `null` values anymore as it did before
- This already happened but usually wasn't visible unless `-v` was used, example
  ```
  $ ./artisan ide-helper:meta -v
  Cannot make 'Faker\Generator': Class 'Faker\Provider\en_US\Barcode' not found.
  Cannot make 'Illuminate\Contracts\Auth\Authenticatable': Class  does not exist
  Cannot make 'cache.psr6': Class 'Symfony\Component\Cache\Adapter\Psr16Adapter' not found.
  Cannot make 'csp-nonce': Class 'Wza3Mf4CXIvCkcp9K3boMUGJoK6S9maO' not found.
  Cannot make 'env': Class 'local' not found.
  Cannot make 'filesystem.cloud': Disk [s3] does not have a configured driver.
  Cannot make 'redis.connection': Redis connection [default] not configured.
  A new meta file was written to .phpstorm.meta.php
  ```
- PHP 8.1+ this triggers deprecation warnings
- because neither the deprecation logger was set up but also because that deprecation warning was generated, the integration test aborted when _something_ was written to the logs
- This PR now **fixes** this by handling `null` values and throwing a `RuntimeException`
- This replaces https://github.com/barryvdh/laravel-ide-helper/pull/1279 which already found out the problem. But because the fix was 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
