### PR TITLE
Improve replacement of return type for methods from Query\Builder

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -395,7 +395,8 @@ class Alias
                             $reflection,
                             $macro_name,
                             $this->interfaces,
-                            $this->classAliases
+                            $this->classAliases,
+                            $this->getReplaceReturnTypes()
                         );
                         $this->usedMethods[] = $macro_name;
                     }

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -18,6 +18,7 @@ use Barryvdh\Reflection\DocBlock\Tag\MethodTag;
 use Closure;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Facades\Facade;
 use ReflectionClass;
 use Throwable;
@@ -340,7 +341,7 @@ class Alias
                         $magic,
                         $this->interfaces,
                         $this->classAliases,
-                        $this->getReplaceReturnTypes()
+                        $this->getReplaceReturnTypes($class)
                     );
                 }
                 $this->usedMethods[] = $magic;
@@ -372,7 +373,7 @@ class Alias
                                 $method->name,
                                 $this->interfaces,
                                 $this->classAliases,
-                                $this->getReplaceReturnTypes()
+                                $this->getReplaceReturnTypes($reflection)
                             );
                         }
                         $this->usedMethods[] = $method->name;
@@ -396,7 +397,7 @@ class Alias
                             $macro_name,
                             $this->interfaces,
                             $this->classAliases,
-                            $this->getReplaceReturnTypes()
+                            $this->getReplaceReturnTypes($reflection)
                         );
                         $this->usedMethods[] = $macro_name;
                     }
@@ -405,9 +406,17 @@ class Alias
         }
     }
 
-    protected function getReplaceReturnTypes()
+    /**
+     * @param ReflectionClass $class
+     * @return string[]
+     */
+    protected function getReplaceReturnTypes($class)
     {
-        return $this->alias === 'Eloquent' ? ['$this' => EloquentBuilder::class . '|static'] : [];
+        if ($this->alias === 'Eloquent' && in_array($class->getName(), [EloquentBuilder::class, QueryBuilder::class])) {
+            return ['$this' => EloquentBuilder::class . '|static'];
+        }
+
+        return [];
     }
 
     /**

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -333,7 +333,15 @@ class Alias
 
             if (!in_array($magic, $this->usedMethods)) {
                 if ($class !== $this->root) {
-                    $this->methods[] = new Method($method, $this->alias, $class, $magic, $this->interfaces, $this->classAliases);
+                    $this->methods[] = new Method(
+                        $method,
+                        $this->alias,
+                        $class,
+                        $magic,
+                        $this->interfaces,
+                        $this->classAliases,
+                        $this->getReplaceReturnTypes()
+                    );
                 }
                 $this->usedMethods[] = $magic;
             }
@@ -363,7 +371,8 @@ class Alias
                                 $reflection,
                                 $method->name,
                                 $this->interfaces,
-                                $this->classAliases
+                                $this->classAliases,
+                                $this->getReplaceReturnTypes()
                             );
                         }
                         $this->usedMethods[] = $method->name;
@@ -393,6 +402,11 @@ class Alias
                 }
             }
         }
+    }
+
+    protected function getReplaceReturnTypes()
+    {
+        return $this->alias === 'Eloquent' ? ['$this' => EloquentBuilder::class . '|static'] : [];
     }
 
     /**

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -414,7 +414,7 @@ class Alias
     {
         if ($this->alias === 'Eloquent' && in_array($class->getName(), [EloquentBuilder::class, QueryBuilder::class])) {
             return [
-                '$this' => '\\' . EloquentBuilder::class . ($this->config->get('ide-helper.use_generics_annotations') ? '<static>' : '|static')
+                '$this' => '\\' . EloquentBuilder::class . ($this->config->get('ide-helper.use_generics_annotations') ? '<static>' : '|static'),
             ];
         }
 

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -413,7 +413,9 @@ class Alias
     protected function getReturnTypeNormalizers($class)
     {
         if ($this->alias === 'Eloquent' && in_array($class->getName(), [EloquentBuilder::class, QueryBuilder::class])) {
-            return ['$this' => '\\' . EloquentBuilder::class . '|static'];
+            return [
+                '$this' => '\\' . EloquentBuilder::class . ($this->config->get('ide-helper.use_generics_annotations') ? '<static>' : '|static')
+            ];
         }
 
         return [];

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -341,7 +341,7 @@ class Alias
                         $magic,
                         $this->interfaces,
                         $this->classAliases,
-                        $this->getReplaceReturnTypes($class)
+                        $this->getReturnTypeNormalizers($class)
                     );
                 }
                 $this->usedMethods[] = $magic;
@@ -373,7 +373,7 @@ class Alias
                                 $method->name,
                                 $this->interfaces,
                                 $this->classAliases,
-                                $this->getReplaceReturnTypes($reflection)
+                                $this->getReturnTypeNormalizers($reflection)
                             );
                         }
                         $this->usedMethods[] = $method->name;
@@ -397,7 +397,7 @@ class Alias
                             $macro_name,
                             $this->interfaces,
                             $this->classAliases,
-                            $this->getReplaceReturnTypes($reflection)
+                            $this->getReturnTypeNormalizers($reflection)
                         );
                         $this->usedMethods[] = $macro_name;
                     }
@@ -408,12 +408,12 @@ class Alias
 
     /**
      * @param ReflectionClass $class
-     * @return string[]
+     * @return array<string, string>
      */
