### PR TITLE
Add support for Laravel 11

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -20,10 +20,14 @@ jobs:
             fail-fast: false
             matrix:
                 php: [8.3, 8.2, 8.1, 8.0]
-                laravel: [10.*, 9.*]
+                laravel: [11.*, 10.*, 9.*]
                 exclude:
                   - php: 8.0
                     laravel: 10.*
+                  - php: 8.0
+                    laravel: 11.*
+                  - php: 8.1
+                    laravel: 11.*
                   - php: 8.3
                     laravel: 9.*
         name: P${{ matrix.php }} - Laravel${{ matrix.laravel }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,13 +21,17 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-2019]
         php: [8.3, 8.2, 8.1, 8.0]
-        laravel: [9.*, 10.*]
+        laravel: [9.*, 10.*, 11.*]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
           - php: 8.0
             laravel: 10.*
           - php: 8.0
             dependency-version: prefer-lowest
+          - php: 8.0
+            laravel: 11.*
+          - php: 8.1
+            laravel: 11.*
     steps:
     - name: Set git to use LF
       if: ${{ matrix.os == 'windows-2019' }}

--- a/composer.json
+++ b/composer.json
@@ -25,25 +25,25 @@
         "barryvdh/reflection-docblock": "^2.0.6",
         "composer/class-map-generator": "^1.0",
         "doctrine/dbal": "^2.6 || ^3",
-        "illuminate/console": "^9 || ^10",
-        "illuminate/filesystem": "^9 || ^10",
-        "illuminate/support": "^9 || ^10",
+        "illuminate/console": "^9 || ^10 || ^11",
+        "illuminate/filesystem": "^9 || ^10 || ^11",
+        "illuminate/support": "^9 || ^10 || ^11",
         "nikic/php-parser": "^4.18 || ^5",
         "phpdocumentor/type-resolver": "^1.1.0"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "friendsofphp/php-cs-fixer": "^3",
