### PR TITLE
Property type isn't detected when casting Eloquent attributes to `spatie/laravel-data` Data objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Add support for custom casts that implement `CastsInboundAttributes` [#1329 / sforward](https://github.com/barryvdh/laravel-ide-helper/pull/1329)
+- A solution to detect property types when casting Eloquent attributes to objects. Add the `@ide-helper-eloquent-cast-to-specified-class` tag to the class being cast to
 
 2022-03-06, 2.12.3
 ------------------

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -935,14 +935,14 @@ class ModelsCommand extends Command
 
             // remove the already existing tag to prevent duplicates
             foreach ($phpdoc->getTagsByName('mixin') as $tag) {
-                if($tag->getContent() === $eloquentClassNameInModel) {
+                if ($tag->getContent() === $eloquentClassNameInModel) {
                     $phpdoc->deleteTag($tag);
                 }
             }
 
             $phpdoc->appendTag(Tag::createInstance('@mixin ' . $eloquentClassNameInModel, $phpdoc));
         }
-        
+
         if ($this->phpstorm_noinspections) {
             /**
              * Facades, Eloquent API

--- a/tests/Console/ModelsCommand/SimpleCasts/Castables/ChildObject.php
+++ b/tests/Console/ModelsCommand/SimpleCasts/Castables/ChildObject.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Castables;
+
+class ChildObject extends ParentObject
+{
+    /**
+     * Retrieve the value stored in this Value object.
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return mb_strtolower($this->value);
+    }
+}

--- a/tests/Console/ModelsCommand/SimpleCasts/Castables/CustomCaster.php
+++ b/tests/Console/ModelsCommand/SimpleCasts/Castables/CustomCaster.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Castables;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class CustomCaster implements CastsAttributes
+{
+    /** @var class-string The class to cast to. */
+    private $castToClass;
+
+    /**
+     * Constructor.
+     *
+     * @param string $castToClass The class to cast to.
+     * @return void
+     */
+    public function __construct(string $castToClass)
+    {
+        $this->castToClass = $castToClass;
+    }
+
+    /**
+     * Transform the attribute from the underlying model values.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function get($model, string $key, $value, array $attributes)
+    {
+        return new $this->castToClass($value);
+    }
+
+    /**
+     * Transform the attribute to its underlying model values.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        /** @var ParentObject $value */
+        return [$key => $value->getValue()];
+    }
+}

--- a/tests/Console/ModelsCommand/SimpleCasts/Castables/ParentObject.php
+++ b/tests/Console/ModelsCommand/SimpleCasts/Castables/ParentObject.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Castables;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
+
+/**
+ * @ide-helper-eloquent-cast-to-specified-class
+ */
+class ParentObject implements Castable
+{
+    /** @var mixed The value that this Value object represents. */
+    protected $value;
+
+    /**
+     * Constructor.
+     *
+     * @param mixed $value The value to represent.
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+    /**
+     * Retrieve the value stored in this Value object.
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return mb_strtoupper($this->value);
+    }
+
+    /**
+     * Get the name of the caster class to use when casting from / to this cast target.
+     *
+     * @param  array  $arguments
+     * @return string|CastsAttributes|CastsInboundAttributes
+     */
+    public static function castUsing(array $arguments): CastsAttributes
+    {
+        return new CustomCaster(static::class);
+    }
+}

--- a/tests/Console/ModelsCommand/SimpleCasts/Models/SimpleCast.php
+++ b/tests/Console/ModelsCommand/SimpleCasts/Models/SimpleCast.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Models;
 
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Castables\ChildObject;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Castables\ParentObject;
 use Illuminate\Database\Eloquent\Model;
 
 class SimpleCast extends Model
@@ -36,5 +38,7 @@ class SimpleCast extends Model
         'cast_to_encrypted_collection' => 'encrypted:collection',
         'cast_to_encrypted_json' => 'encrypted:json',
         'cast_to_encrypted_object' => 'encrypted:object',
+        'cast_to_parent_object_using_cast_static_tag' => ParentObject::class,
+        'cast_to_child_object_using_cast_static_tag' => ChildObject::class,
     ];
 }

--- a/tests/Console/ModelsCommand/SimpleCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/SimpleCasts/__snapshots__/Test__test__1.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Models;
 
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Castables\ChildObject;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Castables\ParentObject;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -36,6 +38,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property \Illuminate\Support\Collection $cast_to_encrypted_collection
  * @property array $cast_to_encrypted_json
  * @property object $cast_to_encrypted_object
+ * @property ParentObject $cast_to_parent_object_using_cast_static_tag
+ * @property ChildObject $cast_to_child_object_using_cast_static_tag
  * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|SimpleCast query()
