### PR TITLE
Fix unsetMethod

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -890,7 +890,7 @@ class ModelsCommand extends Command
 
     public function unsetMethod($name)
     {
-        unset($this->methods[strtolower($name)]);
+        unset($this->methods[$name]);
     }
 
     public function getMethodType(Model $model, string $classType)


### PR DESCRIPTION
Method keys aren't in lower case format, there is no way to unset method in camel case format automaticly generated from scope methods. This commit fixes issues for hooks e.g. like this:

```php
final class MyCustomHook implements ModelHookInterface
{
    public function run(ModelsCommand $command, Model $model): void
    {
        if ($model instanceof MyModel) {
            $command->unsetMethod('getAssoc');
        }
        $command->setMethod('getAssoc', 'Collection');
    }
}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

