### PR TITLE
Add phpstorm metadata for mock methods when testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Handle PHP 8.1 deprecation warnings when passing `null` to `new \ReflectionClass` [#1351 / mfn](https://github.com/barryvdh/laravel-ide-helper/pull/1351)
 - Fix issue where \Eloquent is not included when using write_mixin [#1352 / Jefemy](https://github.com/barryvdh/laravel-ide-helper/pull/1352)
 - Fix model factory method arguments for Laravel >= 9 [#1361 / wimski](https://github.com/barryvdh/laravel-ide-helper/pull/1361)
+- Improve return type of mock helper methods in tests [#1405 / bentleyo](https://github.com/barryvdh/laravel-ide-helper/pull/1405) 
 
 ### Added
 - Add support for custom casts that implement `CastsInboundAttributes` [#1329 / sforward](https://github.com/barryvdh/laravel-ide-helper/pull/1329)

--- a/resources/views/meta.php
+++ b/resources/views/meta.php
@@ -28,6 +28,10 @@ namespace PHPSTORM_META {
     ]));
 <?php endif; ?>
 
+    override(\Illuminate\Foundation\Testing\Concerns\InteractsWithContainer::mock(0), map(["" => "@&\Mockery\MockInterface"]));
+    override(\Illuminate\Foundation\Testing\Concerns\InteractsWithContainer::partialMock(0), map(["" => "@&\Mockery\MockInterface"]));
+    override(\Illuminate\Foundation\Testing\Concerns\InteractsWithContainer::instance(0), type(1));
+    override(\Illuminate\Foundation\Testing\Concerns\InteractsWithContainer::spy(0), map(["" => "@&\Mockery\MockInterface"]));
     override(\Illuminate\Support\Arr::add(0), type(0));
     override(\Illuminate\Support\Arr::except(0), type(0));
     override(\Illuminate\Support\Arr::first(0), elementType(0));


### PR DESCRIPTION
## Summary
This adds some PhpStorm metadata to help with the return type when calling the `$this->mock`, `$this->partialMock` etc. methods in tests. By default PhpStorm believes the return type is an object implementing `MockInterface`, but this PR adds an additional typehint for the mocked class.

Here is an example in a test:
```
$user = $this->mock(User::class);
```

PhpStorm will now say the return type is `App\Models\User&Mockery\MockInterface`.

<img width="697" alt="Screen Shot 2023-01-16 at 13 46 41" src="https://user-images.githubusercontent.com/1701266/212594476-77a4e72b-0bce-4709-8465-d4775b5bf9f0.png">

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

### Checklist
- [x] Add a CHANGELOG.md entry
