### PR TITLE
Enable the recognition of attributes without any return type in the declared closures

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1184,7 +1184,7 @@ class ModelsCommand extends Command
             'get' => $attribute->get,
             'set' => $attribute->set,
         ])
-            ->map(function($function, $functionName) {
+            ->map(function ($function, $functionName) {
                 if (!$function) {
                     return null;
                 }
@@ -1213,7 +1213,7 @@ class ModelsCommand extends Command
                     } else {
                         $types = collect($this->extractReflectionTypes($type));
                     }
-                    
+
                     if ($type->allowsNull()) {
                         $types->push('null');
                     }

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1181,24 +1181,42 @@ class ModelsCommand extends Command
         $attribute = $reflectionMethod->invoke($model);
 
         return collect([
-            'get' => $attribute->get ? optional(new \ReflectionFunction($attribute->get))->getReturnType() : null,
-            'set' => $attribute->set ? optional(new \ReflectionFunction($attribute->set))->getReturnType() : null,
+            'get' => $attribute->get,
+            'set' => $attribute->set,
         ])
-            ->filter()
-            ->map(function ($type) {
-                if ($type instanceof \ReflectionUnionType) {
-                    $types = collect($type->getTypes())
-                        /** @var ReflectionType $reflectionType */
-                        ->map(function ($reflectionType) {
-                            return collect($this->extractReflectionTypes($reflectionType));
-                        })
-                        ->flatten();
-                } else {
-                    $types = collect($this->extractReflectionTypes($type));
+            ->map(function($function, $functionName) {
+                if (!$function) {
+                    return null;
                 }
 
-                if ($type->allowsNull()) {
-                    $types->push('null');
+                $reflectionFunction = new \ReflectionFunction($function);
+                $functionReturnType = optional($reflectionFunction)->getReturnType();
+
+                if (!$functionReturnType) {
+                    $functionReturnType = 'mixed';
+                }
+
+                return $functionReturnType;
+            })
+            ->filter()
+            ->map(function ($type) {
+                if ($type === 'mixed') {
+                    $types = collect(['mixed']);
+                } else {
+                    if ($type instanceof \ReflectionUnionType) {
+                        $types = collect($type->getTypes())
+                            /** @var ReflectionType $reflectionType */
+                            ->map(function ($reflectionType) {
+                                return collect($this->extractReflectionTypes($reflectionType));
+                            })
+                            ->flatten();
+                    } else {
+                        $types = collect($this->extractReflectionTypes($type));
+                    }
+                    
+                    if ($type->allowsNull()) {
+                        $types->push('null');
+                    }
                 }
 
                 return $types->join('|');

--- a/tests/Console/ModelsCommand/Attributes/Models/Simple.php
+++ b/tests/Console/ModelsCommand/Attributes/Models/Simple.php
@@ -21,6 +21,18 @@ class Simple extends Model
         );
     }
 
+    protected function attributeWithoutReturnTypes(): Attribute
+    {
+        return new Attribute(
+            function (?string $name) {
+                return $name;
+            },
+            function (?string $name) {
+                return $name === null ? null : ucfirst($name);
+            }
+        );
+    }
+
     /**
      * ide-helper does not recognize this method being an Attribute
      * because the method has no actual return type;

--- a/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Model;
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Attributes\Models\Simple
  *
  * @property integer $id
+ * @property mixed $attribute_without_return_types
  * @property string|null $name
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
@@ -27,6 +28,18 @@ class Simple extends Model
                 return $name;
             },
             function (?string $name): ?string {
+                return $name === null ? null : ucfirst($name);
+            }
+        );
+    }
+
+    protected function attributeWithoutReturnTypes(): Attribute
+    {
+        return new Attribute(
+            function (?string $name) {
+                return $name;
+            },
+            function (?string $name) {
                 return $name === null ? null : ucfirst($name);
             }
         );


### PR DESCRIPTION
## Summary
Enable the recognition of attributes without any return type in the declared closures.

The following example was not recognized before:
```php
protected function attributeWithoutReturnTypes(): Attribute
{
    return new Attribute(
        function (?string $name) {
            return $name;
        },
        function (?string $name) {
            return $name === null ? null : ucfirst($name);
        }
    );
}
```
Now it is.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
