### PR TITLE
Add support for `AsCollection::using` and `AsEnumCollection::of` casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Add support for AsCollection::using and AsEnumCollection::of casts [#1577 / uno-sw](https://github.com/barryvdh/laravel-ide-helper/pull/1577)
+
 2024-07-12, 3.1.0
 ------------------
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -409,8 +409,6 @@ class ModelsCommand extends Command
                 case 'immutable_datetime':
                     $realType = '\Carbon\CarbonImmutable';
                     break;
-                case AsCollection::class:
-                case AsEnumCollection::class:
                 case 'collection':
                     $realType = '\Illuminate\Support\Collection';
                     break;
@@ -434,6 +432,18 @@ class ModelsCommand extends Command
             }
             if ($this->isInboundCast($realType)) {
                 continue;
+            }
+
+            if (Str::startsWith($type, AsCollection::class)) {
+                $realType = $this->getTypeInModel($model, $params[0] ?? null) ?? '\Illuminate\Support\Collection';
+            }
+
+            if (Str::startsWith($type, AsEnumCollection::class)) {
+                $realType = '\Illuminate\Support\Collection';
+                $relatedModel = $this->getTypeInModel($model, $params[0] ?? null);
+                if ($relatedModel) {
+                    $realType = $this->getCollectionTypeHint($realType, $relatedModel);
+                }
             }
 
             $realType = $this->checkForCastableCasts($realType, $params);

--- a/tests/Console/ModelsCommand/AdvancedCasts/Collections/AdvancedCastCollection.php
+++ b/tests/Console/ModelsCommand/AdvancedCasts/Collections/AdvancedCastCollection.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AdvancedCasts\Collections;
+
+use Illuminate\Support\Collection;
+
+class AdvancedCastCollection extends Collection
+{
+}

--- a/tests/Console/ModelsCommand/AdvancedCasts/Enums/AdvancedCastEnum.php
+++ b/tests/Console/ModelsCommand/AdvancedCasts/Enums/AdvancedCastEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AdvancedCasts\Enums;
+
+enum AdvancedCastEnum
+{
+    case apple;
+    case banana;
+    case orange;
+}

--- a/tests/Console/ModelsCommand/AdvancedCasts/Models/AdvancedCast.php
+++ b/tests/Console/ModelsCommand/AdvancedCasts/Models/AdvancedCast.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AdvancedCasts\Models;
 
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AdvancedCasts\Collections\AdvancedCastCollection;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AdvancedCasts\Enums\AdvancedCastEnum;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
@@ -11,21 +13,26 @@ use Illuminate\Database\Eloquent\Model;
 
 class AdvancedCast extends Model
 {
-    protected $casts = [
-        'cast_to_date_serialization' => 'date:Y-m-d',
-        'cast_to_datetime_serialization' => 'datetime:Y-m-d H:i:s',
-        'cast_to_custom_datetime' => 'custom_datetime:Y-m-d H:i:s',
-        'cast_to_immutable_date' => 'immutable_date',
-        'cast_to_immutable_custom_datetime' => 'immutable_custom_datetime:Y-m-d H:i:s',
-        'cast_to_immutable_datetime' => 'immutable_datetime',
-        'cast_to_timestamp' => 'timestamp',
-        'cast_to_encrypted' => 'encrypted',
-        'cast_to_encrypted_array' => 'encrypted:array',
-        'cast_to_encrypted_collection' => 'encrypted:collection',
-        'cast_to_encrypted_json' => 'encrypted:json',
-        'cast_to_encrypted_object' => 'encrypted:object',
-        'cast_to_as_collection' => AsCollection::class,
-        'cast_to_as_enum_collection' => AsEnumCollection::class,
-        'cast_to_as_array_object' => AsArrayObject::class,
-    ];
+    protected function casts(): array
+    {
+        return [
+            'cast_to_date_serialization' => 'date:Y-m-d',
+            'cast_to_datetime_serialization' => 'datetime:Y-m-d H:i:s',
+            'cast_to_custom_datetime' => 'custom_datetime:Y-m-d H:i:s',
+            'cast_to_immutable_date' => 'immutable_date',
+            'cast_to_immutable_custom_datetime' => 'immutable_custom_datetime:Y-m-d H:i:s',
+            'cast_to_immutable_datetime' => 'immutable_datetime',
+            'cast_to_timestamp' => 'timestamp',
+            'cast_to_encrypted' => 'encrypted',
+            'cast_to_encrypted_array' => 'encrypted:array',
+            'cast_to_encrypted_collection' => 'encrypted:collection',
+            'cast_to_encrypted_json' => 'encrypted:json',
+            'cast_to_encrypted_object' => 'encrypted:object',
+            'cast_to_as_collection' => AsCollection::class,
+            'cast_to_as_collection_using' => AsCollection::using(AdvancedCastCollection::class),
+            'cast_to_as_enum_collection' => AsEnumCollection::class,
+            'cast_to_as_enum_collection_of' => AsEnumCollection::of(AdvancedCastEnum::class),
+            'cast_to_as_array_object' => AsArrayObject::class,
+        ];
+    }
 }

