### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -1,8 +1,8 @@
 <?= '<?php' ?>
 <?php
 /**
- * @var \Barryvdh\LaravelIdeHelper\Alias[][] $namespaces_by_alias_ns
- * @var \Barryvdh\LaravelIdeHelper\Alias[][] $namespaces_by_extends_ns
+ * @var Barryvdh\LaravelIdeHelper\Alias[][] $namespaces_by_alias_ns
+ * @var Barryvdh\LaravelIdeHelper\Alias[][] $namespaces_by_extends_ns
  * @var bool $include_fluent
  * @var string $helpers
  */

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1304,7 +1304,7 @@ class ModelsCommand extends Command
      *
      * @return null|string
      */
-    protected function getReturnTypeFromDocBlock(\ReflectionMethod $reflection, \Reflector $reflectorForContext = null)
+    protected function getReturnTypeFromDocBlock(\ReflectionMethod $reflection, ?\Reflector $reflectorForContext = null)
     {
         $phpDocContext = (new ContextFactory())->createFromReflector($reflectorForContext ?? $reflection);
         $context = new Context(

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -50,7 +50,7 @@ class Generator
         $config,
         /* Illuminate\View\Factory */
         $view,
-        OutputInterface $output = null,
+        ?OutputInterface $output = null,
         $helpers = ''
     ) {
         $this->config = $config;

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -55,7 +55,7 @@ class MacroTest extends TestCase
     {
         $phpdoc = (new MacroMock())->getPhpDoc(
             new ReflectionFunction(
-                function (int $a = null): int {
+                function (?int $a = null): int {
                     return 0;
                 }
             )
@@ -79,7 +79,7 @@ class MacroTest extends TestCase
                 /**
                  * Test docblock.
                  */
-                function (int $a = null): int {
+                function (?int $a = null): int {
                     return 0;
                 }
             )
@@ -103,7 +103,7 @@ class MacroTest extends TestCase
                 /**
                  * Test docblock.
                  */
-                function (int $a = null) {
+                function (?int $a = null) {
                     return 0;
                 }
             )
@@ -274,7 +274,7 @@ class MacroMock extends Macro
         // no need to call parent
     }
 
-    public function getPhpDoc(ReflectionFunctionAbstract $method, ReflectionClass $class = null): DocBlock
+    public function getPhpDoc(ReflectionFunctionAbstract $method, ?ReflectionClass $class = null): DocBlock
     {
         return (new Macro($method, '', $class ?? $method->getClosureScopeClass()))->phpdoc;
     }


### PR DESCRIPTION
## Summary
This PR removes implicitly nullable parameters because these result in deprecation warnings for PHP 8.4.

https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
