### PR TITLE
fix: Remove unnecessary test failing in Laravel 11.23 and later

### DIFF
--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Barryvdh\LaravelIdeHelper\Tests;
 
 use Barryvdh\LaravelIdeHelper\Method;
-use Illuminate\Database\Eloquent\Builder;
 use PHPUnit\Framework\TestCase;
 
 class MethodTest extends TestCase
@@ -50,36 +49,6 @@ DOC;
         $this->assertSame(['$last', '$first', '...$middle'], $method->getParams(false));
         $this->assertSame('$last, $first = \'Barry\', ...$middle', $method->getParamsWithDefault(true));
         $this->assertSame(['$last', '$first = \'Barry\'', '...$middle'], $method->getParamsWithDefault(false));
-        $this->assertTrue($method->shouldReturn());
-    }
-
-    /**
-     * Test the output of a class
-     */
-    public function testEloquentBuilderOutput()
-    {
-        $reflectionClass = new \ReflectionClass(Builder::class);
-        $reflectionMethod = $reflectionClass->getMethod('with');
-
-        $method = new Method($reflectionMethod, 'Builder', $reflectionClass);
-
-        $output =  <<<'DOC'
-/**
- * Set the relationships that should be eager loaded.
- *
- * @param string|array $relations
- * @param string|\Closure|null $callback
- * @return \Illuminate\Database\Eloquent\Builder|static 
- * @static 
- */
-DOC;
-        $this->assertSame($output, $method->getDocComment(''));
-        $this->assertSame('with', $method->getName());
-        $this->assertSame('\\' . Builder::class, $method->getDeclaringClass());
-        $this->assertSame('$relations, $callback', $method->getParams(true));
-        $this->assertSame(['$relations', '$callback'], $method->getParams(false));
-        $this->assertSame('$relations, $callback = null', $method->getParamsWithDefault(true));
-        $this->assertSame(['$relations', '$callback = null'], $method->getParamsWithDefault(false));
         $this->assertTrue($method->shouldReturn());
     }
 


### PR DESCRIPTION
## Summary

Fixed test failures in Laravel 11.23 and later. The cause is the following changes on the laravel/framework side:

* laravel/framework#52729
* laravel/framework#52762

However, the output that this test asserts is not currently output anywhere in Helper. Therefore, I simply removed the test.

This test failure occurs at `laravel=11.*`, `stability=prefer-stable`, and blocks #1591, #1592.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added

---

## Detail

1. The failing test targets the `with()` method of the `Illuminate\Database\Eloquent\Builder` class. The pull request on the laravel/framework side mentioned above was also a fix to this DocBlock.
2. A method named `with()` also exists in the `Illuminate/Database/Eloquent/Model` class:
   https://github.com/laravel/framework/blob/231091c19945f058c576005907a5518fcc7a2bb1/src/Illuminate/Database/Eloquent/Model.php#L698-L704
3. In this case, the `with()` from the `Model` side is used, as it is evaluated first.
4. **The resolved `Model::with()` is not emitted by design because it is a method on a base class:**
   https://github.com/barryvdh/laravel-ide-helper/blob/4f588b97824b5c542f65132296677a2a4a91f4a0/src/Alias.php#L357
