### PR TITLE
Bump minimum PHP version to 8.1 & misc maintenance

### DIFF
--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   normalize:
     timeout-minutes: 15
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/fix-code-style.yml
+++ b/.github/workflows/fix-code-style.yml
@@ -7,7 +7,7 @@ jobs:
   fix-style:
     name: Fix Code Style
     timeout-minutes: 15
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COMPOSER_NO_INTERACTION: 1
 

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
     php-laravel-integration-tests:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         timeout-minutes: 15
         env:
             COMPOSER_NO_INTERACTION: 1

--- a/.github/workflows/run-static-analysis.yml
+++ b/.github/workflows/run-static-analysis.yml
@@ -9,7 +9,7 @@ on:
 jobs:
     build:
         timeout-minutes: 15
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-22.04, windows-2019]
         php: [8.3, 8.2, 8.1]
         laravel: [10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,6 @@ jobs:
         php: [8.3, 8.2, 8.1]
         laravel: [10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
-        dependency-version: [prefer-lowest, prefer-stable]
         exclude:
           - php: 8.1
             laravel: 11.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,16 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-### Changed
-- Use of doctrine/dbal [#1512 / barryvdh](https://github.com/barryvdh/laravel-ide-helper/pull/1512) 
-  With this functionality gone, a few changes have been made:
-- support for custom datatypes has been dropped (config `custom_db_types`) unknown data types default to `string` now and to fix the type, add a proper cast in Eloquent
-- You _might_ have top-level dependency on doctrine/dbal. This may have been in the past due to ide-helper, we suggest to check if you still need it and remove it otherwise
-
 ### Added
 - Support for Laravel 11 [#1520 / KentarouTakeda](https://github.com/barryvdh/laravel-ide-helper/pull/1520)
+
+### Removed
+- Support for Laravel 9 and use of doctrine/dbal [#1512 / barryvdh](https://github.com/barryvdh/laravel-ide-helper/pull/1512) 
+  With this functionality gone, a few changes have been made:
+  - support for custom datatypes has been dropped (config `custom_db_types`) unknown data types default to `string` now and to fix the type, add a proper cast in Eloquent
+  - You _might_ have top-level dependency on doctrine/dbal. This may have been in the past due to ide-helper, we suggest to check if you still need it and remove it otherwise
+  - Minimum PHP version, due to Laravel 10, is now PHP 8.1
+
 
 2024-02-15, 2.15.1
 ------------------

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "illuminate/view": "^9 || ^10 || ^11",
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^8 || ^9",
-        "phpunit/phpunit": "^9 || ^10.5",
+        "phpunit/phpunit": "^10.5",
         "spatie/phpunit-snapshot-assertions": "^4 || ^5",
         "vimeo/psalm": "^5.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "barryvdh/reflection-docblock": "^2.1.1",
         "composer/class-map-generator": "^1.0",

--- a/tests/Console/ModelsCommand/AdvancedCasts/Test.php
+++ b/tests/Console/ModelsCommand/AdvancedCasts/Test.php
@@ -6,18 +6,11 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AdvancedCasts;
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
-use Illuminate\Foundation\Application;
 
 class Test extends AbstractModelsCommand
 {
     public function test(): void
     {
-        if (!version_compare(Application::VERSION, '8.28', '>=')) {
-            $this->markTestSkipped(
-                'This test only works in Laravel >= 8.28'
-            );
-        }
-
         $command = $this->app->make(ModelsCommand::class);
 
         $tester = $this->runCommand($command, [

--- a/tests/Console/ModelsCommand/GenerateBasicPhpDocWithEnumDefaults/Test.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpDocWithEnumDefaults/Test.php
@@ -11,12 +11,6 @@ class Test extends AbstractModelsCommand
 {
     public function test(): void
     {
-        if (!version_compare(PHP_VERSION, '8.1', '>=')) {
-            $this->markTestSkipped(
-                'This test only works in PHP >= 8.1'
-            );
-        }
-
         $command = $this->app->make(ModelsCommand::class);
 
         $tester = $this->runCommand($command, [


### PR DESCRIPTION
## Summary
- Bump minimum PHP version to 8.1 & misc maintenance
  Laravel 10 doesn't support 8.0 anyway and our github actions already reflect that and don't test this version
- Remove phpunit 9
  It's not required anymore, Laravel 10+ support phpunit 10+
- gha: remove unused matrix dimension `dependency-version` (we use `stability`)
- gha: bump runner os to ubuntu-22.04
- tests: remove outdated version checks

I also took the library and adapted the CHANGELOG slightly, to make it also clear that doctrine/dbal removal actually means Laravel 9 goes out of support, too.

- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
