### PR TITLE
feat(pivot): add support for multiple pivot types when using the same accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-[Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v3.1.0...master)
+[Next release](https://github.com/barryvdh/laravel-ide-helper/compare/v3.2.0...master)
+--------------
+
+### Changed
+Add support for multiple pivot types when using the same accessor.
+
+2024-10-18, 3.2.0
 --------------
 
 ### Fixed

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -726,7 +726,7 @@ class ModelsCommand extends Command
 
                                             $this->setProperty(
                                                 $relationObj->getPivotAccessor(),
-                                                $this->getClassNameInDestinationFile($model, $pivot),
+                                                $pivot,
                                                 true,
                                                 false
                                             );

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -714,6 +714,17 @@ class ModelsCommand extends Command
                                     if ($relationObj instanceof BelongsToMany) {
                                         $pivot = get_class($relationObj->newPivot());
                                         if (!in_array($pivot, [Pivot::class, MorphPivot::class])) {
+
+                                            $pivot = $this->getClassNameInDestinationFile($model, $pivot);
+
+                                            if($existingPivot = ($this->properties[$relationObj->getPivotAccessor()] ?? null)){
+                                                // If the pivot is already set, we need to append the type to it
+                                                $pivot .= '|'. $existingPivot['type'];
+                                            } else{
+                                                // pivots are not always set
+                                                $pivot .= '|null';
+                                            }
+
                                             $this->setProperty(
                                                 $relationObj->getPivotAccessor(),
                                                 $this->getClassNameInDestinationFile($model, $pivot),
@@ -722,6 +733,7 @@ class ModelsCommand extends Command
                                             );
                                         }
                                     }
+
                                     //Collection or array of models (because Collection is Arrayable)
                                     $relatedClass = '\\' . get_class($relationObj->getRelated());
                                     $collectionClass = $this->getCollectionClass($relatedClass);

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -714,13 +714,12 @@ class ModelsCommand extends Command
                                     if ($relationObj instanceof BelongsToMany) {
                                         $pivot = get_class($relationObj->newPivot());
                                         if (!in_array($pivot, [Pivot::class, MorphPivot::class])) {
-
                                             $pivot = $this->getClassNameInDestinationFile($model, $pivot);
 
-                                            if($existingPivot = ($this->properties[$relationObj->getPivotAccessor()] ?? null)){
+                                            if ($existingPivot = ($this->properties[$relationObj->getPivotAccessor()] ?? null)) {
                                                 // If the pivot is already set, we need to append the type to it
-                                                $pivot .= '|'. $existingPivot['type'];
-                                            } else{
+                                                $pivot .= '|' . $existingPivot['type'];
+                                            } else {
                                                 // pivots are not always set
                                                 $pivot .= '|null';
                                             }

--- a/tests/Console/ModelsCommand/Pivot/Models/ModelWithPivot.php
+++ b/tests/Console/ModelsCommand/Pivot/Models/ModelWithPivot.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Pivot\Models;
 
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Pivot\Models\Pivots\CustomPivot;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Pivot\Models\Pivots\DifferentCustomPivot;
 use Illuminate\Database\Eloquent\Model;
 
 class ModelWithPivot extends Model
@@ -14,5 +15,27 @@ class ModelWithPivot extends Model
         return $this->belongsToMany(ModelwithPivot::class)
             ->using(CustomPivot::class)
             ->as('customAccessor');
+    }
+
+
+    public function relationWithDifferentCustomPivot()
+    {
+        return $this->belongsToMany(ModelwithPivot::class)
+            ->using(DifferentCustomPivot::class)
+            ->as('differentCustomAccessor');
+    }
+
+    // without an accessor
+
+    public function relationCustomPivotUsingSameAccessor()
+    {
+        return $this->belongsToMany(ModelwithPivot::class)
+            ->using(CustomPivot::class);
+    }
+
+    public function relationWithDifferentCustomPivotUsingSameAccessor()
+    {
+        return $this->belongsToMany(ModelwithPivot::class)
+            ->using(DifferentCustomPivot::class);
     }
 }

--- a/tests/Console/ModelsCommand/Pivot/Models/Pivots/DifferentCustomPivot.php
+++ b/tests/Console/ModelsCommand/Pivot/Models/Pivots/DifferentCustomPivot.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Pivot\Models\Pivots;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class DifferentCustomPivot extends Pivot
+{
+}

--- a/tests/Console/ModelsCommand/Pivot/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Pivot/__snapshots__/Test__test__1.php
@@ -11,13 +11,13 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * 
  *
- * @property-read \DifferentCustomPivot|\CustomPivot|null $pivot
+ * @property-read DifferentCustomPivot|CustomPivot|null $pivot
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationCustomPivotUsingSameAccessor
  * @property-read int|null $relation_custom_pivot_using_same_accessor_count
- * @property-read \CustomPivot|null $customAccessor
+ * @property-read CustomPivot|null $customAccessor
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithCustomPivot
  * @property-read int|null $relation_with_custom_pivot_count
- * @property-read \DifferentCustomPivot|null $differentCustomAccessor
+ * @property-read DifferentCustomPivot|null $differentCustomAccessor
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithDifferentCustomPivot
  * @property-read int|null $relation_with_different_custom_pivot_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithDifferentCustomPivotUsingSameAccessor

--- a/tests/Console/ModelsCommand/Pivot/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Pivot/__snapshots__/Test__test__1.php
@@ -11,15 +11,15 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * 
  *
- * @property-read \DifferentCustomPivot|\CustomPivot|null $pivot
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationCustomPivotUsingSameAccessor
  * @property-read int|null $relation_custom_pivot_using_same_accessor_count
- * @property-read \CustomPivot|null $customAccessor
+ * @property-read DifferentCustomPivot|null $pivot
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithCustomPivot
  * @property-read int|null $relation_with_custom_pivot_count
- * @property-read \DifferentCustomPivot|null $differentCustomAccessor
+ * @property-read CustomPivot|null $customAccessor
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithDifferentCustomPivot
  * @property-read int|null $relation_with_different_custom_pivot_count
+ * @property-read DifferentCustomPivot|null $differentCustomAccessor
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithDifferentCustomPivotUsingSameAccessor
  * @property-read int|null $relation_with_different_custom_pivot_using_same_accessor_count
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ModelWithPivot newModelQuery()

--- a/tests/Console/ModelsCommand/Pivot/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Pivot/__snapshots__/Test__test__1.php
@@ -11,15 +11,15 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * 
  *
+ * @property-read \DifferentCustomPivot|\CustomPivot|null $pivot
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationCustomPivotUsingSameAccessor
  * @property-read int|null $relation_custom_pivot_using_same_accessor_count
- * @property-read DifferentCustomPivot|null $pivot
+ * @property-read \CustomPivot|null $customAccessor
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithCustomPivot
  * @property-read int|null $relation_with_custom_pivot_count
- * @property-read CustomPivot|null $customAccessor
+ * @property-read \DifferentCustomPivot|null $differentCustomAccessor
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithDifferentCustomPivot
  * @property-read int|null $relation_with_different_custom_pivot_count
- * @property-read DifferentCustomPivot|null $differentCustomAccessor
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithDifferentCustomPivotUsingSameAccessor
  * @property-read int|null $relation_with_different_custom_pivot_using_same_accessor_count
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ModelWithPivot newModelQuery()

--- a/tests/Console/ModelsCommand/Pivot/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Pivot/__snapshots__/Test__test__1.php
@@ -5,14 +5,23 @@ declare(strict_types=1);
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Pivot\Models;
 
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Pivot\Models\Pivots\CustomPivot;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Pivot\Models\Pivots\DifferentCustomPivot;
 use Illuminate\Database\Eloquent\Model;
 
 /**
  * 
  *
- * @property-read CustomPivot $customAccessor
+ * @property-read \DifferentCustomPivot|\CustomPivot|null $pivot
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationCustomPivotUsingSameAccessor
+ * @property-read int|null $relation_custom_pivot_using_same_accessor_count
+ * @property-read \CustomPivot|null $customAccessor
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithCustomPivot
  * @property-read int|null $relation_with_custom_pivot_count
+ * @property-read \DifferentCustomPivot|null $differentCustomAccessor
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithDifferentCustomPivot
+ * @property-read int|null $relation_with_different_custom_pivot_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithDifferentCustomPivotUsingSameAccessor
+ * @property-read int|null $relation_with_different_custom_pivot_using_same_accessor_count
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ModelWithPivot newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ModelWithPivot newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ModelWithPivot query()
@@ -25,6 +34,28 @@ class ModelWithPivot extends Model
         return $this->belongsToMany(ModelwithPivot::class)
             ->using(CustomPivot::class)
             ->as('customAccessor');
+    }
+
+
+    public function relationWithDifferentCustomPivot()
+    {
+        return $this->belongsToMany(ModelwithPivot::class)
+            ->using(DifferentCustomPivot::class)
+            ->as('differentCustomAccessor');
+    }
+
+    // without an accessor
+
+    public function relationCustomPivotUsingSameAccessor()
+    {
+        return $this->belongsToMany(ModelwithPivot::class)
+            ->using(CustomPivot::class);
+    }
+
+    public function relationWithDifferentCustomPivotUsingSameAccessor()
+    {
+        return $this->belongsToMany(ModelwithPivot::class)
+            ->using(DifferentCustomPivot::class);
     }
 }
 <?php
@@ -44,5 +75,24 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
  * @mixin \Eloquent
  */
 class CustomPivot extends Pivot
+{
+}
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Pivot\Models\Pivots;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * 
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|DifferentCustomPivot newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|DifferentCustomPivot newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|DifferentCustomPivot query()
+ * @mixin \Eloquent
+ */
+class DifferentCustomPivot extends Pivot
 {
 }


### PR DESCRIPTION
## Summary
Currently, when you have multiple `belongsToMany` relations with a custom pivot, the accessor will have a single type. This PR ensures that multiple types are allowed. Also the $pivot property should be nullable as it is not always set during runtime.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
