### PR TITLE
Add support for nikic/php-parser:^5 and (hopefully) doctrine/dbal:^4

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -17,6 +17,7 @@ jobs:
         env:
             COMPOSER_NO_INTERACTION: 1
         strategy:
+            fail-fast: false
             matrix:
                 php: [8.3, 8.2, 8.1, 8.0, 7.4, 7.3]
                 laravel: [10.*, 9.*, 8.*]

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -26,14 +26,18 @@ jobs:
                     laravel: 10.*
                   - php: 7.4
                     laravel: 10.*
-                  - php: 7.4
-                    laravel: 10.*
                   - php: 7.3
                     laravel: 10.*
+                  - php: 8.3
+                    laravel: 9.*
                   - php: 7.4
                     laravel: 9.*
                   - php: 7.3
                     laravel: 9.*
+                  - php: 8.3
+                    laravel: 8.*
+                  - php: 8.2
+                    laravel: 8.*
         name: P${{ matrix.php }} - Laravel${{ matrix.laravel }}
         steps:
             - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Add support for attribute accessors marked as protected. [#1339 / pindab0ter](https://github.com/barryvdh/laravel-ide-helper/pull/1339)
 
 ### Added
+- Add support for nikic/php-parser 5 (next to 4) [#1502 / mfn](https://github.com/barryvdh/laravel-ide-helper/pull/1502)
 - Add support for `immutable_date:*` and `immutable_datetime:*` casts. [#1380 / thekonz](https://github.com/barryvdh/laravel-ide-helper/pull/1380)
 
 2023-02-04, 2.13.0

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-json": "*",
         "barryvdh/reflection-docblock": "^2.0.6",
         "composer/class-map-generator": "^1.0",
-        "doctrine/dbal": "^2.6 || ^3",
+        "doctrine/dbal": "^2.6 || ^3 || ^4",
         "illuminate/console": "^8 || ^9 || ^10",
         "illuminate/filesystem": "^8 || ^9 || ^10",
         "illuminate/support": "^8 || ^9 || ^10",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "illuminate/console": "^8 || ^9 || ^10",
         "illuminate/filesystem": "^8 || ^9 || ^10",
         "illuminate/support": "^8 || ^9 || ^10",
-        "nikic/php-parser": "^4.7",
+        "nikic/php-parser": "^4.18 || ^5",
         "phpdocumentor/type-resolver": "^1.1.0"
     },
     "require-dev": {

--- a/src/UsesResolver.php
+++ b/src/UsesResolver.php
@@ -64,7 +64,7 @@ class UsesResolver
             '\\'
         );
 
-        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $parser = (new ParserFactory())->createForHostVersion();
         $namespaceData = null;
 
         foreach ($parser->parse($code) as $node) {


### PR DESCRIPTION
## Summary
- `createForHostVersion` has been added to php-parser 4.18 so code can run with both versions [1]
- therefore also bumped the minimum required version to it

However, unrelated some tests in `master` were not working currently, which I also fixed to get the ✅ : 
- Excluded unsupported PHP / Laravel combinations ([used the official docs as reference](https://laravel.com/docs/10.x/releases))
- Allow doctrine/dbal:^4 too
  This solved some combination of the integration tests failing, though I'm not 100% sure if dbal truly works with it; it seems none of the feature tests install it and it has no stable release yet 🤔

Fixes https://github.com/barryvdh/laravel-ide-helper/issues/1498 and https://github.com/barryvdh/laravel-ide-helper/issues/1490

## Notes
- The dev dependency vimeo/psalm is **not** compatible with php-parser:^5 currently. This does not impact usages of this library, but sometimes cause friction when working on this library. For our CI this isn't a problem, because we already remove that dependency before running the test suite.

[1] https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-the-parser-factory

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