-        "illuminate/config": "^9 || ^10",
-        "illuminate/view": "^9 || ^10",
+        "illuminate/config": "^9 || ^10 || ^11",
+        "illuminate/view": "^9 || ^10 || ^11",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^7 || ^8",
-        "phpunit/phpunit": "^8.5 || ^9",
-        "spatie/phpunit-snapshot-assertions": "^3 || ^4",
+        "orchestra/testbench": "^7 || ^8 || ^9",
+        "phpunit/phpunit": "^8.5 || ^9 || ^10.5",
+        "spatie/phpunit-snapshot-assertions": "^3 || ^4 || ^5",
         "vimeo/psalm": "^5.4"
     },
     "suggest": {
-        "illuminate/events": "Required for automatic helper generation (^6|^7|^8|^9|^10)."
+        "illuminate/events": "Required for automatic helper generation (^6|^7|^8|^9|^10|^11)."
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/Database/Concerns/ConnectsToDatabase.php
+++ b/src/Database/Concerns/ConnectsToDatabase.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper\Database\Concerns;
+
+use Barryvdh\LaravelIdeHelper\Database\PDOConnection;
+
+/**
+ * Migrated classes removed in Laravel 11 from Laravel 10.
+ *
+ * @see https://github.com/laravel/framework/blob/v10.43.0/src/Illuminate/Database/PDO/Concerns/ConnectsToDatabase.php
+ */
+trait ConnectsToDatabase
+{
+    public function connect(array $params)
+    {
+        return new PDOConnection($params['pdo']);
+    }
+}

--- a/src/Database/MySqlDriver.php
+++ b/src/Database/MySqlDriver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper\Database;
+
+use Barryvdh\LaravelIdeHelper\Database\Concerns\ConnectsToDatabase;
+use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+
+/**
+ * Migrated classes removed in Laravel 11 from Laravel 10.
+ *
+ * @see https://github.com/laravel/framework/blob/v10.43.0/src/Illuminate/Database/PDO/MySqlDriver.php
+ */
+class MySqlDriver extends AbstractMySQLDriver
+{
+    use ConnectsToDatabase;
+
+    public function getName()
+    {
+        return 'pdo_mysql';
+    }
+}

--- a/src/Database/PDOConnection.php
+++ b/src/Database/PDOConnection.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper\Database;
+
+use Doctrine\DBAL\Driver\PDO\Exception;
+use Doctrine\DBAL\Driver\PDO\Result;
+use Doctrine\DBAL\Driver\PDO\Statement;
+use Doctrine\DBAL\Driver\Result as ResultInterface;
+use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
+use Doctrine\DBAL\ParameterType;
+use PDO;
+use PDOException;
+use PDOStatement;
+
+/**
+ * Migrated classes removed in Laravel 11 from Laravel 10.
+ *
+ * @see https://github.com/laravel/framework/blob/v10.43.0/src/Illuminate/Database/PDO/Connection.php
+ */
+class PDOConnection implements ServerInfoAwareConnection
+{
+    /**
+     * The underlying PDO connection.
+     */
+    protected PDO $connection;
+
+    /**
+     * Create a new PDO connection instance.
+     */
+    public function __construct(PDO $connection)
+    {
+        $this->connection = $connection;
+        $this->getNativeConnection();
+    }
+
+    public function exec(string $sql): int
+    {
+        try {
+            $result = $this->connection->exec($sql);
+
+            assert($result !== false);
+
+            return $result;
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
+        }
+    }
+
+    public function prepare(string $sql): StatementInterface
+    {
+        try {
+            return $this->createStatement(
+                $this->connection->prepare($sql)
+            );
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
+        }
+    }
+
+    public function query(string $sql): ResultInterface
+    {
+        try {
+            $stmt = $this->connection->query($sql);
+
+            assert($stmt instanceof PDOStatement);
+
+            return new Result($stmt);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
+        }
+    }
+
+    public function lastInsertId($name = null)
+    {
+        try {
+            if ($name === null) {
+                return $this->connection->lastInsertId();
+            }
+
+            return $this->connection->lastInsertId($name);
+        } catch (PDOException $exception) {
+            throw Exception::new($exception);
+        }
+    }
+
+    /**
+     * Create a new statement instance.
+     */
+    protected function createStatement(PDOStatement $stmt): Statement
+    {
+        return new Statement($stmt);
+    }
+
+    public function beginTransaction()
+    {
+        return $this->connection->beginTransaction();
+    }
+
+    public function commit()
+    {
+        return $this->connection->commit();
+    }
+
+    public function rollBack()
+    {
+        return $this->connection->rollBack();
+    }
+
+    public function quote($value, $type = ParameterType::STRING)
+    {
+        return $this->connection->quote($value, $type);
+    }
+
+    public function getServerVersion()
+    {
+        return $this->connection->getAttribute(PDO::ATTR_SERVER_VERSION);
+    }
+
+    /**
+     * Get the wrapped PDO connection.
+     */
+    public function getWrappedConnection(): PDO
+    {
+        return $this->connection;
+    }
+
+    public function getNativeConnection()
+    {
+        //
+    }
+}

--- a/src/Database/PostgresDriver.php
+++ b/src/Database/PostgresDriver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper\Database;
+
+use Barryvdh\LaravelIdeHelper\Database\Concerns\ConnectsToDatabase;
+use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
+
+/**
+ * Migrated classes removed in Laravel 11 from Laravel 10.
+ *
+ * @see https://github.com/laravel/framework/blob/v10.43.0/src/Illuminate/Database/PDO/PostgresDriver.php
+ */
+class PostgresDriver extends AbstractPostgreSQLDriver
+{
+    use ConnectsToDatabase;
+
+    public function getName()
+    {
+        return 'pdo_pgsql';
+    }
+}

--- a/src/Database/SQLiteDriver.php
+++ b/src/Database/SQLiteDriver.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper\Database;
+
+use Barryvdh\LaravelIdeHelper\Database\Concerns\ConnectsToDatabase;
+use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
+
+/**
+ * Migrated classes removed in Laravel 11 from Laravel 10.
+ *
+ * @see https://github.com/laravel/framework/blob/v10.43.0/src/Illuminate/Database/PDO/SQLiteDriver.php
+ */
+class SQLiteDriver extends AbstractSQLiteDriver
+{
+    use ConnectsToDatabase;
+
+    public function getName()
+    {
+        return 'pdo_sqlite';
+    }
+}

--- a/src/Database/SqlServerConnection.php
+++ b/src/Database/SqlServerConnection.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper\Database;
+
+use Doctrine\DBAL\Driver\PDO\SQLSrv\Statement;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
+use Doctrine\DBAL\Driver\Statement as StatementInterface;
+use Doctrine\DBAL\ParameterType;
+use PDO;
+
+/**
+ * Migrated classes removed in Laravel 11 from Laravel 10.
+ *
+ * @see https://github.com/laravel/framework/blob/v10.43.0/src/Illuminate/Database/PDO/SqlServerConnection.php
+ */
+class SqlServerConnection implements ServerInfoAwareConnection
+{
+    /**
+     * The underlying connection instance.
+     */
+    protected PDOConnection $connection;
+
+    /**
+     * Create a new SQL Server connection instance.
+     */
+    public function __construct(PDOConnection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function prepare(string $sql): StatementInterface
+    {
+        return new Statement(
+            $this->connection->prepare($sql)
+        );
+    }
+
+    public function query(string $sql): Result
+    {
+        return $this->connection->query($sql);
+    }
+
+    public function exec(string $sql): int
+    {
+        return $this->connection->exec($sql);
+    }
+
+    public function lastInsertId($name = null)
+    {
+        if ($name === null) {
+            return $this->connection->lastInsertId($name);
+        }
+
+        return $this->prepare('SELECT CONVERT(VARCHAR(MAX), current_value) FROM sys.sequences WHERE name = ?')
+            ->execute([$name])
+            ->fetchOne();
+    }
+
+    public function beginTransaction()
+    {
+        return $this->connection->beginTransaction();
+    }
+
+    public function commit()
+    {
+        return $this->connection->commit();
+    }
+
+    public function rollBack()
+    {
+        return $this->connection->rollBack();
+    }
+
+    public function quote($value, $type = ParameterType::STRING)
+    {
+        $val = $this->connection->quote($value, $type);
+
+        // Fix for a driver version terminating all values with null byte...
+        if (is_string($val) && str_contains($val, "\0")) {
+            $val = substr($val, 0, -1);
+        }
+
+        return $val;
+    }
+
+    public function getServerVersion()
+    {
+        return $this->connection->getServerVersion();
+    }
+
+    /**
+     * Get the wrapped PDO connection.
+     */
+    public function getWrappedConnection(): PDO
+    {
+        return $this->connection->getWrappedConnection();
+    }
+
+    public function getNativeConnection()
+    {
+        //
+    }
+}

--- a/src/Database/SqlServerDriver.php
+++ b/src/Database/SqlServerDriver.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper\Database;
+
+use Doctrine\DBAL\Driver\AbstractSQLServerDriver;
+
+/**
+ * Migrated classes removed in Laravel 11 from Laravel 10.
+ *
+ * @see https://github.com/laravel/framework/blob/v10.43.0/src/Illuminate/Database/PDO/SqlServerDriver.php
+ */
+class SqlServerDriver extends AbstractSQLServerDriver
+{
+    public function connect(array $params)
+    {
+        return new SqlServerConnection(
+            new PDOConnection($params['pdo'])
+        );
+    }
+
+    public function getName()
+    {
+        return 'pdo_sqlsrv';
+    }
+}

--- a/tests/Console/ModelsCommand/AllowGlobDirectory/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/AllowGlobDirectory/__snapshots__/Test__test__1.php
@@ -46,8 +46,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property string|null $unsigned_decimal_nullable
- * @property string $unsigned_decimal_not_nullable
  * @property integer|null $boolean_nullable
  * @property integer $boolean_not_nullable
  * @property string|null $enum_nullable
@@ -143,8 +141,6 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereTinyIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedMediumIntegerNotNullable($value)

--- a/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
@@ -52,8 +52,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGenerateP
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property string|null $unsigned_decimal_nullable
- * @property string $unsigned_decimal_not_nullable
  * @property integer|null $boolean_nullable
  * @property integer $boolean_not_nullable
  * @property string|null $enum_nullable
@@ -149,8 +147,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGenerateP
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereTinyIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedMediumIntegerNotNullable($value)

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdoc/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdoc/__snapshots__/Test__test__1.php
@@ -46,8 +46,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property string|null $unsigned_decimal_nullable
- * @property string $unsigned_decimal_not_nullable
  * @property integer|null $boolean_nullable
  * @property integer $boolean_not_nullable
  * @property string|null $enum_nullable
@@ -143,8 +141,6 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereTinyIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedMediumIntegerNotNullable($value)

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdocCamel/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdocCamel/__snapshots__/Test__test__1.php
@@ -46,8 +46,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property float $doubleNotNullable
  * @property string|null $decimalNullable
  * @property string $decimalNotNullable
- * @property string|null $unsignedDecimalNullable
- * @property string $unsignedDecimalNotNullable
  * @property integer|null $booleanNullable
  * @property integer $booleanNotNullable
  * @property string|null $enumNullable
@@ -143,8 +141,6 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereTinyIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedMediumIntegerNotNullable($value)

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdocFinal/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdocFinal/__snapshots__/Test__test__1.php
@@ -46,8 +46,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property string|null $unsigned_decimal_nullable
- * @property string $unsigned_decimal_not_nullable
  * @property integer|null $boolean_nullable
  * @property integer $boolean_not_nullable
  * @property string|null $enum_nullable
@@ -143,8 +141,6 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereTinyIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedMediumIntegerNotNullable($value)

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
@@ -52,8 +52,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property string|null $unsigned_decimal_nullable
- * @property string $unsigned_decimal_not_nullable
  * @property integer|null $boolean_nullable
  * @property integer $boolean_not_nullable
  * @property string|null $enum_nullable
@@ -152,8 +150,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post whereTinyIntegerNullable($value)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post whereUnsignedBigIntegerNotNullable($value)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post whereUnsignedBigIntegerNullable($value)
- * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post whereUnsignedDecimalNotNullable($value)
- * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post whereUnsignedDecimalNullable($value)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post whereUnsignedIntegerNotNullable($value)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post whereUnsignedIntegerNullable($value)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Builders\PostExternalQueryBuilder|Post whereUnsignedMediumIntegerNotNullable($value)

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilderWithFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilderWithFqn/__snapshots__/Test__test__1.php
@@ -47,8 +47,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property string|null $unsigned_decimal_nullable
- * @property string $unsigned_decimal_not_nullable
  * @property integer|null $boolean_nullable
  * @property integer $boolean_not_nullable
  * @property string|null $enum_nullable
@@ -147,8 +145,6 @@ use Illuminate\Database\Eloquent\Model;
  * @method static PostExternalQueryBuilder|Post whereTinyIntegerNullable($value)
  * @method static PostExternalQueryBuilder|Post whereUnsignedBigIntegerNotNullable($value)
  * @method static PostExternalQueryBuilder|Post whereUnsignedBigIntegerNullable($value)
- * @method static PostExternalQueryBuilder|Post whereUnsignedDecimalNotNullable($value)
- * @method static PostExternalQueryBuilder|Post whereUnsignedDecimalNullable($value)
  * @method static PostExternalQueryBuilder|Post whereUnsignedIntegerNotNullable($value)
  * @method static PostExternalQueryBuilder|Post whereUnsignedIntegerNullable($value)
  * @method static PostExternalQueryBuilder|Post whereUnsignedMediumIntegerNotNullable($value)

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
@@ -48,8 +48,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property string|null $unsigned_decimal_nullable
- * @property string $unsigned_decimal_not_nullable
  * @property integer|null $boolean_nullable
  * @property integer $boolean_not_nullable
  * @property string|null $enum_nullable
@@ -149,8 +147,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTinyIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedBigIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedBigIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedDecimalNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedDecimalNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedMediumIntegerNotNullable($value)

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
@@ -54,8 +54,6 @@ use Illuminate\Support\Carbon;
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property string|null $unsigned_decimal_nullable
- * @property string $unsigned_decimal_not_nullable
  * @property integer|null $boolean_nullable
  * @property integer $boolean_not_nullable
  * @property string|null $enum_nullable
@@ -155,8 +153,6 @@ use Illuminate\Support\Carbon;
  * @method static EloquentBuilder|Post whereTinyIntegerNullable($value)
  * @method static EloquentBuilder|Post whereUnsignedBigIntegerNotNullable($value)
  * @method static EloquentBuilder|Post whereUnsignedBigIntegerNullable($value)
- * @method static EloquentBuilder|Post whereUnsignedDecimalNotNullable($value)
- * @method static EloquentBuilder|Post whereUnsignedDecimalNullable($value)
  * @method static EloquentBuilder|Post whereUnsignedIntegerNotNullable($value)
  * @method static EloquentBuilder|Post whereUnsignedIntegerNullable($value)
  * @method static EloquentBuilder|Post whereUnsignedMediumIntegerNotNullable($value)

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/__snapshots__/Test__test__1.php
@@ -52,8 +52,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property string|null $unsigned_decimal_nullable
- * @property string $unsigned_decimal_not_nullable
  * @property integer|null $boolean_nullable
  * @property integer $boolean_not_nullable
  * @property string|null $enum_nullable
@@ -149,8 +147,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Builders\EMaterialQueryBuilder|Post whereTinyIntegerNullable($value)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Builders\EMaterialQueryBuilder|Post whereUnsignedBigIntegerNotNullable($value)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Builders\EMaterialQueryBuilder|Post whereUnsignedBigIntegerNullable($value)
- * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Builders\EMaterialQueryBuilder|Post whereUnsignedDecimalNotNullable($value)
- * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Builders\EMaterialQueryBuilder|Post whereUnsignedDecimalNullable($value)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Builders\EMaterialQueryBuilder|Post whereUnsignedIntegerNotNullable($value)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Builders\EMaterialQueryBuilder|Post whereUnsignedIntegerNullable($value)
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Builders\EMaterialQueryBuilder|Post whereUnsignedMediumIntegerNotNullable($value)

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/__snapshots__/Test__test__1.php
@@ -70,8 +70,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property string|null $unsigned_decimal_nullable
- * @property string $unsigned_decimal_not_nullable
  * @property integer|null $boolean_nullable
  * @property integer $boolean_not_nullable
  * @property string|null $enum_nullable
@@ -167,8 +165,6 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereTinyIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedMediumIntegerNotNullable($value)

--- a/tests/Console/ModelsCommand/Interfaces/Models/User.php
+++ b/tests/Console/ModelsCommand/Interfaces/Models/User.php
@@ -19,6 +19,11 @@ class User extends Model implements Authenticatable
         // TODO: Implement getAuthIdentifier() method.
     }
 
+    public function getAuthPasswordName()
+    {
+        // TODO: Implement getAuthPasswordName() method.
+    }
+
     public function getAuthPassword()
     {
         // TODO: Implement getAuthPassword() method.

--- a/tests/Console/ModelsCommand/MagicWhere/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/MagicWhere/__snapshots__/Test__test__1.php
@@ -46,8 +46,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property string|null $unsigned_decimal_nullable
- * @property string $unsigned_decimal_not_nullable
  * @property integer|null $boolean_nullable
  * @property integer $boolean_not_nullable
  * @property string|null $enum_nullable

--- a/tests/Console/ModelsCommand/RelationCountProperties/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/RelationCountProperties/__snapshots__/Test__test__1.php
@@ -47,8 +47,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property string|null $unsigned_decimal_nullable
- * @property string $unsigned_decimal_not_nullable
  * @property integer|null $boolean_nullable
  * @property integer $boolean_not_nullable
  * @property string|null $enum_nullable
@@ -145,8 +143,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereTinyIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedBigIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedDecimalNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedIntegerNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Post whereUnsignedMediumIntegerNotNullable($value)

--- a/tests/Console/ModelsCommand/migrations/____posts_table.php
+++ b/tests/Console/ModelsCommand/migrations/____posts_table.php
@@ -67,9 +67,6 @@ class PostsTable extends Migration
             $table->decimal('decimal_nullable')->nullable();
             $table->decimal('decimal_not_nullable');
 
-            $table->unsignedDecimal('unsigned_decimal_nullable')->nullable();
-            $table->unsignedDecimal('unsigned_decimal_not_nullable');
-
             $table->boolean('boolean_nullable')->nullable();
             $table->boolean('boolean_not_nullable');
 


### PR DESCRIPTION
## Summary

This pull request resolves #1509.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`


## Overview of responses to each issue

* [x] PHPUnit version upgrade

  I have expanded the version range accordingly. There was no corresponding breaking change in PHPUnit 10, so there is no need to modify the test code.

* [x] Support for Doctrine DBAL removal

  I have migrated the minimal necessary code for the Laravel IDE Helper from the implementation existing in Laravel 10, which was removed in Laravel 11.

  Ideally, it should be implemented in a newly created Laravel API with the removal of Doctrine DBAL, but the version with that modification would be `laravel/framework > 10` only. We'll need to support `<=10` for a while, so this is the way to go for now.

* [x] Migration method changes for floating-point types

  I have removed the corresponding migration method from the test. Only `$table->unsignedDecimal()` was applicable.

  I don't think there is any need to worry about narrowing the scope of the test.

  * The migration method itself is not the target of the test; it is simply used to create the test table.
  * This feature has already been deprecated and has been removed in the latest version.
  * Tests where the database-side floating-point type is converted to `string` are covered by other tests such as `$table->decimal()`.

* [x] Adding methods to `Authenticatable` contract

  I have implemented a new method in the Authenticatable contract. Like any other request method, it is simply declared and empty.

## Test Results

* In my repository from which this pull request is based, I have confirmed that all existing tests pass with newer versions including php-8.3 and Laravel 11. CI results can be seen from [here](https://github.com/KentarouTakeda/barryvdh-laravel-ide-helper/actions/runs/7813420496).
* CI testing is done with SQLite only. I set up PostgreSQL and MySQL in my local environment and confirmed that the `User` class (`users` table and its migration) in the initial state of Laravel produced the same execution results as before.
   * SQL Server was not confirmed as it was difficult to set up.

I'm looking forward to continuing to use the great tools you've created in Laravel 11. Please let us know if you have any feedback regarding this pull request. Thank you for confirmation.

Regards.
