### PR TITLE
chore: add dependabot for github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      deps:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary
Inspired by https://github.com/barryvdh/laravel-ide-helper/pull/1469 , so we don't need to "think" about keeping things update.

This deliberately only targets GHA and not e.g. `composer`. As a library I believe we want the widest and not the narrowest dependencies, so neither minor nor major updates make sense to me (for now, at least).

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
