### PR TITLE
[3.x] Use official ReflectionDocBlock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "illuminate/filesystem": "^10 || ^11",
         "illuminate/support": "^10 || ^11",
         "nikic/php-parser": "^4.18 || ^5",
+        "phpdocumentor/reflection-docblock": "^5.3",
         "phpdocumentor/type-resolver": "^1.1.0"
     },
     "require-dev": {

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -11,6 +11,7 @@
 
 namespace Barryvdh\LaravelIdeHelper;
 
+use Barryvdh\LaravelIdeHelper\DocBlock\DocBlockBuilder;
 use Closure;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
@@ -18,7 +19,6 @@ use Illuminate\Support\Facades\Facade;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlock\Serializer;
 use phpDocumentor\Reflection\DocBlock\Tags\Method as MethodTag;
-use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\Types\Context;
 use ReflectionClass;
 use Throwable;
@@ -87,11 +87,8 @@ class Alias
             //Create a DocBlock
             $this->phpdocContext = new Context($this->namespace, $this->classAliases);
             $reflector = new ReflectionClass($alias);
-            if ($reflector->getDocComment()) {
-                $this->phpdoc = (DocBlockFactory::createInstance())->create($reflector, $this->phpdocContext);
-            } else {
-                $this->phpdoc =  new DocBlock('', null, [], $this->phpdocContext);
-            }
+
+            $this->phpdoc = DocBlockBuilder::createFromReflector($reflector, $this->phpdocContext);
         }
 
         if ($facade === '\Illuminate\Database\Eloquent\Model') {
@@ -440,18 +437,13 @@ class Alias
             // we can perform reflection on the class and
             // add in the original class DocBlock
             if (count($this->phpdoc->getTags()) === 0) {
-
                 $reflector = new ReflectionClass($this->root);
-                if ($reflector->getDocComment()) {
-                    $this->phpdoc = (DocBlockFactory::createInstance())->create($reflector, $this->phpdocContext);
-                } else {
-                    $this->phpdoc =  new DocBlock('', null, [], $this->phpdocContext);
-                }
+                $this->phpdoc = DocBlockBuilder::createFromReflector($reflector, $this->phpdocContext);
             }
         }
 
         $this->removeDuplicateMethodsFromPhpDoc();
-        return $serializer->getDocComment($this->phpdoc);
+        return $serializer->getDocComment($this->phpdoc->getDocBlock());
     }
 
     /**

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -45,7 +45,6 @@ use phpDocumentor\Reflection\DocBlock\StandardTagFactory;
 use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Reflection\DocBlock\TagFactory;
 use phpDocumentor\Reflection\DocBlock\Tags\BaseTag;
-use phpDocumentor\Reflection\DocBlock\Tags\Property;
 use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\TypeResolver;
@@ -910,7 +909,7 @@ class ModelsCommand extends Command
             }
 
             if (!$this->reset) {
-              $tags = $existingTags;
+                $tags = $existingTags;
             }
         }
 
@@ -980,22 +979,20 @@ class ModelsCommand extends Command
              * @see https://www.jetbrains.com/help/phpstorm/php-unnecessary-fully-qualified-name.html
              */
             $tags[] = $tagFactory->create('@noinspection PhpUnnecessaryFullyQualifiedNameInspection', $phpDocContext);
