### PR TITLE
fix: Model's `--write` duplicates array properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "barryvdh/reflection-docblock": "^2.1.1",
+        "barryvdh/reflection-docblock": "^2.1.2",
         "composer/class-map-generator": "^1.0",
         "illuminate/console": "^10 || ^11",
         "illuminate/database": "^10.38 || ^11",

--- a/tests/Console/ModelsCommand/ArrayCastsWithComment/Test.php
+++ b/tests/Console/ModelsCommand/ArrayCastsWithComment/Test.php
@@ -9,10 +9,6 @@ use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
 
 class Test extends AbstractModelsCommand
 {
-    /**
-     * The generated snapshot is wrong until
-     * https://github.com/barryvdh/laravel-ide-helper/issues/1505 is fixed
-     */
     public function test(): void
     {
         $command = $this->app->make(ModelsCommand::class);

--- a/tests/Console/ModelsCommand/ArrayCastsWithComment/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/ArrayCastsWithComment/__snapshots__/Test__test__1.php
@@ -28,9 +28,6 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $cast_to_bool
  * @property string $cast_to_boolean
  * @property string $cast_to_object
- * @property array $cast_to_array
- * @property array $cast_to_json
- * @property \Illuminate\Support\Collection $cast_to_collection
  * @property string $cast_to_date
  * @property string $cast_to_datetime
  * @property string $cast_to_date_serialization


### PR DESCRIPTION
## Summary

Thanks for merging barryvdh/ReflectionDocBlock#17. This pull request closes #1505 

Now that the new version has been published:

* Use the new corrected version for testing, including the `prefer-lowest` tests
* Fix the tests that were marked as incorrect to be correct

I've made the above changes.

## Type of change

- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist

- [x] Existing tests have been adapted and/or new tests have been added
