### PR TITLE
phpunit --migrate-configuration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+        cacheDirectory=".phpunit.result.cache"
+>
     <testsuites>
         <testsuite name="Unit Tests">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">src/</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>


### PR DESCRIPTION
## Summary
Fixes the following warning:
> 1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!

## Type of change
- [x] Misc. change (internal, infrastructure, maintenance, etc.)
