### PR TITLE
Remove doctrine/dbal:^4 support

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -62,7 +62,7 @@ jobs:
               run: |
                   cd sample
                   sed -e 's|"type": "project",|&\n"repositories": [ { "type": "path", "url": "../src" } ],|' -i composer.json
-                  composer require --dev "barryvdh/laravel-ide-helper:*"
+                  composer require --dev "barryvdh/laravel-ide-helper:*" --with-all-dependencies
 
             - name: Execute generate run
               run: |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Require this package with composer using the following command:
 composer require --dev barryvdh/laravel-ide-helper
 ```
 
+> [!NOTE]  
+> If you encounter version conflicts with doctrine/dbal, please try:
+> `composer require --dev barryvdh/laravel-ide-helper --with-all-dependencies`
+ 
 This package makes use of [Laravels package auto-discovery mechanism](https://medium.com/@taylorotwell/package-auto-discovery-in-laravel-5-5-ea9e3ab20518), which means if you don't install dev dependencies in production, it also won't be loaded.
 
 If for some reason you want manually control this:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-json": "*",
         "barryvdh/reflection-docblock": "^2.0.6",
         "composer/class-map-generator": "^1.0",
-        "doctrine/dbal": "^2.6 || ^3 || ^4",
+        "doctrine/dbal": "^2.6 || ^3",
         "illuminate/console": "^8 || ^9 || ^10",
         "illuminate/filesystem": "^8 || ^9 || ^10",
         "illuminate/support": "^8 || ^9 || ^10",


### PR DESCRIPTION
## Summary
Remove doctrine/dbal:^4 support

Tests fail with:
`PHP Fatal error:  Declaration of Illuminate\Database\PDO\Concerns\ConnectsToDatabase::connect(array $params, $username = null, $password = null, array $driverOptions = []) must be compatible with Doctrine\DBAL\Driver::connect(array $params): Doctrine\DBAL\Driver\Connection in /home/runner/work/laravel-ide-helper/laravel-ide-helper/vendor/laravel/framework/src/Illuminate/Database/PDO/Concerns/ConnectsToDatabase.php on line 22`

This was just recently added, before doctrine/dbal 4.0.0 was released, which happened 1 hour ago and tests don't work now.

Remove it until this is figured.

Marking it as internal change, because this wasn't release yet.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