-
         }
 
         $serializer = new Serializer();
 
         if ($this->write_mixin) {
-
             // remove all mixin tags prefixed with IdeHelper
-            $mixinTags = array_filter($existingTags, function(Tag $tag) {
+            $mixinTags = array_filter($existingTags, function (Tag $tag) {
                 return !($tag instanceof BaseTag) || !Str::startsWith($tag->getDescription(), 'IdeHelper');
             });
 
             $mixinClassName = "IdeHelper{$classname}";
             $mixinTags[] = $tagFactory->create("@mixin {$mixinClassName}", $phpDocContext);
 
-            $tags = array_filter($tags, function(Tag $tag) {
+            $tags = array_filter($tags, function (Tag $tag) {
                 return !($tag instanceof BaseTag) || !Str::startsWith($tag->getDescription(), 'IdeHelper');
             });
 
@@ -1045,7 +1042,7 @@ class ModelsCommand extends Command
         return $output . "{}\n}\n\n";
     }
 
-    private function getTagFactory() : TagFactory
+    private function getTagFactory(): TagFactory
     {
         $fqsenResolver = new FqsenResolver();
         $tagFactory = new StandardTagFactory($fqsenResolver);
@@ -1227,7 +1224,7 @@ class ModelsCommand extends Command
      *
      * @return null|string
      */
-    protected function getCommentFromDocBlock(\ReflectionMethod $reflection) : ?string
+    protected function getCommentFromDocBlock(\ReflectionMethod $reflection): ?string
     {
         if (!$reflection->getDocComment()) {
             return '';
@@ -1236,7 +1233,7 @@ class ModelsCommand extends Command
         $phpDocContext = (new ContextFactory())->createFromReflector($reflection);
         $phpdoc = (DocBlockFactory::createInstance())->create($reflection, $phpDocContext);
 
-        foreach($phpdoc->getTagsByName('comment') as $tag) {
+        foreach ($phpdoc->getTagsByName('comment') as $tag) {
             return $tag;
         }
 
@@ -1250,7 +1247,7 @@ class ModelsCommand extends Command
      *
      * @return null|string
      */
-    protected function getReturnTypeFromDocBlock(\ReflectionMethod $reflection, \Reflector $reflectorForContext = null) : ?string
+    protected function getReturnTypeFromDocBlock(\ReflectionMethod $reflection, \Reflector $reflectorForContext = null): ?string
     {
         if (!$reflection->getDocComment()) {
             return null;

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1004,6 +1004,14 @@ class ModelsCommand extends Command
             }
         }
 
+        $tags = collect($tags)->unique(function (Tag $tag) {
+            if (method_exists($tag, 'getVariableName')) {
+                return $tag->getName() . ' ' . $tag->getVariableName();
+            }
+            return (string) $tag;
+
+        })->toArray();
+
         $phpdoc = new DocBlock($summary ?: '', $description, $tags, $phpDocContext);
         $docComment = $serializer->getDocComment($phpdoc);
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -12,6 +12,7 @@
 namespace Barryvdh\LaravelIdeHelper\Console;
 
 use Barryvdh\LaravelIdeHelper\Contracts\ModelHookInterface;
+use Barryvdh\LaravelIdeHelper\TypeResolver\LocalFsqenResolver;
 use Composer\ClassMapGenerator\ClassMapGenerator;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Database\Eloquent\Castable;
@@ -46,7 +47,6 @@ use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Reflection\DocBlock\TagFactory;
 use phpDocumentor\Reflection\DocBlock\Tags\BaseTag;
 use phpDocumentor\Reflection\DocBlockFactory;
-use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\ContextFactory;
 use ReflectionClass;
@@ -1044,7 +1044,7 @@ class ModelsCommand extends Command
 
     private function getTagFactory(): TagFactory
     {
-        $fqsenResolver = new FqsenResolver();
+        $fqsenResolver = new LocalFsqenResolver();
         $tagFactory = new StandardTagFactory($fqsenResolver);
         $descriptionFactory = new DescriptionFactory($tagFactory);
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -42,6 +42,8 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use phpDocumentor\Reflection\DocBlock\Tags\Generic;
+use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\Types\ContextFactory;
 use ReflectionClass;
 use ReflectionNamedType;
@@ -1212,21 +1214,20 @@ class ModelsCommand extends Command
      *
      * @return null|string
      */
-    protected function getCommentFromDocBlock(\ReflectionMethod $reflection)
+    protected function getCommentFromDocBlock(\ReflectionMethod $reflection) : ?string
     {
-        $phpDocContext = (new ContextFactory())->createFromReflector($reflection);
-        $context = new Context(
-            $phpDocContext->getNamespace(),
-            $phpDocContext->getNamespaceAliases()
-        );
-        $comment = '';
-        $phpdoc = new DocBlock($reflection, $context);
-
-        if ($phpdoc->hasTag('comment')) {
-            $comment = $phpdoc->getTagsByName('comment')[0]->getContent();
+        if (!$reflection->getDocComment()) {
+            return '';
         }
 
-        return $comment;
+        $phpDocContext = (new ContextFactory())->createFromReflector($reflection);
+        $phpdoc = (DocBlockFactory::createInstance())->create($reflection->getDocComment(), $phpDocContext);
+
+        if (!$phpdoc->hasTag('comment')) {
+            return '';
+        }
+
+        return $phpdoc->getTagsByName('comment')[0] ?: '';
     }
 
     /**

--- a/src/DocBlock/DocBlockBuilder.php
+++ b/src/DocBlock/DocBlockBuilder.php
@@ -81,6 +81,10 @@ class DocBlockBuilder
         $this->description = $description;
     }
 
+    public function getContext()
+    {
+        return $this->context;
+    }
     public function getTags()
     {
         return $this->tags;
@@ -95,6 +99,7 @@ class DocBlockBuilder
 
     public function hasTag(string $name): bool
     {
+        /** @var Tag $tag */
         foreach ($this->tags as $tag) {
             if ($tag->getName() === $name) {
                 return true;
@@ -102,6 +107,22 @@ class DocBlockBuilder
         }
 
         return false;
+    }
+
+    public function getTagsByName($name)
+    {
+        $result = [];
+
+        /** @var Tag $tag */
+        foreach ($this->tags as $tag) {
+            if ($tag->getName() != $name) {
+                continue;
+            }
+
+            $result[] = $tag;
+        }
+
+        return $result;
     }
 
     public function appendTag(Tag $tag)

--- a/src/DocBlock/DocBlockBuilder.php
+++ b/src/DocBlock/DocBlockBuilder.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper\DocBlock;
+
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
+use phpDocumentor\Reflection\DocBlock\StandardTagFactory;
+use phpDocumentor\Reflection\DocBlock\Tag;
+use phpDocumentor\Reflection\DocBlock\TagFactory;
+use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\TypeResolver;
+use phpDocumentor\Reflection\Types\Context;
+
+class DocBlockBuilder
+{
+    /** @var $tagFactory TagFactory  */
+    private $tagFactory = null;
+
+    private function __construct(
+        protected string $summary = '',
+        protected ?DocBlock\Description $description = null,
+        protected array $tags = [],
+        protected ?Context $context = null
+    ) {
+    }
+
+    public static function createFromReflector(\Reflector $reflector, ?Context $context = null): static
+    {
+        if ($doc = $reflector->getDocComment()) {
+            $docblock = DocBlockFactory::createInstance()->create($doc, $context);
+
+            return new static(
+                $docblock->getSummary(),
+                $docblock->getDescription(),
+                $docblock->getTags(),
+                $docblock->getContext()
+            );
+        }
+
+        return static::create('', null, [], $context);
+    }
+
+    public static function create(
+        string $summary = '',
+        ?DocBlock\Description $description = null,
+        array $tags = null,
+        ?Context $context = null
+    ): static {
+        return new static($summary, $description, $tags, $context);
+    }
+
+    public function getDocBlock(): DocBlock
+    {
+        $tags = collect($this->tags)->unique(function (Tag $tag) {
+            if (method_exists($tag, 'getVariableName')) {
+                return $tag->getName() . ' ' . $tag->getVariableName();
+            }
+            return (string) $tag;
+        })->toArray();
+
+        return new DocBlock($this->summary, $this->description, $tags, $this->context);
+    }
+
+    public function getSummary(): ?string
+    {
+        return $this->summary;
+    }
+
+    public function setSummary(string $summary)
+    {
+        $this->summary = $summary;
+    }
+
+    public function getDescription(): ?DocBlock\Description
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?DocBlock\Description $description)
+    {
+        $this->description = $description;
+    }
+
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    public function appendTagline(string $tagline)
+    {
+        $tag = $this->getTagFactory()->create($tagline, $this->context);
+
+        $this->appendTag($tag);
+    }
+
+    public function hasTag(string $name): bool
+    {
+        foreach ($this->tags as $tag) {
+            if ($tag->getName() === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function appendTag(Tag $tag)
+    {
+        $this->tags[] = $tag;
+    }
+
+    public function removeTag(Tag $tagToRemove)
+    {
+        foreach ($this->tags as $i => $tag) {
+            if ($tag === $tagToRemove) {
+                unset($this->tags[$i]);
+                break;
+            }
+        }
+    }
+
+    public function clearTags()
+    {
+        $this->tags = [];
+    }
+
+    private function getTagFactory(): TagFactory
+    {
+        if ($this->tagFactory === null) {
+            $fqsenResolver = new LocalFsqenResolver();
+            $tagFactory = new StandardTagFactory($fqsenResolver);
+            $descriptionFactory = new DescriptionFactory($tagFactory);
+
+            $tagFactory->addService($descriptionFactory);
+            $tagFactory->addService(new TypeResolver($fqsenResolver));
+
+            $this->tagFactory = $tagFactory;
+        }
+        return $this->tagFactory;
+    }
+}

--- a/src/DocBlock/LocalFsqenResolver.php
+++ b/src/DocBlock/LocalFsqenResolver.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Barryvdh\LaravelIdeHelper\TypeResolver;
+namespace Barryvdh\LaravelIdeHelper\DocBlock;
 
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\FqsenResolver;

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -2,8 +2,8 @@
 
 namespace Barryvdh\LaravelIdeHelper;
 
+use Barryvdh\LaravelIdeHelper\DocBlock\DocBlockBuilder;
 use Barryvdh\Reflection\DocBlock;
-use Barryvdh\Reflection\DocBlock\Tag;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Support\Collection;
 
@@ -35,7 +35,7 @@ class Macro extends Method
      */
     protected function initPhpDoc($method)
     {
-        $this->phpdoc = new DocBlock($method);
+        $this->phpdoc = DocBlockBuilder::createFromReflector($method);
 
         $this->addLocationToPhpDoc();
 
@@ -56,7 +56,7 @@ class Macro extends Method
                 $name = $parameter->isVariadic() ? '...' : '';
                 $name .= '$' . $parameter->getName();
 
-                $this->phpdoc->appendTag(Tag::createInstance("@param {$type} {$name}"));
+                $this->phpdoc->appendTagline("@param {$type} {$name}");
             }
         }
 
@@ -73,7 +73,7 @@ class Macro extends Method
                 $type .= $return->allowsNull() ? '|null' : '';
             }
 
-            $this->phpdoc->appendTag(Tag::createInstance("@return {$type}"));
+            $this->phpdoc->appendTagLine("@return {$type}");
         }
     }
 
@@ -109,9 +109,9 @@ class Macro extends Method
             });
 
         if ($enclosingMethod) {
-            $this->phpdoc->appendTag(Tag::createInstance(
+            $this->phpdoc->appendTagLine(
                 '@see \\' . $enclosingClass->getName() . '::' . $enclosingMethod->getName() . '()'
-            ));
+            );
         }
     }
 

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -6,6 +6,7 @@ use Barryvdh\LaravelIdeHelper\DocBlock\DocBlockBuilder;
 use Barryvdh\Reflection\DocBlock;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Support\Collection;
+use phpDocumentor\Reflection\FqsenResolver;
 
 class Macro extends Method
 {
@@ -64,8 +65,8 @@ class Macro extends Method
         if ($method->hasReturnType() && !$this->phpdoc->hasTag('return')) {
             $builder = EloquentBuilder::class;
             $return = $method->getReturnType();
-
             $type = $this->concatReflectionTypes($return);
+
 
             /** @psalm-suppress UndefinedClass */
             if (!$return instanceof \ReflectionUnionType) {

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -6,7 +6,6 @@ use Barryvdh\LaravelIdeHelper\DocBlock\DocBlockBuilder;
 use Barryvdh\Reflection\DocBlock;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Support\Collection;
-use phpDocumentor\Reflection\FqsenResolver;
 
 class Macro extends Method
 {

--- a/src/Method.php
+++ b/src/Method.php
@@ -13,10 +13,7 @@ namespace Barryvdh\LaravelIdeHelper;
 
 use Barryvdh\LaravelIdeHelper\DocBlock\DocBlockBuilder;
 use Barryvdh\Reflection\DocBlock;
-use Barryvdh\Reflection\DocBlock\Context;
 use Barryvdh\Reflection\DocBlock\Tag;
-use Barryvdh\Reflection\DocBlock\Tag\ParamTag;
-use Barryvdh\Reflection\DocBlock\Tag\ReturnTag;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 use phpDocumentor\Reflection\DocBlock\Serializer;
@@ -234,7 +231,6 @@ class Method
         // Set the changed content
         $this->phpdoc->removeTag($tag);
         $this->phpdoc->appendTagline('@return ' . $returnValue . ' ' . $tag->getDescription());
-
     }
 
     /**

--- a/src/TypeResolver/LocalFsqenResolver.php
+++ b/src/TypeResolver/LocalFsqenResolver.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper\TypeResolver;
+
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\FqsenResolver;
+use phpDocumentor\Reflection\Types\Context;
+
+class LocalFsqenResolver extends FqsenResolver
+{
+    public function resolve(string $fqsen, ?Context $context = null): Fqsen
+    {
+        return new Fqsen($fqsen);
+    }
+}

--- a/tests/Console/ModelsCommand/AdvancedCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/AdvancedCasts/__snapshots__/Test__test__1.php
@@ -17,7 +17,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property \Carbon\CarbonImmutable $cast_to_immutable_date
  * @property \Carbon\CarbonImmutable $cast_to_immutable_custom_datetime
  * @property \Carbon\CarbonImmutable $cast_to_immutable_datetime
- * @property integer $cast_to_timestamp
+ * @property int $cast_to_timestamp
  * @property mixed $cast_to_encrypted
  * @property array $cast_to_encrypted_array
  * @property \Illuminate\Support\Collection $cast_to_encrypted_collection

--- a/tests/Console/ModelsCommand/AllowGlobDirectory/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/AllowGlobDirectory/__snapshots__/Test__test__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AllowGlobDirectory\Services\Post\Models\Post
  *
- * @property integer $id
+ * @property int $id
  * @property string|null $char_nullable
  * @property string $char_not_nullable
  * @property string|null $string_nullable
@@ -20,34 +20,34 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $medium_text_not_nullable
  * @property string|null $long_text_nullable
  * @property string $long_text_not_nullable
- * @property integer|null $integer_nullable
- * @property integer $integer_not_nullable
- * @property integer|null $tiny_integer_nullable
- * @property integer $tiny_integer_not_nullable
- * @property integer|null $small_integer_nullable
- * @property integer $small_integer_not_nullable
- * @property integer|null $medium_integer_nullable
- * @property integer $medium_integer_not_nullable
- * @property integer|null $big_integer_nullable
- * @property integer $big_integer_not_nullable
- * @property integer|null $unsigned_integer_nullable
- * @property integer $unsigned_integer_not_nullable
- * @property integer|null $unsigned_tiny_integer_nullable
- * @property integer $unsigned_tiny_integer_not_nullable
- * @property integer|null $unsigned_small_integer_nullable
- * @property integer $unsigned_small_integer_not_nullable
- * @property integer|null $unsigned_medium_integer_nullable
- * @property integer $unsigned_medium_integer_not_nullable
- * @property integer|null $unsigned_big_integer_nullable
- * @property integer $unsigned_big_integer_not_nullable
+ * @property int|null $integer_nullable
+ * @property int $integer_not_nullable
+ * @property int|null $tiny_integer_nullable
+ * @property int $tiny_integer_not_nullable
+ * @property int|null $small_integer_nullable
+ * @property int $small_integer_not_nullable
+ * @property int|null $medium_integer_nullable
+ * @property int $medium_integer_not_nullable
+ * @property int|null $big_integer_nullable
+ * @property int $big_integer_not_nullable
+ * @property int|null $unsigned_integer_nullable
+ * @property int $unsigned_integer_not_nullable
+ * @property int|null $unsigned_tiny_integer_nullable
+ * @property int $unsigned_tiny_integer_not_nullable
+ * @property int|null $unsigned_small_integer_nullable
+ * @property int $unsigned_small_integer_not_nullable
+ * @property int|null $unsigned_medium_integer_nullable
+ * @property int $unsigned_medium_integer_not_nullable
+ * @property int|null $unsigned_big_integer_nullable
+ * @property int $unsigned_big_integer_not_nullable
  * @property float|null $float_nullable
  * @property float $float_not_nullable
  * @property float|null $double_nullable
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property integer|null $boolean_nullable
- * @property integer $boolean_not_nullable
+ * @property int|null $boolean_nullable
+ * @property int $boolean_not_nullable
  * @property string|null $enum_nullable
  * @property string $enum_not_nullable
  * @property string|null $json_nullable
@@ -68,8 +68,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $timestamp_not_nullable
  * @property string|null $timestamptz_nullable
  * @property string $timestamptz_not_nullable
- * @property integer|null $year_nullable
- * @property integer $year_not_nullable
+ * @property int|null $year_nullable
+ * @property int $year_not_nullable
  * @property string|null $binary_nullable
  * @property string $binary_not_nullable
  * @property string|null $uuid_nullable

--- a/tests/Console/ModelsCommand/ArrayCastsWithComment/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/ArrayCastsWithComment/__snapshots__/Test__test__1.php
@@ -7,18 +7,16 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ArrayCastsWithCo
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ArrayCastsWithComment\Models\ArrayCastsWithComment
- *
- * @property array<int, string>|null $cast_to_array -- These three should not be duplicated
- * @property array<int, string> $cast_to_json some-description
- * @property \Illuminate\Support\Collection<int, string> $cast_to_collection some-description
+ * @property array<int,string>|null $cast_to_array -- These three should not be duplicated
+ * @property array<int,string> $cast_to_json some-description
+ * @property \Illuminate\Support\Collection<int,string> $cast_to_collection some-description
  * @property array|null $cast_to_encrypted_array -- These three are OK (no types)
  * @property array $cast_to_encrypted_json some-description
  * @property \Illuminate\Support\Collection $cast_to_encrypted_collection some-description
  * @property string $cast_to_string -- The next three are OK (no description), this not included
- * @property array<int, string>|null $cast_to_immutable_date
- * @property array<int, string> $cast_to_immutable_date_serialization
- * @property \Illuminate\Support\Collection<int, string> $cast_to_immutable_custom_datetime
+ * @property array<int,string>|null $cast_to_immutable_date
+ * @property array<int,string> $cast_to_immutable_date_serialization
+ * @property \Illuminate\Support\Collection<int,string> $cast_to_immutable_custom_datetime
  * @property string $cast_to_int
  * @property string $cast_to_integer
  * @property string $cast_to_real
@@ -28,9 +26,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $cast_to_bool
  * @property string $cast_to_boolean
  * @property string $cast_to_object
- * @property array $cast_to_array
- * @property array $cast_to_json
- * @property \Illuminate\Support\Collection $cast_to_collection
  * @property string $cast_to_date
  * @property string $cast_to_datetime
  * @property string $cast_to_date_serialization

--- a/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Attributes\Models\Simple
  *
- * @property integer $id
+ * @property int $id
  * @property int $diverging_type_hinted_get_and_set
  * @property string|null $name
  * @property-read mixed $non_type_hinted_get

--- a/tests/Console/ModelsCommand/Comment/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Comment/__snapshots__/Test__test__1.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Comment\Models\Simple
  *
- * @property integer $id
+ * @property int $id
  * @property string $both_same_name I'm a getter
  * @property string $both_without_getter_comment
  * @property-read string $faker_comment

--- a/tests/Console/ModelsCommand/CustomCollection/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/CustomCollection/__snapshots__/Test__test__1.php
@@ -11,11 +11,11 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomCollection\Models\Simple
  *
- * @property integer $id
+ * @property int $id
  * @property-read SimpleCollection<int, Simple> $relationHasMany
  * @property-read int|null $relation_has_many_count
- * @method static SimpleCollection<int, static> all($columns = ['*'])
- * @method static SimpleCollection<int, static> get($columns = ['*'])
+ * @method static void SimpleCollection() <int, static> all($columns = ['*'])
+ * @method static void SimpleCollection() <int, static> get($columns = ['*'])
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()

--- a/tests/Console/ModelsCommand/CustomPhpdocTags/__snapshots__/Test__testNoSpaceAfterCustomPhpdocTag__1.php
+++ b/tests/Console/ModelsCommand/CustomPhpdocTags/__snapshots__/Test__testNoSpaceAfterCustomPhpdocTag__1.php
@@ -11,8 +11,8 @@ use Illuminate\Database\Eloquent\Model;
  * the class phpdoc is written back, one is inserted.
  *
  * @link https://github.com/barryvdh/laravel-ide-helper/issues/666
- * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
- * @property integer $id
+ * @SuppressWarnings (PHPMD.ExcessiveClassComplexity)
+ * @property int $id
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()

--- a/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
@@ -15,7 +15,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGenerateP
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Models\Post
  *
- * @property integer $id
+ * @property int $id
  * @property string|null $char_nullable
  * @property string $char_not_nullable
  * @property string|null $string_nullable
@@ -26,34 +26,34 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGenerateP
  * @property string $medium_text_not_nullable
  * @property string|null $long_text_nullable
  * @property string $long_text_not_nullable
- * @property integer|null $integer_nullable
- * @property integer $integer_not_nullable
- * @property integer|null $tiny_integer_nullable
- * @property integer $tiny_integer_not_nullable
- * @property integer|null $small_integer_nullable
- * @property integer $small_integer_not_nullable
- * @property integer|null $medium_integer_nullable
- * @property integer $medium_integer_not_nullable
- * @property integer|null $big_integer_nullable
- * @property integer $big_integer_not_nullable
- * @property integer|null $unsigned_integer_nullable
- * @property integer $unsigned_integer_not_nullable
- * @property integer|null $unsigned_tiny_integer_nullable
- * @property integer $unsigned_tiny_integer_not_nullable
- * @property integer|null $unsigned_small_integer_nullable
- * @property integer $unsigned_small_integer_not_nullable
- * @property integer|null $unsigned_medium_integer_nullable
- * @property integer $unsigned_medium_integer_not_nullable
- * @property integer|null $unsigned_big_integer_nullable
- * @property integer $unsigned_big_integer_not_nullable
+ * @property int|null $integer_nullable
+ * @property int $integer_not_nullable
+ * @property int|null $tiny_integer_nullable
+ * @property int $tiny_integer_not_nullable
+ * @property int|null $small_integer_nullable
+ * @property int $small_integer_not_nullable
+ * @property int|null $medium_integer_nullable
+ * @property int $medium_integer_not_nullable
+ * @property int|null $big_integer_nullable
+ * @property int $big_integer_not_nullable
+ * @property int|null $unsigned_integer_nullable
+ * @property int $unsigned_integer_not_nullable
+ * @property int|null $unsigned_tiny_integer_nullable
+ * @property int $unsigned_tiny_integer_not_nullable
+ * @property int|null $unsigned_small_integer_nullable
+ * @property int $unsigned_small_integer_not_nullable
+ * @property int|null $unsigned_medium_integer_nullable
+ * @property int $unsigned_medium_integer_not_nullable
+ * @property int|null $unsigned_big_integer_nullable
+ * @property int $unsigned_big_integer_not_nullable
  * @property float|null $float_nullable
  * @property float $float_not_nullable
  * @property float|null $double_nullable
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property integer|null $boolean_nullable
- * @property integer $boolean_not_nullable
+ * @property int|null $boolean_nullable
+ * @property int $boolean_not_nullable
  * @property string|null $enum_nullable
  * @property string $enum_not_nullable
  * @property string|null $json_nullable
@@ -74,8 +74,8 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGenerateP
  * @property string $timestamp_not_nullable
  * @property string|null $timestamptz_nullable
  * @property string $timestamptz_not_nullable
- * @property integer|null $year_nullable
- * @property integer $year_not_nullable
+ * @property int|null $year_nullable
+ * @property int $year_not_nullable
  * @property string|null $binary_nullable
  * @property string $binary_not_nullable
  * @property string|null $uuid_nullable

--- a/tests/Console/ModelsCommand/Factories/__snapshots__/Test__testFactory__1.php
+++ b/tests/Console/ModelsCommand/Factories/__snapshots__/Test__testFactory__1.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Models\ModelWithCustomNamespace
  *
- * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\CustomSpace\ModelWithCustomNamespaceFactory factory($count = null, $state = [])
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\CustomSpace\ModelWithCustomNamespaceFactory factory(mixed $count, mixed $state)
  * @method static \Illuminate\Database\Eloquent\Builder|ModelWithCustomNamespace newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|ModelWithCustomNamespace newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|ModelWithCustomNamespace query()
@@ -43,7 +43,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Models\ModelWithFactory
  *
- * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Factories\ModelWithFactoryFactory factory($count = null, $state = [])
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Factories\ModelWithFactoryFactory factory(mixed $count, mixed $state)
  * @method static \Illuminate\Database\Eloquent\Builder|ModelWithFactory newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|ModelWithFactory newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|ModelWithFactory query()
@@ -62,7 +62,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Models
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Models\ModelWithNestedFactory
  *
- * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Factories\ModelWithNestedFactoryFactory factory($count = null, $state = [])
+ * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Factories\ModelWithNestedFactoryFactory factory(mixed $count, mixed $state)
  * @method static \Illuminate\Database\Eloquent\Builder|ModelWithNestedFactory newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|ModelWithNestedFactory newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|ModelWithNestedFactory query()

--- a/tests/Console/ModelsCommand/GenerateBasicPhpDocWithEnumDefaults/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpDocWithEnumDefaults/__snapshots__/Test__test__1.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhpDocWithEnumDefaults\Models\Post
  *
- * @property integer $id
+ * @property int $id
  * @property string|null $char_nullable
  * @property string $char_not_nullable
  * @property string|null $string_nullable
@@ -22,34 +22,34 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $medium_text_not_nullable
  * @property string|null $long_text_nullable
  * @property string $long_text_not_nullable
- * @property integer|null $integer_nullable
- * @property integer $integer_not_nullable
- * @property integer|null $tiny_integer_nullable
- * @property integer $tiny_integer_not_nullable
- * @property integer|null $small_integer_nullable
- * @property integer $small_integer_not_nullable
- * @property integer|null $medium_integer_nullable
- * @property integer $medium_integer_not_nullable
- * @property integer|null $big_integer_nullable
- * @property integer $big_integer_not_nullable
- * @property integer|null $unsigned_integer_nullable
- * @property integer $unsigned_integer_not_nullable
- * @property integer|null $unsigned_tiny_integer_nullable
- * @property integer $unsigned_tiny_integer_not_nullable
- * @property integer|null $unsigned_small_integer_nullable
- * @property integer $unsigned_small_integer_not_nullable
- * @property integer|null $unsigned_medium_integer_nullable
- * @property integer $unsigned_medium_integer_not_nullable
- * @property integer|null $unsigned_big_integer_nullable
- * @property integer $unsigned_big_integer_not_nullable
+ * @property int|null $integer_nullable
+ * @property int $integer_not_nullable
+ * @property int|null $tiny_integer_nullable
+ * @property int $tiny_integer_not_nullable
+ * @property int|null $small_integer_nullable
+ * @property int $small_integer_not_nullable
+ * @property int|null $medium_integer_nullable
+ * @property int $medium_integer_not_nullable
+ * @property int|null $big_integer_nullable
+ * @property int $big_integer_not_nullable
+ * @property int|null $unsigned_integer_nullable
+ * @property int $unsigned_integer_not_nullable
+ * @property int|null $unsigned_tiny_integer_nullable
+ * @property int $unsigned_tiny_integer_not_nullable
+ * @property int|null $unsigned_small_integer_nullable
+ * @property int $unsigned_small_integer_not_nullable
+ * @property int|null $unsigned_medium_integer_nullable
+ * @property int $unsigned_medium_integer_not_nullable
+ * @property int|null $unsigned_big_integer_nullable
+ * @property int $unsigned_big_integer_not_nullable
  * @property float|null $float_nullable
  * @property float $float_not_nullable
  * @property float|null $double_nullable
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property integer|null $boolean_nullable
- * @property integer $boolean_not_nullable
+ * @property int|null $boolean_nullable
+ * @property int $boolean_not_nullable
  * @property string|null $enum_nullable
  * @property string $enum_not_nullable
  * @property string|null $json_nullable
@@ -70,8 +70,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $timestamp_not_nullable
  * @property string|null $timestamptz_nullable
  * @property string $timestamptz_not_nullable
- * @property integer|null $year_nullable
- * @property integer $year_not_nullable
+ * @property int|null $year_nullable
+ * @property int $year_not_nullable
  * @property string|null $binary_nullable
  * @property string $binary_not_nullable
  * @property string|null $uuid_nullable

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdoc/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdoc/__snapshots__/Test__test__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhpdoc\Models\Post
  *
- * @property integer $id
+ * @property int $id
  * @property string|null $char_nullable
  * @property string $char_not_nullable
  * @property string|null $string_nullable
@@ -20,34 +20,34 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $medium_text_not_nullable
  * @property string|null $long_text_nullable
  * @property string $long_text_not_nullable
- * @property integer|null $integer_nullable
- * @property integer $integer_not_nullable
- * @property integer|null $tiny_integer_nullable
- * @property integer $tiny_integer_not_nullable
- * @property integer|null $small_integer_nullable
- * @property integer $small_integer_not_nullable
- * @property integer|null $medium_integer_nullable
- * @property integer $medium_integer_not_nullable
- * @property integer|null $big_integer_nullable
- * @property integer $big_integer_not_nullable
- * @property integer|null $unsigned_integer_nullable
- * @property integer $unsigned_integer_not_nullable
- * @property integer|null $unsigned_tiny_integer_nullable
- * @property integer $unsigned_tiny_integer_not_nullable
- * @property integer|null $unsigned_small_integer_nullable
- * @property integer $unsigned_small_integer_not_nullable
- * @property integer|null $unsigned_medium_integer_nullable
- * @property integer $unsigned_medium_integer_not_nullable
- * @property integer|null $unsigned_big_integer_nullable
- * @property integer $unsigned_big_integer_not_nullable
+ * @property int|null $integer_nullable
+ * @property int $integer_not_nullable
+ * @property int|null $tiny_integer_nullable
+ * @property int $tiny_integer_not_nullable
+ * @property int|null $small_integer_nullable
+ * @property int $small_integer_not_nullable
+ * @property int|null $medium_integer_nullable
+ * @property int $medium_integer_not_nullable
+ * @property int|null $big_integer_nullable
+ * @property int $big_integer_not_nullable
+ * @property int|null $unsigned_integer_nullable
+ * @property int $unsigned_integer_not_nullable
+ * @property int|null $unsigned_tiny_integer_nullable
+ * @property int $unsigned_tiny_integer_not_nullable
+ * @property int|null $unsigned_small_integer_nullable
+ * @property int $unsigned_small_integer_not_nullable
+ * @property int|null $unsigned_medium_integer_nullable
+ * @property int $unsigned_medium_integer_not_nullable
+ * @property int|null $unsigned_big_integer_nullable
+ * @property int $unsigned_big_integer_not_nullable
  * @property float|null $float_nullable
  * @property float $float_not_nullable
  * @property float|null $double_nullable
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property integer|null $boolean_nullable
- * @property integer $boolean_not_nullable
+ * @property int|null $boolean_nullable
+ * @property int $boolean_not_nullable
  * @property string|null $enum_nullable
  * @property string $enum_not_nullable
  * @property string|null $json_nullable
@@ -68,8 +68,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $timestamp_not_nullable
  * @property string|null $timestamptz_nullable
  * @property string $timestamptz_not_nullable
- * @property integer|null $year_nullable
- * @property integer $year_not_nullable
+ * @property int|null $year_nullable
+ * @property int $year_not_nullable
  * @property string|null $binary_nullable
  * @property string $binary_not_nullable
  * @property string|null $uuid_nullable

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdocCamel/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdocCamel/__snapshots__/Test__test__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhpdocCamel\Models\Post
  *
- * @property integer $id
+ * @property int $id
  * @property string|null $charNullable
  * @property string $charNotNullable
  * @property string|null $stringNullable
@@ -20,34 +20,34 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $mediumTextNotNullable
  * @property string|null $longTextNullable
  * @property string $longTextNotNullable
- * @property integer|null $integerNullable
- * @property integer $integerNotNullable
- * @property integer|null $tinyIntegerNullable
- * @property integer $tinyIntegerNotNullable
- * @property integer|null $smallIntegerNullable
- * @property integer $smallIntegerNotNullable
- * @property integer|null $mediumIntegerNullable
- * @property integer $mediumIntegerNotNullable
- * @property integer|null $bigIntegerNullable
- * @property integer $bigIntegerNotNullable
- * @property integer|null $unsignedIntegerNullable
- * @property integer $unsignedIntegerNotNullable
- * @property integer|null $unsignedTinyIntegerNullable
- * @property integer $unsignedTinyIntegerNotNullable
- * @property integer|null $unsignedSmallIntegerNullable
- * @property integer $unsignedSmallIntegerNotNullable
- * @property integer|null $unsignedMediumIntegerNullable
- * @property integer $unsignedMediumIntegerNotNullable
- * @property integer|null $unsignedBigIntegerNullable
- * @property integer $unsignedBigIntegerNotNullable
+ * @property int|null $integerNullable
+ * @property int $integerNotNullable
+ * @property int|null $tinyIntegerNullable
+ * @property int $tinyIntegerNotNullable
+ * @property int|null $smallIntegerNullable
+ * @property int $smallIntegerNotNullable
+ * @property int|null $mediumIntegerNullable
+ * @property int $mediumIntegerNotNullable
+ * @property int|null $bigIntegerNullable
+ * @property int $bigIntegerNotNullable
+ * @property int|null $unsignedIntegerNullable
+ * @property int $unsignedIntegerNotNullable
+ * @property int|null $unsignedTinyIntegerNullable
+ * @property int $unsignedTinyIntegerNotNullable
+ * @property int|null $unsignedSmallIntegerNullable
+ * @property int $unsignedSmallIntegerNotNullable
+ * @property int|null $unsignedMediumIntegerNullable
+ * @property int $unsignedMediumIntegerNotNullable
+ * @property int|null $unsignedBigIntegerNullable
+ * @property int $unsignedBigIntegerNotNullable
  * @property float|null $floatNullable
  * @property float $floatNotNullable
  * @property float|null $doubleNullable
  * @property float $doubleNotNullable
  * @property string|null $decimalNullable
  * @property string $decimalNotNullable
- * @property integer|null $booleanNullable
- * @property integer $booleanNotNullable
+ * @property int|null $booleanNullable
+ * @property int $booleanNotNullable
  * @property string|null $enumNullable
  * @property string $enumNotNullable
  * @property string|null $jsonNullable
@@ -68,8 +68,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $timestampNotNullable
  * @property string|null $timestamptzNullable
  * @property string $timestamptzNotNullable
- * @property integer|null $yearNullable
- * @property integer $yearNotNullable
+ * @property int|null $yearNullable
+ * @property int $yearNotNullable
  * @property string|null $binaryNullable
  * @property string $binaryNotNullable
  * @property string|null $uuidNullable

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdocFinal/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdocFinal/__snapshots__/Test__test__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhpdocFinal\Models\Post
  *
- * @property integer $id
+ * @property int $id
  * @property string|null $char_nullable
  * @property string $char_not_nullable
  * @property string|null $string_nullable
@@ -20,34 +20,34 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $medium_text_not_nullable
  * @property string|null $long_text_nullable
  * @property string $long_text_not_nullable
- * @property integer|null $integer_nullable
- * @property integer $integer_not_nullable
- * @property integer|null $tiny_integer_nullable
- * @property integer $tiny_integer_not_nullable
- * @property integer|null $small_integer_nullable
- * @property integer $small_integer_not_nullable
- * @property integer|null $medium_integer_nullable
- * @property integer $medium_integer_not_nullable
- * @property integer|null $big_integer_nullable
- * @property integer $big_integer_not_nullable
- * @property integer|null $unsigned_integer_nullable
- * @property integer $unsigned_integer_not_nullable
- * @property integer|null $unsigned_tiny_integer_nullable
- * @property integer $unsigned_tiny_integer_not_nullable
- * @property integer|null $unsigned_small_integer_nullable
- * @property integer $unsigned_small_integer_not_nullable
- * @property integer|null $unsigned_medium_integer_nullable
- * @property integer $unsigned_medium_integer_not_nullable
- * @property integer|null $unsigned_big_integer_nullable
- * @property integer $unsigned_big_integer_not_nullable
+ * @property int|null $integer_nullable
+ * @property int $integer_not_nullable
+ * @property int|null $tiny_integer_nullable
+ * @property int $tiny_integer_not_nullable
+ * @property int|null $small_integer_nullable
+ * @property int $small_integer_not_nullable
+ * @property int|null $medium_integer_nullable
+ * @property int $medium_integer_not_nullable
+ * @property int|null $big_integer_nullable
+ * @property int $big_integer_not_nullable
+ * @property int|null $unsigned_integer_nullable
+ * @property int $unsigned_integer_not_nullable
+ * @property int|null $unsigned_tiny_integer_nullable
+ * @property int $unsigned_tiny_integer_not_nullable
+ * @property int|null $unsigned_small_integer_nullable
+ * @property int $unsigned_small_integer_not_nullable
+ * @property int|null $unsigned_medium_integer_nullable
+ * @property int $unsigned_medium_integer_not_nullable
+ * @property int|null $unsigned_big_integer_nullable
+ * @property int $unsigned_big_integer_not_nullable
  * @property float|null $float_nullable
  * @property float $float_not_nullable
  * @property float|null $double_nullable
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property integer|null $boolean_nullable
- * @property integer $boolean_not_nullable
+ * @property int|null $boolean_nullable
+ * @property int $boolean_not_nullable
  * @property string|null $enum_nullable
  * @property string $enum_not_nullable
  * @property string|null $json_nullable
@@ -68,8 +68,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $timestamp_not_nullable
  * @property string|null $timestamptz_nullable
  * @property string $timestamptz_not_nullable
- * @property integer|null $year_nullable
- * @property integer $year_not_nullable
+ * @property int|null $year_nullable
+ * @property int $year_not_nullable
  * @property string|null $binary_nullable
  * @property string $binary_not_nullable
  * @property string|null $uuid_nullable

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
@@ -15,7 +15,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Models\Post
  *
- * @property integer $id
+ * @property int $id
  * @property string|null $char_nullable
  * @property string $char_not_nullable
  * @property string|null $string_nullable
@@ -26,34 +26,34 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @property string $medium_text_not_nullable
  * @property string|null $long_text_nullable
  * @property string $long_text_not_nullable
- * @property integer|null $integer_nullable
- * @property integer $integer_not_nullable
- * @property integer|null $tiny_integer_nullable
- * @property integer $tiny_integer_not_nullable
- * @property integer|null $small_integer_nullable
- * @property integer $small_integer_not_nullable
- * @property integer|null $medium_integer_nullable
- * @property integer $medium_integer_not_nullable
- * @property integer|null $big_integer_nullable
- * @property integer $big_integer_not_nullable
- * @property integer|null $unsigned_integer_nullable
- * @property integer $unsigned_integer_not_nullable
- * @property integer|null $unsigned_tiny_integer_nullable
- * @property integer $unsigned_tiny_integer_not_nullable
- * @property integer|null $unsigned_small_integer_nullable
- * @property integer $unsigned_small_integer_not_nullable
- * @property integer|null $unsigned_medium_integer_nullable
- * @property integer $unsigned_medium_integer_not_nullable
- * @property integer|null $unsigned_big_integer_nullable
- * @property integer $unsigned_big_integer_not_nullable
+ * @property int|null $integer_nullable
+ * @property int $integer_not_nullable
+ * @property int|null $tiny_integer_nullable
+ * @property int $tiny_integer_not_nullable
+ * @property int|null $small_integer_nullable
+ * @property int $small_integer_not_nullable
+ * @property int|null $medium_integer_nullable
+ * @property int $medium_integer_not_nullable
+ * @property int|null $big_integer_nullable
+ * @property int $big_integer_not_nullable
+ * @property int|null $unsigned_integer_nullable
+ * @property int $unsigned_integer_not_nullable
+ * @property int|null $unsigned_tiny_integer_nullable
+ * @property int $unsigned_tiny_integer_not_nullable
+ * @property int|null $unsigned_small_integer_nullable
+ * @property int $unsigned_small_integer_not_nullable
+ * @property int|null $unsigned_medium_integer_nullable
+ * @property int $unsigned_medium_integer_not_nullable
+ * @property int|null $unsigned_big_integer_nullable
+ * @property int $unsigned_big_integer_not_nullable
  * @property float|null $float_nullable
  * @property float $float_not_nullable
  * @property float|null $double_nullable
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property integer|null $boolean_nullable
- * @property integer $boolean_not_nullable
+ * @property int|null $boolean_nullable
+ * @property int $boolean_not_nullable
  * @property string|null $enum_nullable
  * @property string $enum_not_nullable
  * @property string|null $json_nullable
@@ -74,8 +74,8 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @property string $timestamp_not_nullable
  * @property string|null $timestamptz_nullable
  * @property string $timestamptz_not_nullable
- * @property integer|null $year_nullable
- * @property integer $year_not_nullable
+ * @property int|null $year_nullable
+ * @property int $year_not_nullable
  * @property string|null $binary_nullable
  * @property string $binary_not_nullable
  * @property string|null $uuid_nullable

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilderWithFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilderWithFqn/__snapshots__/Test__test__1.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilderWithFqn\Models\Post
  *
- * @property integer $id
+ * @property int $id
  * @property string|null $char_nullable
  * @property string $char_not_nullable
  * @property string|null $string_nullable
@@ -21,34 +21,34 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $medium_text_not_nullable
  * @property string|null $long_text_nullable
  * @property string $long_text_not_nullable
- * @property integer|null $integer_nullable
- * @property integer $integer_not_nullable
- * @property integer|null $tiny_integer_nullable
- * @property integer $tiny_integer_not_nullable
- * @property integer|null $small_integer_nullable
- * @property integer $small_integer_not_nullable
- * @property integer|null $medium_integer_nullable
- * @property integer $medium_integer_not_nullable
- * @property integer|null $big_integer_nullable
- * @property integer $big_integer_not_nullable
- * @property integer|null $unsigned_integer_nullable
- * @property integer $unsigned_integer_not_nullable
- * @property integer|null $unsigned_tiny_integer_nullable
- * @property integer $unsigned_tiny_integer_not_nullable
- * @property integer|null $unsigned_small_integer_nullable
- * @property integer $unsigned_small_integer_not_nullable
- * @property integer|null $unsigned_medium_integer_nullable
- * @property integer $unsigned_medium_integer_not_nullable
- * @property integer|null $unsigned_big_integer_nullable
- * @property integer $unsigned_big_integer_not_nullable
+ * @property int|null $integer_nullable
+ * @property int $integer_not_nullable
+ * @property int|null $tiny_integer_nullable
+ * @property int $tiny_integer_not_nullable
+ * @property int|null $small_integer_nullable
+ * @property int $small_integer_not_nullable
+ * @property int|null $medium_integer_nullable
+ * @property int $medium_integer_not_nullable
+ * @property int|null $big_integer_nullable
+ * @property int $big_integer_not_nullable
+ * @property int|null $unsigned_integer_nullable
+ * @property int $unsigned_integer_not_nullable
+ * @property int|null $unsigned_tiny_integer_nullable
+ * @property int $unsigned_tiny_integer_not_nullable
+ * @property int|null $unsigned_small_integer_nullable
+ * @property int $unsigned_small_integer_not_nullable
+ * @property int|null $unsigned_medium_integer_nullable
+ * @property int $unsigned_medium_integer_not_nullable
+ * @property int|null $unsigned_big_integer_nullable
+ * @property int $unsigned_big_integer_not_nullable
  * @property float|null $float_nullable
  * @property float $float_not_nullable
  * @property float|null $double_nullable
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property integer|null $boolean_nullable
- * @property integer $boolean_not_nullable
+ * @property int|null $boolean_nullable
+ * @property int $boolean_not_nullable
  * @property string|null $enum_nullable
  * @property string $enum_not_nullable
  * @property string|null $json_nullable
@@ -69,8 +69,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $timestamp_not_nullable
  * @property string|null $timestamptz_nullable
  * @property string $timestamptz_not_nullable
- * @property integer|null $year_nullable
- * @property integer $year_not_nullable
+ * @property int|null $year_nullable
+ * @property int $year_not_nullable
  * @property string|null $binary_nullable
  * @property string $binary_not_nullable
  * @property string|null $uuid_nullable

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post
  *
- * @property integer $id
+ * @property int $id
  * @property string|null $char_nullable
  * @property string $char_not_nullable
  * @property string|null $string_nullable
@@ -22,34 +22,34 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $medium_text_not_nullable
  * @property string|null $long_text_nullable
  * @property string $long_text_not_nullable
- * @property integer|null $integer_nullable
- * @property integer $integer_not_nullable
- * @property integer|null $tiny_integer_nullable
- * @property integer $tiny_integer_not_nullable
- * @property integer|null $small_integer_nullable
- * @property integer $small_integer_not_nullable
- * @property integer|null $medium_integer_nullable
- * @property integer $medium_integer_not_nullable
- * @property integer|null $big_integer_nullable
- * @property integer $big_integer_not_nullable
- * @property integer|null $unsigned_integer_nullable
- * @property integer $unsigned_integer_not_nullable
- * @property integer|null $unsigned_tiny_integer_nullable
- * @property integer $unsigned_tiny_integer_not_nullable
- * @property integer|null $unsigned_small_integer_nullable
- * @property integer $unsigned_small_integer_not_nullable
- * @property integer|null $unsigned_medium_integer_nullable
- * @property integer $unsigned_medium_integer_not_nullable
- * @property integer|null $unsigned_big_integer_nullable
- * @property integer $unsigned_big_integer_not_nullable
+ * @property int|null $integer_nullable
+ * @property int $integer_not_nullable
+ * @property int|null $tiny_integer_nullable
+ * @property int $tiny_integer_not_nullable
+ * @property int|null $small_integer_nullable
+ * @property int $small_integer_not_nullable
+ * @property int|null $medium_integer_nullable
+ * @property int $medium_integer_not_nullable
+ * @property int|null $big_integer_nullable
+ * @property int $big_integer_not_nullable
+ * @property int|null $unsigned_integer_nullable
+ * @property int $unsigned_integer_not_nullable
+ * @property int|null $unsigned_tiny_integer_nullable
+ * @property int $unsigned_tiny_integer_not_nullable
+ * @property int|null $unsigned_small_integer_nullable
+ * @property int $unsigned_small_integer_not_nullable
+ * @property int|null $unsigned_medium_integer_nullable
+ * @property int $unsigned_medium_integer_not_nullable
+ * @property int|null $unsigned_big_integer_nullable
+ * @property int $unsigned_big_integer_not_nullable
  * @property float|null $float_nullable
  * @property float $float_not_nullable
  * @property float|null $double_nullable
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property integer|null $boolean_nullable
- * @property integer $boolean_not_nullable
+ * @property int|null $boolean_nullable
+ * @property int $boolean_not_nullable
  * @property string|null $enum_nullable
  * @property string $enum_not_nullable
  * @property string|null $json_nullable
@@ -70,8 +70,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $timestamp_not_nullable
  * @property string|null $timestamptz_nullable
  * @property string $timestamptz_not_nullable
- * @property integer|null $year_nullable
- * @property integer $year_not_nullable
+ * @property int|null $year_nullable
+ * @property int $year_not_nullable
  * @property string|null $binary_nullable
  * @property string $binary_not_nullable
  * @property string|null $uuid_nullable
@@ -82,84 +82,84 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $macaddress_not_nullable
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
- * @property-read \Illuminate\Database\Eloquent\Collection<int, \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post> $posts
+ * @property-read \Illuminate\Database\Eloquent\Collection<int,\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post> $posts
  * @property-read int|null $posts_count
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post null(string $unusedParam)
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post onlyTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post query()
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereBigIntegerNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereBigIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereBinaryNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereBinaryNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereBooleanNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereBooleanNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereCharNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereCharNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDateNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDateNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDatetimeNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDatetimeNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDatetimetzNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDatetimetzNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDecimalNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDecimalNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDoubleNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDoubleNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereEnumNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereEnumNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereFloatNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereFloatNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereIntegerNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereIpaddressNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereIpaddressNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereJsonNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereJsonNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereJsonbNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereJsonbNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereLongTextNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereLongTextNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereMacaddressNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereMacaddressNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereMediumIntegerNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereMediumIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereMediumTextNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereMediumTextNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereSmallIntegerNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereSmallIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereStringNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereStringNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTextNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTextNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimeNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimeNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimestampNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimestampNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimestamptzNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimestamptzNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimetzNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimetzNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTinyIntegerNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTinyIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedBigIntegerNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedBigIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedIntegerNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedMediumIntegerNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedMediumIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedSmallIntegerNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedSmallIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedTinyIntegerNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedTinyIntegerNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUpdatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUuidNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUuidNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereYearNotNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereYearNullable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereBigIntegerNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereBigIntegerNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereBinaryNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereBinaryNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereBooleanNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereBooleanNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereCharNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereCharNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereCreatedAt(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDateNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDateNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDatetimeNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDatetimeNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDatetimetzNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDatetimetzNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDecimalNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDecimalNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDoubleNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereDoubleNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereEnumNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereEnumNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereFloatNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereFloatNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereId(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereIntegerNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereIntegerNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereIpaddressNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereIpaddressNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereJsonNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereJsonNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereJsonbNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereJsonbNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereLongTextNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereLongTextNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereMacaddressNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereMacaddressNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereMediumIntegerNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereMediumIntegerNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereMediumTextNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereMediumTextNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereSmallIntegerNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereSmallIntegerNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereStringNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereStringNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTextNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTextNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimeNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimeNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimestampNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimestampNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimestamptzNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimestamptzNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimetzNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTimetzNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTinyIntegerNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereTinyIntegerNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedBigIntegerNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedBigIntegerNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedIntegerNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedIntegerNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedMediumIntegerNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedMediumIntegerNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedSmallIntegerNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedSmallIntegerNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedTinyIntegerNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUnsignedTinyIntegerNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUpdatedAt(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUuidNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUuidNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereYearNotNullable(mixed $value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereYearNullable(mixed $value)
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post withTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post withoutTrashed()
  * @mixin \Eloquent

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Carbon;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqn\Models\Post
  *
- * @property integer $id
+ * @property int $id
  * @property string|null $char_nullable
  * @property CastType $char_not_nullable
  * @property string|null $string_nullable
@@ -28,34 +28,34 @@ use Illuminate\Support\Carbon;
  * @property string $medium_text_not_nullable
  * @property string|null $long_text_nullable
  * @property string $long_text_not_nullable
- * @property integer|null $integer_nullable
- * @property integer $integer_not_nullable
- * @property integer|null $tiny_integer_nullable
- * @property integer $tiny_integer_not_nullable
- * @property integer|null $small_integer_nullable
- * @property integer $small_integer_not_nullable
- * @property integer|null $medium_integer_nullable
- * @property integer $medium_integer_not_nullable
- * @property integer|null $big_integer_nullable
- * @property integer $big_integer_not_nullable
- * @property integer|null $unsigned_integer_nullable
- * @property integer $unsigned_integer_not_nullable
- * @property integer|null $unsigned_tiny_integer_nullable
- * @property integer $unsigned_tiny_integer_not_nullable
- * @property integer|null $unsigned_small_integer_nullable
- * @property integer $unsigned_small_integer_not_nullable
- * @property integer|null $unsigned_medium_integer_nullable
- * @property integer $unsigned_medium_integer_not_nullable
- * @property integer|null $unsigned_big_integer_nullable
- * @property integer $unsigned_big_integer_not_nullable
+ * @property int|null $integer_nullable
+ * @property int $integer_not_nullable
+ * @property int|null $tiny_integer_nullable
+ * @property int $tiny_integer_not_nullable
+ * @property int|null $small_integer_nullable
+ * @property int $small_integer_not_nullable
+ * @property int|null $medium_integer_nullable
+ * @property int $medium_integer_not_nullable
+ * @property int|null $big_integer_nullable
+ * @property int $big_integer_not_nullable
+ * @property int|null $unsigned_integer_nullable
+ * @property int $unsigned_integer_not_nullable
+ * @property int|null $unsigned_tiny_integer_nullable
+ * @property int $unsigned_tiny_integer_not_nullable
+ * @property int|null $unsigned_small_integer_nullable
+ * @property int $unsigned_small_integer_not_nullable
+ * @property int|null $unsigned_medium_integer_nullable
+ * @property int $unsigned_medium_integer_not_nullable
+ * @property int|null $unsigned_big_integer_nullable
+ * @property int $unsigned_big_integer_not_nullable
  * @property float|null $float_nullable
  * @property float $float_not_nullable
  * @property float|null $double_nullable
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property integer|null $boolean_nullable
- * @property integer $boolean_not_nullable
+ * @property int|null $boolean_nullable
+ * @property int $boolean_not_nullable
  * @property string|null $enum_nullable
  * @property string $enum_not_nullable
  * @property string|null $json_nullable
@@ -76,8 +76,8 @@ use Illuminate\Support\Carbon;
  * @property string $timestamp_not_nullable
  * @property string|null $timestamptz_nullable
  * @property string $timestamptz_not_nullable
- * @property integer|null $year_nullable
- * @property integer $year_not_nullable
+ * @property int|null $year_nullable
+ * @property int $year_not_nullable
  * @property string|null $binary_nullable
  * @property string $binary_not_nullable
  * @property string|null $uuid_nullable

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/__snapshots__/Test__test__1.php
@@ -15,7 +15,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Models\Post
  *
- * @property integer $id
+ * @property int $id
  * @property string|null $char_nullable
  * @property string $char_not_nullable
  * @property string|null $string_nullable
@@ -26,34 +26,34 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @property string $medium_text_not_nullable
  * @property string|null $long_text_nullable
  * @property string $long_text_not_nullable
- * @property integer|null $integer_nullable
- * @property integer $integer_not_nullable
- * @property integer|null $tiny_integer_nullable
- * @property integer $tiny_integer_not_nullable
- * @property integer|null $small_integer_nullable
- * @property integer $small_integer_not_nullable
- * @property integer|null $medium_integer_nullable
- * @property integer $medium_integer_not_nullable
- * @property integer|null $big_integer_nullable
- * @property integer $big_integer_not_nullable
- * @property integer|null $unsigned_integer_nullable
- * @property integer $unsigned_integer_not_nullable
- * @property integer|null $unsigned_tiny_integer_nullable
- * @property integer $unsigned_tiny_integer_not_nullable
- * @property integer|null $unsigned_small_integer_nullable
- * @property integer $unsigned_small_integer_not_nullable
- * @property integer|null $unsigned_medium_integer_nullable
- * @property integer $unsigned_medium_integer_not_nullable
- * @property integer|null $unsigned_big_integer_nullable
- * @property integer $unsigned_big_integer_not_nullable
+ * @property int|null $integer_nullable
+ * @property int $integer_not_nullable
+ * @property int|null $tiny_integer_nullable
+ * @property int $tiny_integer_not_nullable
+ * @property int|null $small_integer_nullable
+ * @property int $small_integer_not_nullable
+ * @property int|null $medium_integer_nullable
+ * @property int $medium_integer_not_nullable
+ * @property int|null $big_integer_nullable
+ * @property int $big_integer_not_nullable
+ * @property int|null $unsigned_integer_nullable
+ * @property int $unsigned_integer_not_nullable
+ * @property int|null $unsigned_tiny_integer_nullable
+ * @property int $unsigned_tiny_integer_not_nullable
+ * @property int|null $unsigned_small_integer_nullable
+ * @property int $unsigned_small_integer_not_nullable
+ * @property int|null $unsigned_medium_integer_nullable
+ * @property int $unsigned_medium_integer_not_nullable
+ * @property int|null $unsigned_big_integer_nullable
+ * @property int $unsigned_big_integer_not_nullable
  * @property float|null $float_nullable
  * @property float $float_not_nullable
  * @property float|null $double_nullable
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property integer|null $boolean_nullable
- * @property integer $boolean_not_nullable
+ * @property int|null $boolean_nullable
+ * @property int $boolean_not_nullable
  * @property string|null $enum_nullable
  * @property string $enum_not_nullable
  * @property string|null $json_nullable
@@ -74,8 +74,8 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @property string $timestamp_not_nullable
  * @property string|null $timestamptz_nullable
  * @property string $timestamptz_not_nullable
- * @property integer|null $year_nullable
- * @property integer $year_not_nullable
+ * @property int|null $year_nullable
+ * @property int $year_not_nullable
  * @property string|null $binary_nullable
  * @property string $binary_not_nullable
  * @property string|null $uuid_nullable

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/__snapshots__/Test__test__1.php
@@ -7,8 +7,10 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
 use Illuminate\Database\Eloquent\Model;
 
 /**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithMixin\Models\FinalPost
+ *
  * @property $someProp
- * @method someMethod(string $method)
+ * @method void someMethod(string $method)
  * @mixin IdeHelperFinalPost
  */
 final class FinalPost extends Model
@@ -23,8 +25,10 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
 use Illuminate\Database\Eloquent\Model;
 
 /**
+ * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithMixin\Models\Post
+ *
  * @property $someProp
- * @method someMethod(string $method)
+ * @method void someMethod(string $method)
  * @mixin IdeHelperPost
  */
 class Post extends Model
@@ -45,10 +49,8 @@ class Post extends Model
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithMixin\Models{
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithMixin\Models\FinalPost
- *
  * @property $someProp
- * @method someMethod(string $method)
+ * @method void someMethod(string $method)
  * @method static \Illuminate\Database\Eloquent\Builder|FinalPost newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|FinalPost newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|FinalPost query()
@@ -60,11 +62,9 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithMixin\Models{
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithMixin\Models\Post
- *
  * @property $someProp
- * @method someMethod(string $method)
- * @property integer $id
+ * @method void someMethod(string $method)
+ * @property int $id
  * @property string|null $char_nullable
  * @property string $char_not_nullable
  * @property string|null $string_nullable
@@ -75,34 +75,34 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @property string $medium_text_not_nullable
  * @property string|null $long_text_nullable
  * @property string $long_text_not_nullable
- * @property integer|null $integer_nullable
- * @property integer $integer_not_nullable
- * @property integer|null $tiny_integer_nullable
- * @property integer $tiny_integer_not_nullable
- * @property integer|null $small_integer_nullable
- * @property integer $small_integer_not_nullable
- * @property integer|null $medium_integer_nullable
- * @property integer $medium_integer_not_nullable
- * @property integer|null $big_integer_nullable
- * @property integer $big_integer_not_nullable
- * @property integer|null $unsigned_integer_nullable
- * @property integer $unsigned_integer_not_nullable
- * @property integer|null $unsigned_tiny_integer_nullable
- * @property integer $unsigned_tiny_integer_not_nullable
- * @property integer|null $unsigned_small_integer_nullable
- * @property integer $unsigned_small_integer_not_nullable
- * @property integer|null $unsigned_medium_integer_nullable
- * @property integer $unsigned_medium_integer_not_nullable
- * @property integer|null $unsigned_big_integer_nullable
- * @property integer $unsigned_big_integer_not_nullable
+ * @property int|null $integer_nullable
+ * @property int $integer_not_nullable
+ * @property int|null $tiny_integer_nullable
+ * @property int $tiny_integer_not_nullable
+ * @property int|null $small_integer_nullable
+ * @property int $small_integer_not_nullable
+ * @property int|null $medium_integer_nullable
+ * @property int $medium_integer_not_nullable
+ * @property int|null $big_integer_nullable
+ * @property int $big_integer_not_nullable
+ * @property int|null $unsigned_integer_nullable
+ * @property int $unsigned_integer_not_nullable
+ * @property int|null $unsigned_tiny_integer_nullable
+ * @property int $unsigned_tiny_integer_not_nullable
+ * @property int|null $unsigned_small_integer_nullable
+ * @property int $unsigned_small_integer_not_nullable
+ * @property int|null $unsigned_medium_integer_nullable
+ * @property int $unsigned_medium_integer_not_nullable
+ * @property int|null $unsigned_big_integer_nullable
+ * @property int $unsigned_big_integer_not_nullable
  * @property float|null $float_nullable
  * @property float $float_not_nullable
  * @property float|null $double_nullable
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property integer|null $boolean_nullable
- * @property integer $boolean_not_nullable
+ * @property int|null $boolean_nullable
+ * @property int $boolean_not_nullable
  * @property string|null $enum_nullable
  * @property string $enum_not_nullable
  * @property string|null $json_nullable
@@ -123,8 +123,8 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
  * @property string $timestamp_not_nullable
  * @property string|null $timestamptz_nullable
  * @property string $timestamptz_not_nullable
- * @property integer|null $year_nullable
- * @property integer $year_not_nullable
+ * @property int|null $year_nullable
+ * @property int $year_not_nullable
  * @property string|null $binary_nullable
  * @property string $binary_not_nullable
  * @property string|null $uuid_nullable

--- a/tests/Console/ModelsCommand/GenericsSyntaxDisabled/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenericsSyntaxDisabled/__snapshots__/Test__test__1.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenericsSyntaxDisabled\Models\Simple
  *
- * @property integer $id
+ * @property int $id
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $regularBelongsToMany
  * @property-read int|null $regular_belongs_to_many_count
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $regularHasMany

--- a/tests/Console/ModelsCommand/Getter/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Getter/__snapshots__/Test__test__1.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Getter\Models\Simple
  *
- * @property integer $id
+ * @property int $id
  * @property-read int|null $attribute_return_type_int_or_null
  * @property-read array $attribute_returns_array
  * @property-read bool $attribute_returns_bool

--- a/tests/Console/ModelsCommand/MagicWhere/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/MagicWhere/__snapshots__/Test__test__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\MagicWhere\Models\Post
  *
- * @property integer $id
+ * @property int $id
  * @property string|null $char_nullable
  * @property string $char_not_nullable
  * @property string|null $string_nullable
@@ -20,34 +20,34 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $medium_text_not_nullable
  * @property string|null $long_text_nullable
  * @property string $long_text_not_nullable
- * @property integer|null $integer_nullable
- * @property integer $integer_not_nullable
- * @property integer|null $tiny_integer_nullable
- * @property integer $tiny_integer_not_nullable
- * @property integer|null $small_integer_nullable
- * @property integer $small_integer_not_nullable
- * @property integer|null $medium_integer_nullable
- * @property integer $medium_integer_not_nullable
- * @property integer|null $big_integer_nullable
- * @property integer $big_integer_not_nullable
- * @property integer|null $unsigned_integer_nullable
- * @property integer $unsigned_integer_not_nullable
- * @property integer|null $unsigned_tiny_integer_nullable
- * @property integer $unsigned_tiny_integer_not_nullable
- * @property integer|null $unsigned_small_integer_nullable
- * @property integer $unsigned_small_integer_not_nullable
- * @property integer|null $unsigned_medium_integer_nullable
- * @property integer $unsigned_medium_integer_not_nullable
- * @property integer|null $unsigned_big_integer_nullable
- * @property integer $unsigned_big_integer_not_nullable
+ * @property int|null $integer_nullable
+ * @property int $integer_not_nullable
+ * @property int|null $tiny_integer_nullable
+ * @property int $tiny_integer_not_nullable
+ * @property int|null $small_integer_nullable
+ * @property int $small_integer_not_nullable
+ * @property int|null $medium_integer_nullable
+ * @property int $medium_integer_not_nullable
+ * @property int|null $big_integer_nullable
+ * @property int $big_integer_not_nullable
+ * @property int|null $unsigned_integer_nullable
+ * @property int $unsigned_integer_not_nullable
+ * @property int|null $unsigned_tiny_integer_nullable
+ * @property int $unsigned_tiny_integer_not_nullable
+ * @property int|null $unsigned_small_integer_nullable
+ * @property int $unsigned_small_integer_not_nullable
+ * @property int|null $unsigned_medium_integer_nullable
+ * @property int $unsigned_medium_integer_not_nullable
+ * @property int|null $unsigned_big_integer_nullable
+ * @property int $unsigned_big_integer_not_nullable
  * @property float|null $float_nullable
  * @property float $float_not_nullable
  * @property float|null $double_nullable
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property integer|null $boolean_nullable
- * @property integer $boolean_not_nullable
+ * @property int|null $boolean_nullable
+ * @property int $boolean_not_nullable
  * @property string|null $enum_nullable
  * @property string $enum_not_nullable
  * @property string|null $json_nullable
@@ -68,8 +68,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $timestamp_not_nullable
  * @property string|null $timestamptz_nullable
  * @property string $timestamptz_not_nullable
- * @property integer|null $year_nullable
- * @property integer $year_not_nullable
+ * @property int|null $year_nullable
+ * @property int $year_not_nullable
  * @property string|null $binary_nullable
  * @property string $binary_not_nullable
  * @property string|null $uuid_nullable

--- a/tests/Console/ModelsCommand/PHPStormNoInspection/__snapshots__/Test__testNoinspectionNotPresent__1.php
+++ b/tests/Console/ModelsCommand/PHPStormNoInspection/__snapshots__/Test__testNoinspectionNotPresent__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple
  *
- * @property integer $id
+ * @property int $id
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()

--- a/tests/Console/ModelsCommand/PHPStormNoInspection/__snapshots__/Test__testNoinspectionPresent__1.php
+++ b/tests/Console/ModelsCommand/PHPStormNoInspection/__snapshots__/Test__testNoinspectionPresent__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple
  *
- * @property integer $id
+ * @property int $id
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()

--- a/tests/Console/ModelsCommand/RelationCountProperties/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/RelationCountProperties/__snapshots__/Test__test__1.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\RelationCountProperties\Models\Post
  *
- * @property integer $id
+ * @property int $id
  * @property string|null $char_nullable
  * @property string $char_not_nullable
  * @property string|null $string_nullable
@@ -21,34 +21,34 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string $medium_text_not_nullable
  * @property string|null $long_text_nullable
  * @property string $long_text_not_nullable
- * @property integer|null $integer_nullable
- * @property integer $integer_not_nullable
- * @property integer|null $tiny_integer_nullable
- * @property integer $tiny_integer_not_nullable
- * @property integer|null $small_integer_nullable
- * @property integer $small_integer_not_nullable
- * @property integer|null $medium_integer_nullable
- * @property integer $medium_integer_not_nullable
- * @property integer|null $big_integer_nullable
- * @property integer $big_integer_not_nullable
- * @property integer|null $unsigned_integer_nullable
- * @property integer $unsigned_integer_not_nullable
- * @property integer|null $unsigned_tiny_integer_nullable
- * @property integer $unsigned_tiny_integer_not_nullable
- * @property integer|null $unsigned_small_integer_nullable
- * @property integer $unsigned_small_integer_not_nullable
- * @property integer|null $unsigned_medium_integer_nullable
- * @property integer $unsigned_medium_integer_not_nullable
- * @property integer|null $unsigned_big_integer_nullable
- * @property integer $unsigned_big_integer_not_nullable
+ * @property int|null $integer_nullable
+ * @property int $integer_not_nullable
+ * @property int|null $tiny_integer_nullable
+ * @property int $tiny_integer_not_nullable
+ * @property int|null $small_integer_nullable
+ * @property int $small_integer_not_nullable
+ * @property int|null $medium_integer_nullable
+ * @property int $medium_integer_not_nullable
+ * @property int|null $big_integer_nullable
+ * @property int $big_integer_not_nullable
+ * @property int|null $unsigned_integer_nullable
+ * @property int $unsigned_integer_not_nullable
+ * @property int|null $unsigned_tiny_integer_nullable
+ * @property int $unsigned_tiny_integer_not_nullable
+ * @property int|null $unsigned_small_integer_nullable
+ * @property int $unsigned_small_integer_not_nullable
+ * @property int|null $unsigned_medium_integer_nullable
+ * @property int $unsigned_medium_integer_not_nullable
+ * @property int|null $unsigned_big_integer_nullable
+ * @property int $unsigned_big_integer_not_nullable
  * @property float|null $float_nullable
  * @property float $float_not_nullable
  * @property float|null $double_nullable
  * @property float $double_not_nullable
  * @property string|null $decimal_nullable
  * @property string $decimal_not_nullable
- * @property integer|null $boolean_nullable
- * @property integer $boolean_not_nullable
+ * @property int|null $boolean_nullable
+ * @property int $boolean_not_nullable
  * @property string|null $enum_nullable
  * @property string $enum_not_nullable
  * @property string|null $json_nullable
@@ -69,8 +69,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string $timestamp_not_nullable
  * @property string|null $timestamptz_nullable
  * @property string $timestamptz_not_nullable
- * @property integer|null $year_nullable
- * @property integer $year_not_nullable
+ * @property int|null $year_nullable
+ * @property int $year_not_nullable
  * @property string|null $binary_nullable
  * @property string $binary_not_nullable
  * @property string|null $uuid_nullable

--- a/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
@@ -10,11 +10,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\BelongsToVariation
  *
- * @property integer $id
- * @property integer $not_null_column_with_foreign_key_constraint
- * @property integer $not_null_column_with_no_foreign_key_constraint
- * @property integer|null $nullable_column_with_foreign_key_constraint
- * @property integer|null $nullable_column_with_no_foreign_key_constraint
+ * @property int $id
+ * @property int $not_null_column_with_foreign_key_constraint
+ * @property int $not_null_column_with_no_foreign_key_constraint
+ * @property int|null $nullable_column_with_foreign_key_constraint
+ * @property int|null $nullable_column_with_no_foreign_key_constraint
  * @property-read BelongsToVariation $notNullColumnWithForeignKeyConstraint
  * @property-read BelongsToVariation|null $notNullColumnWithNoForeignKeyConstraint
  * @property-read BelongsToVariation|null $nullableColumnWithForeignKeyConstraint
@@ -63,11 +63,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\CompositeBelongsToVariation
  *
- * @property integer $id
- * @property integer $not_null_column_with_foreign_key_constraint
- * @property integer $not_null_column_with_no_foreign_key_constraint
- * @property integer|null $nullable_column_with_foreign_key_constraint
- * @property integer|null $nullable_column_with_no_foreign_key_constraint
+ * @property int $id
+ * @property int $not_null_column_with_foreign_key_constraint
+ * @property int $not_null_column_with_no_foreign_key_constraint
+ * @property int|null $nullable_column_with_foreign_key_constraint
+ * @property int|null $nullable_column_with_no_foreign_key_constraint
  * @property-read CompositeBelongsToVariation $bothNonNullableWithForeignKeyConstraint
  * @property-read CompositeBelongsToVariation|null $nonNullableMixedWithoutForeignKeyConstraint
  * @property-read CompositeBelongsToVariation|null $nullableMixedWithForeignKeyConstraint
@@ -134,7 +134,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple
  *
- * @property integer $id
+ * @property int $id
  * @property-read Simple|null $relationBelongsTo
  * @property-read AnotherModel|null $relationBelongsToInAnotherNamespace
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationBelongsToMany

--- a/tests/Console/ModelsCommand/ResetAndSmartReset/__snapshots__/Test__testNoReset__1.php
+++ b/tests/Console/ModelsCommand/ResetAndSmartReset/__snapshots__/Test__testNoReset__1.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
  * Text of existing phpdoc
  *
  * @property string $foo
- * @property integer $id
+ * @property int $id
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()

--- a/tests/Console/ModelsCommand/ResetAndSmartReset/__snapshots__/Test__testReset__1.php
+++ b/tests/Console/ModelsCommand/ResetAndSmartReset/__snapshots__/Test__testReset__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple
  *
- * @property integer $id
+ * @property int $id
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()

--- a/tests/Console/ModelsCommand/ResetAndSmartReset/__snapshots__/Test__testSmartReset__1.php
+++ b/tests/Console/ModelsCommand/ResetAndSmartReset/__snapshots__/Test__testSmartReset__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Text of existing phpdoc
  *
- * @property integer $id
+ * @property int $id
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple query()

--- a/tests/Console/ModelsCommand/SimpleCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/SimpleCasts/__snapshots__/Test__test__1.php
@@ -9,15 +9,15 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Models\SimpleCast
  *
- * @property integer $cast_to_int
- * @property integer $cast_to_integer
+ * @property int $cast_to_int
+ * @property int $cast_to_integer
  * @property float $cast_to_real
  * @property float $cast_to_float
  * @property float $cast_to_double
  * @property string $cast_to_decimal
  * @property string $cast_to_string
- * @property boolean $cast_to_bool
- * @property boolean $cast_to_boolean
+ * @property bool $cast_to_bool
+ * @property bool $cast_to_boolean
  * @property object $cast_to_object
  * @property array $cast_to_array
  * @property array $cast_to_json
@@ -32,7 +32,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property \Carbon\CarbonImmutable $cast_to_immutable_custom_datetime
  * @property \Carbon\CarbonImmutable $cast_to_immutable_datetime
  * @property \Carbon\CarbonImmutable $cast_to_immutable_datetime_serialization
- * @property integer $cast_to_timestamp
+ * @property int $cast_to_timestamp
  * @property mixed $cast_to_encrypted
  * @property array $cast_to_encrypted_array
  * @property \Illuminate\Support\Collection $cast_to_encrypted_collection

--- a/tests/Console/ModelsCommand/SoftDeletes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/SoftDeletes/__snapshots__/Test__test__1.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SoftDeletes\Models\Simple
  *
- * @property integer $id
+ * @property int $id
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Simple onlyTrashed()

--- a/tests/Console/ModelsCommand/Variadic/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Variadic/__snapshots__/Test__test__1.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Variadic\Models\Simple
  *
- * @property integer $id
+ * @property int $id
  * @method static Builder|Simple newModelQuery()
  * @method static Builder|Simple newQuery()
  * @method static Builder|Simple query()

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Barryvdh\LaravelIdeHelper\Tests;
 
 use Barryvdh\LaravelIdeHelper\Macro;
-use Barryvdh\Reflection\DocBlock;
-use Barryvdh\Reflection\DocBlock\Tag;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Routing\UrlGenerator;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\Tag;
 use ReflectionClass;
 use ReflectionFunction;
 use ReflectionFunctionAbstract;
@@ -62,7 +62,7 @@ class MacroTest extends TestCase
         );
 
         $this->assertNotNull($phpdoc);
-        $this->assertEmpty($phpdoc->getText());
+        $this->assertEmpty($phpdoc->getSummary());
         $this->assertEquals('@param int|null $a', $this->tagsToString($phpdoc, 'param'));
         $this->assertEquals('@return int', $this->tagsToString($phpdoc, 'return'));
         $this->assertTrue($phpdoc->hasTag('see'));
@@ -86,7 +86,7 @@ class MacroTest extends TestCase
         );
 
         $this->assertNotNull($phpdoc);
-        $this->assertStringContainsString('Test docblock', $phpdoc->getText());
+        $this->assertStringContainsString('Test docblock', $phpdoc->getSummary());
         $this->assertEquals('@param int|null $a', $this->tagsToString($phpdoc, 'param'));
         $this->assertEquals('@return int', $this->tagsToString($phpdoc, 'return'));
         $this->assertTrue($phpdoc->hasTag('see'));
@@ -110,7 +110,7 @@ class MacroTest extends TestCase
         );
 
         $this->assertNotNull($phpdoc);
-        $this->assertStringContainsString('Test docblock', $phpdoc->getText());
+        $this->assertStringContainsString('Test docblock', $phpdoc->getSummary());
         $this->assertEquals('@param int|null $a', $this->tagsToString($phpdoc, 'param'));
         $this->assertFalse($phpdoc->hasTag('return'));
         $this->assertTrue($phpdoc->hasTag('see'));
@@ -134,7 +134,7 @@ class MacroTest extends TestCase
         );
 
         $this->assertNotNull($phpdoc);
-        $this->assertStringContainsString('Test docblock', $phpdoc->getText());
+        $this->assertStringContainsString('Test docblock', $phpdoc->getSummary());
         $this->assertFalse($phpdoc->hasTag('param'));
         $this->assertEquals('@return int', $this->tagsToString($phpdoc, 'return'));
         $this->assertTrue($phpdoc->hasTag('see'));
@@ -159,7 +159,7 @@ class MacroTest extends TestCase
         );
 
         $this->assertNotNull($phpdoc);
-        $this->assertStringContainsString('Test docblock', $phpdoc->getText());
+        $this->assertStringContainsString('Test docblock', $phpdoc->getSummary());
         $this->assertEquals('@param \stdClass|null $a aaaaa', $this->tagsToString($phpdoc, 'param'));
         $this->assertEquals('@return int', $this->tagsToString($phpdoc, 'return'));
     }
@@ -183,7 +183,7 @@ class MacroTest extends TestCase
         );
 
         $this->assertNotNull($phpdoc);
-        $this->assertStringContainsString('Test docblock', $phpdoc->getText());
+        $this->assertStringContainsString('Test docblock', $phpdoc->getSummary());
         $this->assertEquals('@param mixed $a', $this->tagsToString($phpdoc, 'param'));
         $this->assertEquals('@return \stdClass|null rrrrrrr', $this->tagsToString($phpdoc, 'return'));
     }
@@ -202,7 +202,7 @@ class MacroTest extends TestCase
         PHP));
 
         $this->assertNotNull($phpdoc);
