### PR TITLE
Fix Factory resolution, get object instead of string

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1349,6 +1349,10 @@ class ModelsCommand extends Command
             $factory = get_class($modelName::newFactory());
         } else {
             $factory = Factory::resolveFactoryName($modelName);
+
+            if (is_object($factory)) {
+                $factory = get_class($factory);
+            }
         }
 
         $factory = '\\' . trim($factory, '\\');

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1351,6 +1351,7 @@ class ModelsCommand extends Command
             $factory = Factory::resolveFactoryName($modelName);
 
             if (is_object($factory)) {
+                /** @psalm-suppress TypeDoesNotContainType */
                 $factory = get_class($factory);
             }
         }


### PR DESCRIPTION
## Summary
During Factories analysis, the Factory::resolve FactoryName method returns an object and not a string.
I using PHP 8.3, I don't tested with older version.

Exception: trim(): Argument #1 ($string) must be of type string, App\Domain\Project\Database\Factories\TaskFactory given
Could not analyze class App\Domain\Project\Models\Task.

Trace:
#0 /var/www/current/vendor/barryvdh/laravel-ide-helper/src/Console/ModelsCommand.php(1353): trim(Object(App\Domain\Project\Database\Factories\TaskFactory), '\\')
#1 /var/www/current/vendor/barryvdh/laravel-ide-helper/src/Console/ModelsCommand.php(297): Barryvdh\LaravelIdeHelper\Console\ModelsCommand->getFactoryMethods(Object(App\Domain\Project\Models\Task))
#2 /var/www/current/vendor/barryvdh/laravel-ide-helper/src/Console/ModelsCommand.php(180): Barryvdh\LaravelIdeHelper\Console\ModelsCommand->generateDocs(Array, Array)
#3 /var/www/current/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): Barryvdh\LaravelIdeHelper\Console\ModelsCommand->handle()
#4 /var/www/current/vendor/laravel/framework/src/Illuminate/Container/Util.php(43): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#5 /var/www/current/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(95): Illuminate\Container\Util::unwrapIfClosure(Object(Closure))
#6 /var/www/current/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(35): Illuminate\Container\BoundMethod::callBoundMethod(Object(Illuminate\Foundation\Application), Array, Object(Closure))
#7 /var/www/current/vendor/laravel/framework/src/Illuminate/Container/Container.php(690): Illuminate\Container\BoundMethod::call(Object(Illuminate\Foundation\Application), Array, Array, NULL)
#8 /var/www/current/vendor/laravel/framework/src/Illuminate/Console/Command.php(213): Illuminate\Container\Container->call(Array)
#9 /var/www/current/vendor/symfony/console/Command/Command.php(279): Illuminate\Console\Command->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Illuminate\Console\OutputStyle))
#10 /var/www/current/vendor/laravel/framework/src/Illuminate/Console/Command.php(182): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Illuminate\Console\OutputStyle))
#11 /var/www/current/vendor/symfony/console/Application.php(1047): Illuminate\Console\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /var/www/current/vendor/symfony/console/Application.php(316): Symfony\Component\Console\Application->doRunCommand(Object(Barryvdh\LaravelIdeHelper\Console\ModelsCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 /var/www/current/vendor/symfony/console/Application.php(167): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 /var/www/current/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(197): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 /var/www/current/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(1203): Illuminate\Foundation\Console\Kernel->handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 /var/www/current/artisan(13): Illuminate\Foundation\Application->handleCommand(Object(Symfony\Component\Console\Input\ArgvInput))
#17 {main}

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
