### PR TITLE
Update view "version" variable name to avoid potential conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Fix return value of query scopes from parent class [#1366 / sforward](https://github.com/barryvdh/laravel-ide-helper/pull/1366)
 
 ### Changed
+- Update view "version" variable name to avoid potential conflicts
 
 ### Added
  - Add type to pivot when using a custom pivot class [#1518 / d3v2a](https://github.com/barryvdh/laravel-ide-helper/pull/1518)

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -14,7 +14,7 @@
 
 /**
  * A helper file for Laravel, to provide autocomplete information to your IDE
- * Generated for Laravel <?= $version ?>.
+ * Generated for Laravel <?= $laravel_version ?>.
  *
  * This file should not be included in your code, only analyzed by your IDE!
  *

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -82,7 +82,7 @@ class Generator
             ->with('namespaces_by_alias_ns', $this->getAliasesByAliasNamespace())
             ->with('real_time_facades', $this->getRealTimeFacades())
             ->with('helpers', $this->helpers)
-            ->with('version', $app->version())
+            ->with('laravel_version', $app->version())
             ->with('include_fluent', $this->config->get('ide-helper.include_fluent', true))
             ->with('factories', $this->config->get('ide-helper.include_factory_builders') ? Factories::all() : [])
             ->render();


### PR DESCRIPTION
## Summary
We inherited a number of projects that have a global `version` variable shared with all views that is an array of things like asset versions, etc.

When running `php artisan ide-helper:generate` it results in an error since `$version` is used in this packages views.
```
Array to string conversion at vendor/barryvdh/laravel-ide-helper/resources/views/helper.php:17
```

This PR renames the variable to `$laravel_version` to avoid conflicts since it may be a common global variable name.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