@@ -98,5 +102,7 @@ class SimpleCast extends Model
         'cast_to_encrypted_collection' => 'encrypted:collection',
         'cast_to_encrypted_json' => 'encrypted:json',
         'cast_to_encrypted_object' => 'encrypted:object',
+        'cast_to_parent_object_using_cast_static_tag' => ParentObject::class,
+        'cast_to_child_object_using_cast_static_tag' => ChildObject::class,
     ];
 }


### PR DESCRIPTION
## The problem

When casting Eloquent attributes to `spatie/laravel-data` Data objects, ide-helper doesn't pick the correct class. For example, the example from Spatie's documentation https://spatie.be/docs/laravel-data/v2/advanced-usage/eloquent-casting:

```php
<?php
# app/Models/Song.php
namespace App\Models;

use App\SpatieData\ArtistData;
use Illuminate\Database\Eloquent\Model;

class Song extends Model
{
    protected $casts = [
        'artist' => ArtistData::class,
    ];
}
```



```php
<?php
# app/SpatieData/ArtistData.php
namespace App\SpatieData;

use Spatie\LaravelData\Data;

class ArtistData extends Data
{
    public function __construct(
        public string $name,
        public int $age,
    ) {
    }
}
```



Running `php artisan ide-helper:models --dir='app' --write` generates this DocBlock:

```php
/**
 * App\Models\Song
 *
 * @property \Spatie\LaravelData\Contracts\BaseData|null $artist // ❌ not the desired prop definition
 * @method static \Illuminate\Database\Eloquent\Builder|Song newModelQuery()
 * @method static \Illuminate\Database\Eloquent\Builder|Song newQuery()
 * @method static \Illuminate\Database\Eloquent\Builder|Song query()
 * @mixin \Eloquent
 */
```



This means that we don't get the benefit of type-hinting for casted attributes like this:

```php
$songModel->artist->name;
```



---



## Why does this happen?

This happens because `src/Support/EloquentCasts/DataEloquentCast.php` from Spatie's package specifies a return type. *This* is what ide-helper picks up:

```php
# src/Support/EloquentCasts/DataEloquentCast.php in spatie/laravel-data
…
    public function get($model, string $key, $value, array $attributes): ?BaseData
    {
…
```



---



## Proposed change

I put this together when looking through the code, trying to work out how to fix it in a project of mine. I thought I'd turn it into a PR for discussion…

This PR lets you instruct ide-helper to use the class *that was specified*, by adding the DocBlock tag `@ide-helper-eloquent-cast-to-specified-class` to the class being cast to. e.g.

```php
<?php
# app/SpatieData/ArtistData.php

/**
 * @ide-helper-eloquent-cast-to-specified-class
 */
class ArtistData extends Data
{
…
```


From which, ide-helper now generates:

```php
/**
 * App\Models\Song
 *
 * @property ArtistData $artist // ✅ the desired prop definition
 * @method static \Illuminate\Database\Eloquent\Builder|Song newModelQuery()
 * @method static \Illuminate\Database\Eloquent\Builder|Song newQuery()
 * @method static \Illuminate\Database\Eloquent\Builder|Song query()
 * @mixin \Eloquent
 */
```



---



## Notes

- The `@ide-helper-eloquent-cast-to-specified-class` tag can be added to a class, or any of it's parents.
- `spatie/laravel-data` could add this tag to their `Spatie\LaravelData\Data` class, so it's always applied to Data classes that use it. But if they don't, it can just as easily be added to Data classes (or a parent class) in individual projects.
- This solution isn't specific to `spatie/laravel-data`. It can be used for any classes being cast to in this manner.



## Thoughts

- I couldn't think of a way for it to happen *automatically* without forcing it in *every* case. Which I don't think is 100% desired.
- I don't think having to add a @tag is a "nice" solution, however it does give control over when it happens.
- An alternative I considered was to specify the relevant classes inside ide-helper's config file. But this doesn't seem very flexible.
- I'd be interested to hear if anybody has other ideas about how to detect when it should occur.



## Other issues and PRs

- This PR may help address this issue https://github.com/barryvdh/laravel-ide-helper/issues/1312
- The https://github.com/barryvdh/laravel-ide-helper/pull/1388 PR addresses a slightly different situation. It falls back to the specified-class when none was specified by the casting class. It is short and elegant. However `spatie/laravel-data` *does* specify a return type. So whilst it might be a useful change, it doesn't affect *this* situation.
- The comment https://github.com/barryvdh/laravel-ide-helper/issues/1312#issuecomment-1221270878 suggests hard-coding a check for `spatie/laravel-data`. This seems inflexible to me as it wouldn't allow for other packages or custom classes to benefit.



---



## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [X] Existing tests have been adapted and/or new tests have been added
- [X] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [X] Code style has been fixed via `composer fix-style`