--- a/tests/Console/ModelsCommand/AdvancedCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/AdvancedCasts/__snapshots__/Test__test__1.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AdvancedCasts\Models;
 
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AdvancedCasts\Collections\AdvancedCastCollection;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AdvancedCasts\Enums\AdvancedCastEnum;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
@@ -27,6 +29,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property \Illuminate\Support\Collection $cast_to_as_collection
  * @property \Illuminate\Support\Collection $cast_to_as_enum_collection
  * @property \ArrayObject $cast_to_as_array_object
+ * @property AdvancedCastCollection $cast_to_as_collection_using
+ * @property \Illuminate\Support\Collection<int, AdvancedCastEnum> $cast_to_as_enum_collection_of
  * @method static \Illuminate\Database\Eloquent\Builder|AdvancedCast newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|AdvancedCast newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|AdvancedCast query()
@@ -49,21 +53,26 @@ use Illuminate\Database\Eloquent\Model;
  */
 class AdvancedCast extends Model
 {
-    protected $casts = [
-        'cast_to_date_serialization' => 'date:Y-m-d',
-        'cast_to_datetime_serialization' => 'datetime:Y-m-d H:i:s',
-        'cast_to_custom_datetime' => 'custom_datetime:Y-m-d H:i:s',
-        'cast_to_immutable_date' => 'immutable_date',
-        'cast_to_immutable_custom_datetime' => 'immutable_custom_datetime:Y-m-d H:i:s',
-        'cast_to_immutable_datetime' => 'immutable_datetime',
-        'cast_to_timestamp' => 'timestamp',
-        'cast_to_encrypted' => 'encrypted',
-        'cast_to_encrypted_array' => 'encrypted:array',
-        'cast_to_encrypted_collection' => 'encrypted:collection',
-        'cast_to_encrypted_json' => 'encrypted:json',
-        'cast_to_encrypted_object' => 'encrypted:object',
-        'cast_to_as_collection' => AsCollection::class,
-        'cast_to_as_enum_collection' => AsEnumCollection::class,
-        'cast_to_as_array_object' => AsArrayObject::class,
-    ];
+    protected function casts(): array
+    {
+        return [
+            'cast_to_date_serialization' => 'date:Y-m-d',
+            'cast_to_datetime_serialization' => 'datetime:Y-m-d H:i:s',
+            'cast_to_custom_datetime' => 'custom_datetime:Y-m-d H:i:s',
+            'cast_to_immutable_date' => 'immutable_date',
+            'cast_to_immutable_custom_datetime' => 'immutable_custom_datetime:Y-m-d H:i:s',
+            'cast_to_immutable_datetime' => 'immutable_datetime',
+            'cast_to_timestamp' => 'timestamp',
+            'cast_to_encrypted' => 'encrypted',
+            'cast_to_encrypted_array' => 'encrypted:array',
+            'cast_to_encrypted_collection' => 'encrypted:collection',
+            'cast_to_encrypted_json' => 'encrypted:json',
+            'cast_to_encrypted_object' => 'encrypted:object',
+            'cast_to_as_collection' => AsCollection::class,
+            'cast_to_as_collection_using' => AsCollection::using(AdvancedCastCollection::class),
+            'cast_to_as_enum_collection' => AsEnumCollection::class,
+            'cast_to_as_enum_collection_of' => AsEnumCollection::of(AdvancedCastEnum::class),
+            'cast_to_as_array_object' => AsArrayObject::class,
+        ];
+    }
 }


### PR DESCRIPTION
## Summary

When you have the casts definition in a model like:

```php
protected function casts(): array
{
    return [
        'options' => AsCollection::using(OptionCollection::class),
        'statuses' => AsEnumCollection::of(ServerStatus::class),
    ];
}
```

then `php artisan ide-helper:models` command will generate the following PHPDoc for the model:

```php
/**
 * @property OptionCollection $options
 * @property \Illuminate\Support\Collection<int, ServerStatus> $statuses
 */
```

It also supports styles prior to Laravel 11:

```php
protected $casts = [
    'options' => AsCollection::class.':'.OptionCollection::class,
    'statuses' => AsEnumCollection::class.':'.ServerStatus::class,
];
```

Related to #1553

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist

- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
