### PR TITLE
Remove outdated dev references to older versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,8 @@
         "illuminate/view": "^9 || ^10",
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^7 || ^8",
-        "phpunit/phpunit": "^8.5 || ^9",
-        "spatie/phpunit-snapshot-assertions": "^3 || ^4",
+        "phpunit/phpunit": "^9",
+        "spatie/phpunit-snapshot-assertions": "^4",
         "vimeo/psalm": "^5.4"
     },
     "suggest": {


### PR DESCRIPTION
## Summary
Neither phpunit 8 nor spatie/phpunit-snapshot-assertions 3 are relevant anymore.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
