### PR TITLE
Add `static` to `isBuiltin()` check in `ide-helper:models`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Fix return value of query scopes from parent class [#1366 / sforward](https://github.com/barryvdh/laravel-ide-helper/pull/1366)
+- Add static to isBuiltin() check in ide-helper:models [#1541 / bram-pkg](https://github.com/barryvdh/laravel-ide-helper/pull/1541)
 
 ### Changed
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1415,7 +1415,7 @@ class ModelsCommand extends Command
             $reflectionType = $this->getReturnTypeFromDocBlock($methodReflection);
         }
 
-        if ($reflectionType === 'static' || $reflectionType === '\\static' || $reflectionType === '$this') {
+        if ($reflectionType === 'static' || $reflectionType === '$this') {
             $reflectionType = $type;
         }
 
@@ -1598,7 +1598,7 @@ class ModelsCommand extends Command
     protected function getReflectionNamedType(ReflectionNamedType $paramType): string
     {
         $parameterName = $paramType->getName();
-        if (!$paramType->isBuiltin()) {
+        if (!$paramType->isBuiltin() && $paramType->getName() !== 'static') {
             $parameterName = '\\' . $parameterName;
         }
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1415,7 +1415,7 @@ class ModelsCommand extends Command
             $reflectionType = $this->getReturnTypeFromDocBlock($methodReflection);
         }
 
-        if ($reflectionType === 'static' || $reflectionType === '$this') {
+        if ($reflectionType === 'static' || $reflectionType === '\\static' || $reflectionType === '$this') {
             $reflectionType = $type;
         }
 

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithStaticReturnType.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CustomCasterWithStaticReturnType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+class CustomCasterWithStaticReturnType implements CastsAttributes
+{
+    public function get(Model $model, string $key, mixed $value, array $attributes): static
+    {
+        // TODO: Implement get() method.
+    }
+
+    public function set(Model $model, string $key, mixed $value, array $attributes): array
+    {
+        // TODO: Implement set() method.
+    }
+}

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Models/CustomCast.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Models/CustomCast.php
@@ -15,6 +15,7 @@ use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Cas
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithPrimitiveDocblockReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithPrimitiveReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithReturnType;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithStaticReturnType;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\ExtendedSelfCastingCasterWithStaticDocblockReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\ExtendedSelfCastingCasterWithThisDocblockReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\InboundAttributeCaster;
@@ -26,6 +27,7 @@ class CustomCast extends Model
 {
     protected $casts = [
         'casted_property_with_return_type' => CustomCasterWithReturnType::class,
+        'casted_property_with_static_return_type' => CustomCasterWithStaticReturnType::class,
         'casted_property_with_return_docblock' => CustomCasterWithDocblockReturn::class,
         'casted_property_with_return_docblock_fqn' => CustomCasterWithDocblockReturnFqn::class,
         'casted_property_with_return_primitive' => CustomCasterWithPrimitiveReturn::class,

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/__snapshots__/Test__test__1.php
@@ -15,6 +15,7 @@ use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Cas
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithPrimitiveDocblockReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithPrimitiveReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithReturnType;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithStaticReturnType;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\ExtendedSelfCastingCasterWithStaticDocblockReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\ExtendedSelfCastingCasterWithThisDocblockReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\InboundAttributeCaster;
@@ -39,6 +40,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property ExtendedSelfCastingCasterWithStaticDocblockReturn $extended_casted_property_with_static_return_docblock
  * @property ExtendedSelfCastingCasterWithThisDocblockReturn $extended_casted_property_with_this_return_docblock
  * @property SelfCastingCasterWithStaticDocblockReturn $casted_property_with_static_return_docblock_and_param
+ * @property CustomCasterWithStaticReturnType $casted_property_with_static_return_type
  * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $casted_property_with_castable
  * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $casted_property_with_anonymous_cast
  * @property CastableWithoutReturnType $casted_property_without_return_type
@@ -67,6 +69,7 @@ class CustomCast extends Model
 {
     protected $casts = [
         'casted_property_with_return_type' => CustomCasterWithReturnType::class,
+        'casted_property_with_static_return_type' => CustomCasterWithStaticReturnType::class,
         'casted_property_with_return_docblock' => CustomCasterWithDocblockReturn::class,
         'casted_property_with_return_docblock_fqn' => CustomCasterWithDocblockReturnFqn::class,
         'casted_property_with_return_primitive' => CustomCasterWithPrimitiveReturn::class,


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->
For some reason, the `static` keyword as a return type, does not return `isBuiltin()` === true, so a `\\` is added. We need to manually add it to the built in check.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
