### PR TITLE
Fix flag reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ By default, you are asked to overwrite or write to a separate file (`_ide_helper
 You can write the comments directly to your Model file, using the `--write (-W)` option, or
 force to not write with `--nowrite (-N)`.
 
-Alternatively using the `--write-mixin (-M)` option will only add a mixin tag to your Model file,
+Alternatively using the `--write_mixins (-M)` option will only add a mixin tag to your Model file,
 writing the rest in (`_ide_helper_models.php`).
 The class name will be different from the model, avoiding the IDE duplicate annoyance.
 
@@ -170,7 +170,7 @@ php artisan ide-helper:models "App\Models\Post"
  */
 ```
 
-With the `--write-mixin (-M)` option
+With the `--write_mixins (-M)` option
 ```php
 /**
  * …


### PR DESCRIPTION
## Summary
Following the README and trying to set up a config with mixins I got an error. After digging through I realized the option is actually `--write_mixins` and not `--write-mixin` as suggested by the README. I've updated the file to reflect that.

## Type of change
- [X] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [X] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
