### PR TITLE
Allow table inspection when the database connection config is generated on the fly.

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -231,6 +231,26 @@ return [
     ],
 
     /*
+    |--------------------------------------------------------------------------
+    | Support for custom DB connection information
+    |--------------------------------------------------------------------------
+    |
+    | This setting allow you to override settings in your database config. This is useful for when models may
+    | connection to difference databases i.e., you have a multi-tenancy setup.
+    |
+    | Complete the overrider with the specific entries you wish to override and these will be applied to the
+    | config('database.connections') config array:
+    |
+    | "tenant" => array(
+    |       "database" => "test_tenant_database",
+    |  ),
+    |
+    */
+    'db_connection_overrides' => [
+
+    ],
+
+    /*
      |--------------------------------------------------------------------------
      | Support for camel cased models
      |--------------------------------------------------------------------------

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -140,6 +140,11 @@ class ModelsCommand extends Command
     {
         $this->filename = $this->laravel['config']->get('ide-helper.models_filename', '_ide_helper_models.php');
         $filename = $this->option('filename') ?? $this->filename;
+        $db_overrides = $this->laravel['config']->get('ide-helper.db_connection_overrides');
+        if (is_array($db_overrides)) {
+            $db_overrides = array_replace_recursive($this->laravel['config']->get('database.connections'), $db_overrides);
+            $this->laravel['config']->set('database.connections', $db_overrides);
+        }
         $this->write = $this->option('write');
         $this->write_mixin = $this->option('write-mixin');
         $this->dirs = array_merge(

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -936,14 +936,14 @@ class ModelsCommand extends Command
 
             // remove the already existing tag to prevent duplicates
             foreach ($phpdoc->getTagsByName('mixin') as $tag) {
-                if($tag->getContent() === $eloquentClassNameInModel) {
+                if ($tag->getContent() === $eloquentClassNameInModel) {
                     $phpdoc->deleteTag($tag);
                 }
             }
 
             $phpdoc->appendTag(Tag::createInstance('@mixin ' . $eloquentClassNameInModel, $phpdoc));
         }
-        
+
         if ($this->phpstorm_noinspections) {
             /**
              * Facades, Eloquent API


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->
For applications were the developer is using a multi-tenancy setup, utilising multiple databases i.e., one for the landlord and many for the tenants, the database config definition is usually altered by the multi-tenancy package when a new tenant is activated.

This however, means that the `database.connections.tenant` config is usually missing a value for `database.connections.tenant.database` so laravel-ide-helper cannot connect to the database to inspect the properties.

This modification adds a new config entry into the `ide-helper.php` config file that allows for overrides for the `database.connections` array to be set. When the model generator command is run, these overrides are set in the in-memory config values, such that when the connection is used to inspect the database schema, it has the full information. However, this doesn't have a knock on effect that the `database.php` config file needs to be constantly altered and then reset.

The user can also elect to use an `env()` value in the `ide-helper.db_connections_override` array so that between developers the database name can be set as needed.

This has been referenced in the following issues:
#1141 
#1280 

An attempt at a pull request #1285 was submitted by vpratfr which attempts a similar idea, but requires specifying a specific connection to use and alters the connection logic. I can see that this could have "breaking" implications and makes things difficult to test. This PR uses the existing connections and allows for the user to specify a database name (in essence) i.e., it's there if the user wants to use it, but if not nothing really changes.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
