### PR TITLE
fix: unknown format PHPDoc

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -110,7 +110,7 @@ class ModelsCommand extends Command
     protected $phpstorm_noinspections;
     protected $write_model_external_builder_methods;
     /**
-     * @var bool[string]
+     * @var array<string, true>
      */
     protected $nullableColumns = [];
     /**


### PR DESCRIPTION
## Summary
Fixed PHPDoc with unknown formatting.
I set `TValue` to `true`, should I use `bool` ?

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
