### PR TITLE
fix(pivot): only use unique classes in the pivot union (Fixes #1606)

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -731,7 +731,7 @@ class ModelsCommand extends Command
                                             if ($existingPivot = ($this->properties[$relationObj->getPivotAccessor()] ?? null)) {
                                                 $existingClasses = explode('|', $existingPivot['type']);
 
-                                                if(!in_array($pivot, $existingClasses)) {
+                                                if (!in_array($pivot, $existingClasses)) {
                                                     array_unshift($existingClasses, $pivot);
                                                 }
                                             } else {

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -720,7 +720,7 @@ class ModelsCommand extends Command
                                     $relationReturnType === 'many' ||
                                     (
                                         !$relationReturnType &&
-                                        strpos(get_class($relationObj), 'Many') !== false
+                                        str_contains(get_class($relationObj), 'Many')
                                     )
                                 ) {
                                     if ($relationObj instanceof BelongsToMany) {
@@ -729,16 +729,22 @@ class ModelsCommand extends Command
                                             $pivot = $this->getClassNameInDestinationFile($model, $pivot);
 
                                             if ($existingPivot = ($this->properties[$relationObj->getPivotAccessor()] ?? null)) {
-                                                // If the pivot is already set, we need to append the type to it
-                                                $pivot .= '|' . $existingPivot['type'];
+                                                $existingClasses = explode('|', $existingPivot['type']);
+
+                                                if(!in_array($pivot, $existingClasses)) {
+                                                    array_unshift($existingClasses, $pivot);
+                                                }
                                             } else {
-                                                // pivots are not always set
-                                                $pivot .= '|null';
+                                                // No existing pivot property, so we need to add a null type
+                                                $existingClasses = [$pivot, 'null'];
                                             }
+
+                                            // create a union type of all pivot classes
+                                            $unionType = implode('|', $existingClasses);
 
                                             $this->setProperty(
                                                 $relationObj->getPivotAccessor(),
-                                                $pivot,
+                                                $unionType,
                                                 true,
                                                 false
                                             );

--- a/tests/Console/ModelsCommand/Pivot/Models/ModelWithPivot.php
+++ b/tests/Console/ModelsCommand/Pivot/Models/ModelWithPivot.php
@@ -33,6 +33,12 @@ class ModelWithPivot extends Model
             ->using(CustomPivot::class);
     }
 
+    public function relationCustomPivotUsingSameAccessorAndClass()
+    {
+        return $this->belongsToMany(ModelwithPivot::class)
+            ->using(CustomPivot::class);
+    }
+
     public function relationWithDifferentCustomPivotUsingSameAccessor()
     {
         return $this->belongsToMany(ModelwithPivot::class)

--- a/tests/Console/ModelsCommand/Pivot/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Pivot/__snapshots__/Test__test__1.php
@@ -14,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property-read DifferentCustomPivot|CustomPivot|null $pivot
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationCustomPivotUsingSameAccessor
  * @property-read int|null $relation_custom_pivot_using_same_accessor_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationCustomPivotUsingSameAccessorAndClass
+ * @property-read int|null $relation_custom_pivot_using_same_accessor_and_class_count
  * @property-read CustomPivot|null $customAccessor
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithCustomPivot
  * @property-read int|null $relation_with_custom_pivot_count
@@ -47,6 +49,12 @@ class ModelWithPivot extends Model
     // without an accessor
 
     public function relationCustomPivotUsingSameAccessor()
+    {
+        return $this->belongsToMany(ModelwithPivot::class)
+            ->using(CustomPivot::class);
+    }
+
+    public function relationCustomPivotUsingSameAccessorAndClass()
     {
         return $this->belongsToMany(ModelwithPivot::class)
             ->using(CustomPivot::class);


### PR DESCRIPTION
## Summary
This makes sure that we won't add a class that's already present in the union type for pivots. This can happen when multiple relations use the same Pivot class.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
