### PR TITLE
chore: Fix the description of unused option

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -219,7 +219,7 @@ class ModelsCommand extends Command
             ],
             ['nowrite', 'N', InputOption::VALUE_NONE, 'Don\'t write to Model file'],
             ['reset', 'R', InputOption::VALUE_NONE, 'Remove the original phpdocs instead of appending'],
-            ['smart-reset', 'r', InputOption::VALUE_NONE, 'Refresh the properties/methods list, but keep the text'],
+            ['smart-reset', 'r', InputOption::VALUE_NONE, 'Retained for compatibility, while it no longer has any effect'],
             ['phpstorm-noinspections', 'p', InputOption::VALUE_NONE,
                 'Add PhpFullyQualifiedNameUsageInspection and PhpUnnecessaryFullyQualifiedNameInspection PHPStorm ' .
                 'noinspection tags',


### PR DESCRIPTION
## Summary

`--smart-reset` was removed in #1525 and has no effect in 3.0 and later.

Removing it would be a breaking change, so why not leave the option and make it clear with `--help` that it has no effect?

## Type of change

- [x] Misc. change (internal, infrastructure, maintenance, etc.)
