### PR TITLE
Allowing table inspection to gracefully fail so other IDE helpers for models may still be generated

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -11,7 +11,7 @@ return [
     |
     */
 
-    'filename'  => '_ide_helper.php',
+    'filename' => '_ide_helper.php',
 
     /*
     |--------------------------------------------------------------------------
@@ -152,6 +152,19 @@ return [
     */
 
     'ignored_models' => [
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Models to silence warnings
+    |--------------------------------------------------------------------------
+    |
+    | Define which models should have warnings silenced
+    |
+    */
+
+    'silenced_models' => [
 
     ],
 


### PR DESCRIPTION
## Summary
This adds logic to allow table inspection to gracefully fail. More specifically, this allows other the doc block generation to continue and generate other helpers that aren't database related. 

A use case for this is for NoSQL database drivers, for which schema inspection doesn't make sense or doesn't have a convention to determine columns, yet is still helpful to have a handful of the other IDE helpers that this package is capable of generating. Currently, when using the latest Laravel MongoDB package the corresponding driver does not implement the `compileColumns` method. So we see an error thrown that mentions this undefined method when running the command to generate doc blocks for models configured to use a Mongo DB connection.

 I've linked a couple of issues that mention this. 

I've also added silence-able warnings if table properties could not be inspected for a given model. A warning is output as the command generates output and another at the end of the output denoting the models whose table could not be inspected, to ensure the developer is aware to scroll up should the output be many lines long. See attached screenshots

https://github.com/barryvdh/laravel-ide-helper/issues/590
https://github.com/mongodb/laravel-mongodb/issues/1785

## Type of change
This could be thought of as a bug fix, new feature, or misc change – depending on how you look at it.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
