### PR TITLE
Fix upstream dependent test failure in Laravel 11.23 and later

### DIFF
--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -59,27 +59,28 @@ DOC;
     public function testEloquentBuilderOutput()
     {
         $reflectionClass = new \ReflectionClass(Builder::class);
-        $reflectionMethod = $reflectionClass->getMethod('with');
+        $reflectionMethod = $reflectionClass->getMethod('upsert');
 
         $method = new Method($reflectionMethod, 'Builder', $reflectionClass);
 
         $output =  <<<'DOC'
 /**
- * Set the relationships that should be eager loaded.
+ * Insert new records or update the existing ones.
  *
- * @param string|array $relations
- * @param string|\Closure|null $callback
- * @return \Illuminate\Database\Eloquent\Builder|static 
+ * @param array $values
+ * @param array|string $uniqueBy
+ * @param array|null $update
+ * @return int 
  * @static 
  */
 DOC;
         $this->assertSame($output, $method->getDocComment(''));
-        $this->assertSame('with', $method->getName());
+        $this->assertSame('upsert', $method->getName());
         $this->assertSame('\\' . Builder::class, $method->getDeclaringClass());
-        $this->assertSame('$relations, $callback', $method->getParams(true));
-        $this->assertSame(['$relations', '$callback'], $method->getParams(false));
-        $this->assertSame('$relations, $callback = null', $method->getParamsWithDefault(true));
-        $this->assertSame(['$relations', '$callback = null'], $method->getParamsWithDefault(false));
+        $this->assertSame('$values, $uniqueBy, $update', $method->getParams(true));
+        $this->assertSame(['$values', '$uniqueBy', '$update'], $method->getParams(false));
+        $this->assertSame('$values, $uniqueBy, $update = null', $method->getParamsWithDefault(true));
+        $this->assertSame(['$values', '$uniqueBy', '$update = null'], $method->getParamsWithDefault(false));
         $this->assertTrue($method->shouldReturn());
     }
 


### PR DESCRIPTION
## Summary

Fixed test failures in Laravel 11.23 and later. The cause is the following changes on the laravel/framework side:

* laravel/framework#52729
* laravel/framework#52762

I addressed the issue by changing the Laravel method that we were testing.

The following points were taken into consideration when selecting the target method:

* It must be a method of the Eloquent `Builder` class, just like before the fix.
* The content does not change between the CI options `prefer-oldest` and `prefer-stable`, and is unlikely to change in the future.
* It must be a method that accepts multiple parameters.
* Some of these parameters must have default values.

By satisfying these conditions, we can perform tests equivalent to `with()`, which was the target of tests before the fix. `upsert` met the conditions, so I selected it.

## Note

This pull request, #1594, and #1591 can all be merged independently.

IMO, the following order is best:

1. Merging 1594 should make all of this pull request's tests pass.
2. If we merge this pull request, all of 1591's tests should pass.
3. 1591 contains a breaking change. Merge it last.

## Type of change

- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