-    protected function getReplaceReturnTypes($class)
+    protected function getReturnTypeNormalizers($class)
     {
         if ($this->alias === 'Eloquent' && in_array($class->getName(), [EloquentBuilder::class, QueryBuilder::class])) {
-            return ['$this' => EloquentBuilder::class . '|static'];
+            return ['$this' => '\\' . EloquentBuilder::class . '|static'];
         }
 
         return [];

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -18,6 +18,7 @@ class Macro extends Method
      * @param null                $methodName
      * @param array               $interfaces
      * @param array               $classAliases
+     * @param array               $replaceReturnTypes
      */
     public function __construct(
         $method,
@@ -25,9 +26,10 @@ class Macro extends Method
         $class,
         $methodName = null,
         $interfaces = [],
-        $classAliases = []
+        $classAliases = [],
+        $replaceReturnTypes = []
     ) {
-        parent::__construct($method, $alias, $class, $methodName, $interfaces, $classAliases);
+        parent::__construct($method, $alias, $class, $methodName, $interfaces, $classAliases, $replaceReturnTypes);
     }
 
     /**

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -18,7 +18,7 @@ class Macro extends Method
      * @param null                $methodName
      * @param array               $interfaces
      * @param array               $classAliases
-     * @param array               $replaceReturnTypes
+     * @param array               $returnTypeNormalizers
      */
     public function __construct(
         $method,
@@ -27,9 +27,9 @@ class Macro extends Method
         $methodName = null,
         $interfaces = [],
         $classAliases = [],
-        $replaceReturnTypes = []
+        $returnTypeNormalizers = []
     ) {
-        parent::__construct($method, $alias, $class, $methodName, $interfaces, $classAliases, $replaceReturnTypes);
+        parent::__construct($method, $alias, $class, $methodName, $interfaces, $classAliases, $returnTypeNormalizers);
     }
 
     /**

--- a/src/Method.php
+++ b/src/Method.php
@@ -46,6 +46,7 @@ class Method
      * @param string|null $methodName
      * @param array $interfaces
      * @param array $classAliases
+     * @param array $replaceReturnTypes
      */
     public function __construct($method, $alias, $class, $methodName = null, $interfaces = [], array $classAliases = [], $replaceReturnTypes = [])
     {

--- a/src/Method.php
+++ b/src/Method.php
@@ -303,7 +303,7 @@ class Method
 
         if ($tag->getType() === '$this') {
             in_array(ltrim($this->root, '\\'), [EloquentBuilder::class, QueryBuilder::class])
-                ? $tag->setType($this->root . '|static')
+                ? $tag->setType(EloquentBuilder::class . '|static')
                 : $tag->setType($this->root);
         }
     }

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -94,7 +94,7 @@ DOC;
         $reflectionClass = new \ReflectionClass(EloquentBuilder::class);
         $reflectionMethod = $reflectionClass->getMethod('where');
 
-        $method = new Method($reflectionMethod, 'Builder', $reflectionClass, null, [], [], ['$this' => '\\' . EloquentBuilder::class . '|static']);
+        $method = new Method($reflectionMethod, 'Builder', $reflectionClass, null, [], [], ['$this' => '\\' . EloquentBuilder::class . '<static>']);
 
         $output =  <<<'DOC'
 /**
@@ -104,7 +104,7 @@ DOC;
  * @param mixed $operator
  * @param mixed $value
  * @param string $boolean
- * @return \Illuminate\Database\Eloquent\Builder|static 
+ * @return \Illuminate\Database\Eloquent\Builder<static> 
  * @static 
  */
 DOC;
@@ -114,7 +114,7 @@ DOC;
         $this->assertSame(['$column', '$operator', '$value', '$boolean'], $method->getParams(false));
         $this->assertSame(['$column', "\$operator = null", "\$value = null", "\$boolean = 'and'"], $method->getParamsWithDefault(false));
         $this->assertTrue($method->shouldReturn());
-        $this->assertSame('\Illuminate\Database\Eloquent\Builder|static', rtrim($method->getReturnTag()->getType()));
+        $this->assertSame('\Illuminate\Database\Eloquent\Builder<static>', rtrim($method->getReturnTag()->getType()));
     }
 
     /**
@@ -125,7 +125,7 @@ DOC;
         $reflectionClass = new \ReflectionClass(QueryBuilder::class);
         $reflectionMethod = $reflectionClass->getMethod('whereNull');
 
-        $method = new Method($reflectionMethod, 'Builder', $reflectionClass, null, [], [], ['$this' => '\\' . EloquentBuilder::class . '|static']);
+        $method = new Method($reflectionMethod, 'Builder', $reflectionClass, null, [], [], ['$this' => '\\' . EloquentBuilder::class . '<static>']);
 
         $output =  <<<'DOC'
 /**
@@ -134,7 +134,7 @@ DOC;
  * @param string|array|\Illuminate\Contracts\Database\Query\Expression $columns
  * @param string $boolean
  * @param bool $not
- * @return \Illuminate\Database\Eloquent\Builder|static 
+ * @return \Illuminate\Database\Eloquent\Builder<static> 
  * @static 
  */
 DOC;
