### PR TITLE
Fix type of hased model property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 --------------
 
 ### Fixed
+- Fix type of hashed model property to `string`
 
 ### Changed
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -382,6 +382,7 @@ class ModelsCommand extends Command
                     break;
                 case 'decimal':
                 case 'string':
+                case 'hashed':
                     $realType = 'string';
                     break;
                 case 'array':

--- a/tests/Console/ModelsCommand/SimpleCasts/Models/SimpleCast.php
+++ b/tests/Console/ModelsCommand/SimpleCasts/Models/SimpleCast.php
@@ -39,5 +39,6 @@ class SimpleCast extends Model
         'cast_to_encrypted_collection' => 'encrypted:collection',
         'cast_to_encrypted_json' => 'encrypted:json',
         'cast_to_encrypted_object' => 'encrypted:object',
+        'cast_to_hashed' => 'hashed',
     ];
 }

--- a/tests/Console/ModelsCommand/SimpleCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/SimpleCasts/__snapshots__/Test__test__1.php
@@ -105,5 +105,6 @@ class SimpleCast extends Model
         'cast_to_encrypted_collection' => 'encrypted:collection',
         'cast_to_encrypted_json' => 'encrypted:json',
         'cast_to_encrypted_object' => 'encrypted:object',
+        'cast_to_hashed' => 'hashed',
     ];
 }


### PR DESCRIPTION
## Summary
Since Laravel 10 + cast `password` as `hashed` by default, the IDE_helper used to set the type of `$user->password` as `mixed`. 
This small PR is to set it to `string`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Code style has been fixed via `composer fix-style`
