### PR TITLE
Support the BINARY(...) database field type

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -545,6 +545,7 @@ class ModelsCommand extends Command
                     case 'datetimetz':
                     case 'datetime':
                     case 'decimal':
+                    case 'binary':
                         $type = 'string';
                         break;
                     case 'integer':


### PR DESCRIPTION
In singlestore we define some strings as
$table->char($columnName, 40)->charset('binary')->collation('binary');

In singelstore, this becomes 'BINARY(40)' instead of 'CHAR(40) CHARACTER SET 'binary' COLLATE 'binary'

This change would allow the generated proeperties to be 'string' instead of 'mixed', as using a string is correct in this case.

## Summary
<!-- Please provide an exhaustive description. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
