### PR TITLE
gha: fix workflow by allowing the composer-normalize plugin

### DIFF
--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -3,6 +3,7 @@ name: normalize composer.json
 on:
   push:
     paths:
+      - .github/workflows/composer-normalize.yml
       - composer.json
 
 jobs:

--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -18,6 +18,7 @@ jobs:
 
       - name: Normalize composer.json
         run: |
+          composer global config --no-plugins allow-plugins.ergebnis/composer-normalize true
           composer global require ergebnis/composer-normalize
           composer normalize
 


### PR DESCRIPTION
## Summary
We don't need to enable it in the project itself, but at least in this workflow which explicitly uses it.

See https://github.com/barryvdh/laravel-ide-helper/actions/runs/3980013548/jobs/6822812621#step:4:34
```
Error: ergebnis/composer-normalize (installed globally) contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
You can run "composer global config --no-plugins allow-plugins.ergebnis/composer-normalize [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
