### PR TITLE
Merge reset/smart reset, don't set class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Support for Laravel 11 [#1520 / KentarouTakeda](https://github.com/barryvdh/laravel-ide-helper/pull/1520)
 
+### Changed
+- Merge --reset and --smart-reset, to always keep the text. Always skipp the classname [#1523 / barryvdh](https://github.com/barryvdh/laravel-ide-helper/pull/1523)
+
 ### Removed
 - Support for Laravel 9 and use of doctrine/dbal [#1512 / barryvdh](https://github.com/barryvdh/laravel-ide-helper/pull/1512) 
   With this functionality gone, a few changes have been made:
   - support for custom datatypes has been dropped (config `custom_db_types`) unknown data types default to `string` now and to fix the type, add a proper cast in Eloquent
   - You _might_ have top-level dependency on doctrine/dbal. This may have been in the past due to ide-helper, we suggest to check if you still need it and remove it otherwise
   - Minimum PHP version, due to Laravel 10, is now PHP 8.1
-
 
 2024-02-15, 2.15.1
 ------------------

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -105,7 +105,6 @@ class ModelsCommand extends Command
     protected $write_mixin = false;
     protected $dirs = [];
     protected $reset;
-    protected $keep_text;
     protected $phpstorm_noinspections;
     protected $write_model_external_builder_methods;
     /**
@@ -151,11 +150,8 @@ class ModelsCommand extends Command
         );
         $model = $this->argument('model');
         $ignore = $this->option('ignore');
-        $this->reset = $this->option('reset');
+        $this->reset = $this->option('reset') || $this->option('smart-reset');
         $this->phpstorm_noinspections = $this->option('phpstorm-noinspections');
-        if ($this->option('smart-reset')) {
-            $this->keep_text = $this->reset = true;
-        }
         $this->write_model_magic_where = $this->laravel['config']->get('ide-helper.write_model_magic_where', true);
         $this->write_model_external_builder_methods = $this->laravel['config']->get('ide-helper.write_model_external_builder_methods', true);
         $this->write_model_relation_count_properties =
@@ -218,8 +214,8 @@ class ModelsCommand extends Command
               "Write models to {$this->filename} and adds @mixin to each model, avoiding IDE duplicate declaration warnings",
           ],
           ['nowrite', 'N', InputOption::VALUE_NONE, 'Don\'t write to Model file'],
-          ['reset', 'R', InputOption::VALUE_NONE, 'Remove the original phpdocs instead of appending'],
-          ['smart-reset', 'r', InputOption::VALUE_NONE, 'Refresh the properties/methods list, but keep the text'],
+          ['reset', 'R', InputOption::VALUE_NONE, 'Refresh the properties/methods list, but keep the text'],
+          ['smart-reset', 'r', InputOption::VALUE_NONE, 'Deprecated: same as --reset'],
           ['phpstorm-noinspections', 'p', InputOption::VALUE_NONE,
               'Add PhpFullyQualifiedNameUsageInspection and PhpUnnecessaryFullyQualifiedNameInspection PHPStorm ' .
               'noinspection tags',
@@ -889,17 +885,11 @@ class ModelsCommand extends Command
 
         if ($this->reset) {
             $phpdoc = new DocBlock('', new Context($namespace));
-            if ($this->keep_text) {
-                $phpdoc->setText(
-                    (new DocBlock($reflection, new Context($namespace)))->getText()
-                );
-            }
+            $phpdoc->setText(
+                (new DocBlock($reflection, new Context($namespace)))->getText()
+            );
         } else {
             $phpdoc = new DocBlock($reflection, new Context($namespace));
-        }
-
-        if (!$phpdoc->getText()) {
-            $phpdoc->setText($class);
         }
 
         $properties = [];

--- a/tests/Console/ModelsCommand/AdvancedCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/AdvancedCasts/__snapshots__/Test__test__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AdvancedCasts\Models\AdvancedCast
+ * 
  *
  * @property \Illuminate\Support\Carbon $cast_to_date_serialization
  * @property \Illuminate\Support\Carbon $cast_to_datetime_serialization

--- a/tests/Console/ModelsCommand/AllowGlobDirectory/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/AllowGlobDirectory/__snapshots__/Test__test__1.php
@@ -7,7 +7,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AllowGlobDirecto
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AllowGlobDirectory\Services\Post\Models\Post
+ * 
  *
  * @property integer $id
  * @property string|null $char_nullable

--- a/tests/Console/ModelsCommand/ArrayCastsWithComment/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/ArrayCastsWithComment/__snapshots__/Test__test__1.php
@@ -7,7 +7,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ArrayCastsWithCo
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ArrayCastsWithComment\Models\ArrayCastsWithComment
+ * 
  *
  * @property array<int, string>|null $cast_to_array -- These three should not be duplicated
  * @property array<int, string> $cast_to_json some-description

--- a/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Attributes\Models\Simple
+ * 
  *
  * @property integer $id
  * @property int $diverging_type_hinted_get_and_set

--- a/tests/Console/ModelsCommand/Comment/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Comment/__snapshots__/Test__test__1.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Comment\Models\Simple
+ * 
  *
  * @property integer $id
  * @property string $both_same_name I'm a getter

--- a/tests/Console/ModelsCommand/CustomCollection/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/CustomCollection/__snapshots__/Test__test__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomCollection\Models\Simple
+ * 
  *
  * @property integer $id
  * @property-read SimpleCollection<int, Simple> $relationHasMany

--- a/tests/Console/ModelsCommand/CustomDate/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/CustomDate/__snapshots__/Test__test__1.php
@@ -7,7 +7,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomDate\Model
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\CustomDate\Models\CustomDate
+ * 
  *
  * @property \Carbon\CarbonImmutable|null $created_at
  * @property \Carbon\CarbonImmutable|null $updated_at

--- a/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/DoesNotGeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
@@ -13,7 +13,7 @@
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Models{
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DoesNotGeneratePhpdocWithExternalEloquentBuilder\Models\Post
+ * 
  *
  * @property integer $id
  * @property string|null $char_nullable

--- a/tests/Console/ModelsCommand/DynamicRelations/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/DynamicRelations/__snapshots__/Test__test__1.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\DynamicRelations\Models\Dynamic
+ * 
  *
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Dynamic> $regularHasMany
  * @property-read int|null $regular_has_many_count

--- a/tests/Console/ModelsCommand/Factories/__snapshots__/Test__testFactory__1.php
+++ b/tests/Console/ModelsCommand/Factories/__snapshots__/Test__testFactory__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Models\ModelWithCustomNamespace
+ * 
  *
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\CustomSpace\ModelWithCustomNamespaceFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder|ModelWithCustomNamespace newModelQuery()
@@ -41,7 +41,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Models\ModelWithFactory
+ * 
  *
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Factories\ModelWithFactoryFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder|ModelWithFactory newModelQuery()
@@ -60,7 +60,7 @@ declare(strict_types=1);
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Models;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Models\ModelWithNestedFactory
+ * 
  *
  * @method static \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Factories\ModelWithNestedFactoryFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder|ModelWithNestedFactory newModelQuery()
@@ -81,7 +81,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Factories\Models\ModelWithoutFactory
+ * 
  *
  * @method static \Illuminate\Database\Eloquent\Builder|ModelWithoutFactory newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|ModelWithoutFactory newQuery()

--- a/tests/Console/ModelsCommand/GenerateBasicPhpDocWithEnumDefaults/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpDocWithEnumDefaults/__snapshots__/Test__test__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhpDocWithEnumDefaults\Models\Post
+ * 
  *
  * @property integer $id
  * @property string|null $char_nullable

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdoc/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdoc/__snapshots__/Test__test__1.php
@@ -7,7 +7,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhp
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhpdoc\Models\Post
+ * 
  *
  * @property integer $id
  * @property string|null $char_nullable

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdocCamel/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdocCamel/__snapshots__/Test__test__1.php
@@ -7,7 +7,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhp
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhpdocCamel\Models\Post
+ * 
  *
  * @property integer $id
  * @property string|null $charNullable

--- a/tests/Console/ModelsCommand/GenerateBasicPhpdocFinal/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenerateBasicPhpdocFinal/__snapshots__/Test__test__1.php
@@ -7,7 +7,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhp
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenerateBasicPhpdocFinal\Models\Post
+ * 
  *
  * @property integer $id
  * @property string|null $char_nullable

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilder/__snapshots__/Test__test__1.php
@@ -13,7 +13,7 @@
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Models{
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilder\Models\Post
+ * 
  *
  * @property integer $id
  * @property string|null $char_nullable

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilderWithFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithExternalEloquentBuilderWithFqn/__snapshots__/Test__test__1.php
@@ -8,7 +8,7 @@ use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExte
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithExternalEloquentBuilderWithFqn\Models\Post
+ * 
  *
  * @property integer $id
  * @property string|null $char_nullable

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post
+ * 
  *
  * @property integer $id
  * @property string|null $char_nullable

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
@@ -15,7 +15,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Carbon;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqn\Models\Post
+ * 
  *
  * @property integer $id
  * @property string|null $char_nullable

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqnInExternalFile/__snapshots__/Test__test__1.php
@@ -13,7 +13,7 @@
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Models{
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithFqnInExternalFile\Models\Post
+ * 
  *
  * @property integer $id
  * @property string|null $char_nullable

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithMixin/__snapshots__/Test__test__1.php
@@ -45,7 +45,7 @@ class Post extends Model
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithMixin\Models{
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithMixin\Models\FinalPost
+ * 
  *
  * @property $someProp
  * @method someMethod(string $method)
@@ -60,7 +60,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWi
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithMixin\Models{
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithMixin\Models\Post
+ * 
  *
  * @property $someProp
  * @method someMethod(string $method)

--- a/tests/Console/ModelsCommand/GenericsSyntaxDisabled/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenericsSyntaxDisabled/__snapshots__/Test__test__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GenericsSyntaxDisabled\Models\Simple
+ * 
  *
  * @property integer $id
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $regularBelongsToMany

--- a/tests/Console/ModelsCommand/Getter/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Getter/__snapshots__/Test__test__1.php
@@ -8,7 +8,7 @@ use DateTime;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Getter\Models\Simple
+ * 
  *
  * @property integer $id
  * @property-read int|null $attribute_return_type_int_or_null

--- a/tests/Console/ModelsCommand/Ignored/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Ignored/__snapshots__/Test__test__1.php
@@ -7,7 +7,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Ignored\Models;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Ignored\Models\NotIgnored
+ * 
  *
  * @method static \Illuminate\Database\Eloquent\Builder|NotIgnored newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|NotIgnored newQuery()

--- a/tests/Console/ModelsCommand/Interfaces/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Interfaces/__snapshots__/Test__test__1.php
@@ -13,7 +13,7 @@
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Interfaces\Models{
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Interfaces\Models\User
+ * 
  *
  * @method static \Illuminate\Database\Eloquent\Builder|User newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|User newQuery()

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/__snapshots__/Test__test__1.php
@@ -23,7 +23,7 @@ use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Cas
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Models\CustomCast
+ * 
  *
  * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $casted_property_with_return_type
  * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $casted_property_with_return_docblock

--- a/tests/Console/ModelsCommand/MagicWhere/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/MagicWhere/__snapshots__/Test__test__1.php
@@ -7,7 +7,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\MagicWhere\Model
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\MagicWhere\Models\Post
+ * 
  *
  * @property integer $id
  * @property string|null $char_nullable

--- a/tests/Console/ModelsCommand/ModelHooks/Test.php
+++ b/tests/Console/ModelsCommand/ModelHooks/Test.php
@@ -71,7 +71,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Model
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelHooks\Models\Simple
+ * 
  *
  * @property int $id
  * @property-read string $custom

--- a/tests/Console/ModelsCommand/PHPStormNoInspection/__snapshots__/Test__testNoinspectionNotPresent__1.php
+++ b/tests/Console/ModelsCommand/PHPStormNoInspection/__snapshots__/Test__testNoinspectionNotPresent__1.php
@@ -7,7 +7,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspec
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple
+ * 
  *
  * @property integer $id
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()

--- a/tests/Console/ModelsCommand/PHPStormNoInspection/__snapshots__/Test__testNoinspectionPresent__1.php
+++ b/tests/Console/ModelsCommand/PHPStormNoInspection/__snapshots__/Test__testNoinspectionPresent__1.php
@@ -7,7 +7,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspec
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\PHPStormNoInspection\Models\Simple
+ * 
  *
  * @property integer $id
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()

--- a/tests/Console/ModelsCommand/RelationCountProperties/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/RelationCountProperties/__snapshots__/Test__test__1.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\RelationCountProperties\Models\Post
+ * 
  *
  * @property integer $id
  * @property string|null $char_nullable

--- a/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\BelongsToVariation
+ * 
  *
  * @property integer $id
  * @property integer $not_null_column_with_foreign_key_constraint
@@ -61,7 +61,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\CompositeBelongsToVariation
+ * 
  *
  * @property integer $id
  * @property integer $not_null_column_with_foreign_key_constraint
@@ -132,7 +132,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Relations\Models\Simple
+ * 
  *
  * @property integer $id
  * @property-read Simple|null $relationBelongsTo

--- a/tests/Console/ModelsCommand/ResetAndSmartReset/__snapshots__/Test__testReset__1.php
+++ b/tests/Console/ModelsCommand/ResetAndSmartReset/__snapshots__/Test__testReset__1.php
@@ -7,7 +7,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartRes
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ResetAndSmartReset\Models\Simple
+ * Text of existing phpdoc
  *
  * @property integer $id
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()

--- a/tests/Console/ModelsCommand/SimpleCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/SimpleCasts/__snapshots__/Test__test__1.php
@@ -7,7 +7,7 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Mode
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SimpleCasts\Models\SimpleCast
+ * 
  *
  * @property integer $cast_to_int
  * @property integer $cast_to_integer

--- a/tests/Console/ModelsCommand/SoftDeletes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/SoftDeletes/__snapshots__/Test__test__1.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\SoftDeletes\Models\Simple
+ * 
  *
  * @property integer $id
  * @method static \Illuminate\Database\Eloquent\Builder|Simple newModelQuery()

--- a/tests/Console/ModelsCommand/UnionTypes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/UnionTypes/__snapshots__/Test__test__1.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Query\Builder;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\UnionTypes\Models\UnionTypeModel
+ * 
  *
  * @property-read string|int|null $foo
  * @property-read \Illuminate\Database\Eloquent\Collection<int, UnionTypeModel> $withUnionTypeReturn

--- a/tests/Console/ModelsCommand/Variadic/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Variadic/__snapshots__/Test__test__1.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Variadic\Models\Simple
+ * 
  *
  * @property integer $id
  * @method static Builder|Simple newModelQuery()


### PR DESCRIPTION
## Summary
Instead of having reset and smart-reset, just reset and never change the test. I don't really see why we should mention the classname in the phpdocs? So just leave the text be, or empty?

## Type of change

- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
