### PR TITLE
Fixed issue #1487

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -506,6 +506,11 @@ class ModelsCommand extends Command
     {
         $database = $model->getConnection()->getDatabaseName();
         $table = $model->getConnection()->getTablePrefix() . $model->getTable();
+        if (str_contains($table, '.')) {
+            $tableArray = explode('.', $table);
+            $database = $table[0];
+            $table = $table[1];
+        }
         $schema = $model->getConnection()->getDoctrineSchemaManager();
         $databasePlatform = $schema->getDatabasePlatform();
         $databasePlatform->registerDoctrineTypeMapping('enum', 'string');

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -506,10 +506,8 @@ class ModelsCommand extends Command
     {
         $database = $model->getConnection()->getDatabaseName();
         $table = $model->getConnection()->getTablePrefix() . $model->getTable();
-        if (str_contains($table, '.')) {
-            $tableArray = explode('.', $table);
-            $database = $tableArray[0];
-            $table = $tableArray[1];
+        if (strpos($table, '.')) {
+            [$database, $table] = explode('.', $table);
         }
         $schema = $model->getConnection()->getDoctrineSchemaManager();
         $databasePlatform = $schema->getDatabasePlatform();

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -508,8 +508,8 @@ class ModelsCommand extends Command
         $table = $model->getConnection()->getTablePrefix() . $model->getTable();
         if (str_contains($table, '.')) {
             $tableArray = explode('.', $table);
-            $database = $table[0];
-            $table = $table[1];
+            $database = $tableArray[0];
+            $table = $tableArray[1];
         }
         $schema = $model->getConnection()->getDoctrineSchemaManager();
         $databasePlatform = $schema->getDatabasePlatform();


### PR DESCRIPTION
Fixed phpdoc generator to fetch data from tables with database name in table property

## Summary
I have multiple databases on the same connection, so my models have database prefix. If i run php artisan ide-helper:models the models with a prefix won't work, but if I change default database and remove the prefix it works. This fix allows to fetch data for those models

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