-        $this->assertStringContainsString('Test docblock', $phpdoc->getText());
+        $this->assertStringContainsString('Test docblock', $phpdoc->getSummary());
         $this->assertEquals('@param \Stringable|string|null $a', $this->tagsToString($phpdoc, 'param'));
         $this->assertEquals('@return \Stringable|string|null', $this->tagsToString($phpdoc, 'return'));
     }
@@ -212,7 +212,7 @@ class MacroTest extends TestCase
         $tags = $docBlock->getTagsByName($name);
         $tags = array_map(
             function (Tag $tag) {
-                return trim((string)$tag);
+                return trim($tag->render());
             },
             $tags
         );
@@ -242,13 +242,13 @@ class MacroTest extends TestCase
         $macro = new Macro($reflectionMethod, 'URL', new ReflectionClass(UrlGenerator::class), 'macroName');
         $output = <<<'DOC'
 /**
- * 
+ *
  *
  * @param string $foo
  * @param int $bar
- * @return string 
+ * @return string
  * @see \Barryvdh\LaravelIdeHelper\Tests\UrlGeneratorMacroClass::__invoke()
- * @static 
+ * @static
  */
 DOC;
         $this->assertSame($output, $macro->getDocComment(''));
@@ -276,7 +276,7 @@ class MacroMock extends Macro
 
     public function getPhpDoc(ReflectionFunctionAbstract $method, ReflectionClass $class = null): DocBlock
     {
-        return (new Macro($method, '', $class ?? $method->getClosureScopeClass()))->phpdoc;
+        return (new Macro($method, '', $class ?? $method->getClosureScopeClass()))->phpdoc->getDocBlock();
     }
 }
 


### PR DESCRIPTION
## Summary
Try to avoid using the fork of ReflectionDocBlock.

The official lib still doesn't support changing the docs but it does support creating a new one..

## Type of change

- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