@@ -145,7 +145,7 @@ DOC;
         $this->assertSame(['$columns', '$boolean', '$not'], $method->getParams(false));
         $this->assertSame(['$columns', "\$boolean = 'and'", '$not = false'], $method->getParamsWithDefault(false));
         $this->assertTrue($method->shouldReturn());
-        $this->assertSame('\Illuminate\Database\Eloquent\Builder|static', rtrim($method->getReturnTag()->getType()));
+        $this->assertSame('\Illuminate\Database\Eloquent\Builder<static>', rtrim($method->getReturnTag()->getType()));
     }
 
     /**

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -135,7 +135,7 @@ DOC;
  * @param string|array|\Illuminate\Contracts\Database\Query\Expression $columns
  * @param string $boolean
  * @param bool $not
- * @return \Illuminate\Database\Query\Builder|static 
+ * @return \Illuminate\Database\Eloquent\Builder|static 
  * @static 
  */
 DOC;
@@ -147,7 +147,7 @@ DOC;
         $this->assertSame(['$columns', "\$boolean = 'and'", '$not = false'], $method->getParamsWithDefault(false));
         $this->assertTrue($method->shouldReturn());
         $this->assertSame('$this', $method->getReturn());
-        $this->assertSame('\Illuminate\Database\Query\Builder|static', rtrim($method->getReturnTag()->getType()));
+        $this->assertSame('\Illuminate\Database\Eloquent\Builder|static', rtrim($method->getReturnTag()->getType()));
     }
 
     /**

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -112,7 +112,7 @@ DOC;
         $this->assertSame('where', $method->getName());
         $this->assertSame('\\' . EloquentBuilder::class, $method->getDeclaringClass());
         $this->assertSame(['$column', '$operator', '$value', '$boolean'], $method->getParams(false));
-        $this->assertSame(['$column', "\$operator = null", "\$value = null", "\$boolean = 'and'"], $method->getParamsWithDefault(false));
+        $this->assertSame(['$column', '$operator = null', '$value = null', "\$boolean = 'and'"], $method->getParamsWithDefault(false));
         $this->assertTrue($method->shouldReturn());
         $this->assertSame('\Illuminate\Database\Eloquent\Builder<static>', rtrim($method->getReturnTag()->getType()));
     }

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -114,7 +114,6 @@ DOC;
         $this->assertSame(['$column', '$operator', '$value', '$boolean'], $method->getParams(false));
         $this->assertSame(['$column', "\$operator = null", "\$value = null", "\$boolean = 'and'"], $method->getParamsWithDefault(false));
         $this->assertTrue($method->shouldReturn());
-        $this->assertSame('$this', $method->getReturn());
         $this->assertSame('\Illuminate\Database\Eloquent\Builder|static', rtrim($method->getReturnTag()->getType()));
     }
 
@@ -146,7 +145,6 @@ DOC;
         $this->assertSame(['$columns', '$boolean', '$not'], $method->getParams(false));
         $this->assertSame(['$columns', "\$boolean = 'and'", '$not = false'], $method->getParamsWithDefault(false));
         $this->assertTrue($method->shouldReturn());
-        $this->assertSame('$this', $method->getReturn());
         $this->assertSame('\Illuminate\Database\Eloquent\Builder|static', rtrim($method->getReturnTag()->getType()));
     }
 


### PR DESCRIPTION
## Summary

See issue for expected improvement: https://github.com/barryvdh/laravel-ide-helper/issues/1574

The class `\Eloquent` in `_ide_helper.php` contains methods from `Illuminate\Database\Eloquent\Builder` and `Illuminate\Database\Query\Builder`. The return type for `$this` is replaced with the real class (in case of the Eloquent\Builder already with an additional `|static`). This merge requests replaces `$this` in methods from Query\Builder with the identical return type `Illuminate\Database\Eloquent\Builder|static`. In the context of an `\Eloquent` instance this should be the real behavior and improves the derived types.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [X] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [X] Code style has been fixed via `composer fix-style`
