### PR TITLE
Add `AllowDynamicProperties` Attribute to cooperate with php8.2 deprecation

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1055,9 +1055,11 @@ class ModelsCommand extends Command
         }
 
         $classname = $this->write_mixin ? $mixinClassName : $classname;
-        $output = "namespace {$namespace}{\n{$docComment}\n\t{$keyword}class {$classname} ";
 
-        if (!$this->write_mixin) {
+        $allowDynamicAttributes = $this->write_mixin ? "#[\AllowDynamicProperties]\n\t" : '';
+        $output = "namespace {$namespace}{\n{$docComment}\n\t{$keyword}{$allowDynamicAttributes}class {$classname} ";
+
+        if (! $this->write_mixin) {
             $output .= "extends \Eloquent ";
 
             if ($interfaceNames) {

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/__snapshots__/Test__test__1.php
@@ -183,6 +183,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereYearNullable($value)
  * @mixin \Eloquent
  */
-	class IdeHelperPost {}
+	#[\AllowDynamicProperties]
+    class IdeHelperPost {}
 }
 

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/__snapshots__/Test__test__1.php
@@ -184,6 +184,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @mixin \Eloquent
  */
 	#[\AllowDynamicProperties]
-    class IdeHelperPost {}
+	class IdeHelperPost {}
 }
 


### PR DESCRIPTION

## Summary
Trying to Add `#[\AllowDynamicProperties]` before class on mixin, as solution to PHPStan errors 

_Note: could add an extra check  `PHP_VERSION_ID>= 80200`, but seems redundant as attributes have backwards compatibility_  

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`


rel #1386
closes #1402