### PR TITLE
fix belongsTo relation is detected as nullable.

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -266,6 +266,7 @@ class ModelsCommand extends Command
             }
             $this->properties = [];
             $this->methods = [];
+            $this->foreignKeyConstraintsColumns = [];
             if (class_exists($name)) {
                 try {
                     // handle abstract classes, interfaces, ...


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->

In ModelsCommand, belongs to relations are detected as nullable when this column is nullable or has not foreign key constraint.

https://github.com/barryvdh/laravel-ide-helper/blob/master/src/Console/ModelsCommand.php#L841-L842

Now read foreign keys is not reset on model loop.
For example. when column x of model A has no foreign key and column x of model B has foreign key, column x of model A may marked as not nullable because column x is recoreded as foreign key by model B.


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
