### PR TITLE
Add weak generics for array type objects

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -389,7 +389,7 @@ class ModelsCommand extends Command
                     break;
                 case 'array':
                 case 'json':
-                    $realType = 'array';
+                    $realType = 'array<array-key, mixed>';
                     break;
                 case 'object':
                     $realType = 'object';
@@ -413,10 +413,10 @@ class ModelsCommand extends Command
                     $realType = '\Carbon\CarbonImmutable';
                     break;
                 case 'collection':
-                    $realType = '\Illuminate\Support\Collection';
+                    $realType = '\Illuminate\Support\Collection<array-key, mixed>';
                     break;
                 case AsArrayObject::class:
-                    $realType = '\ArrayObject';
+                    $realType = '\ArrayObject<array-key, mixed>';
                     break;
                 default:
                     // In case of an optional custom cast parameter , only evaluate

--- a/tests/Console/ModelsCommand/AdvancedCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/AdvancedCasts/__snapshots__/Test__test__1.php
@@ -22,13 +22,13 @@ use Illuminate\Database\Eloquent\Model;
  * @property \Carbon\CarbonImmutable $cast_to_immutable_datetime
  * @property int $cast_to_timestamp
  * @property mixed $cast_to_encrypted
- * @property array $cast_to_encrypted_array
- * @property \Illuminate\Support\Collection $cast_to_encrypted_collection
- * @property array $cast_to_encrypted_json
+ * @property array<array-key, mixed> $cast_to_encrypted_array
+ * @property \Illuminate\Support\Collection<array-key, mixed> $cast_to_encrypted_collection
+ * @property array<array-key, mixed> $cast_to_encrypted_json
  * @property object $cast_to_encrypted_object
  * @property \Illuminate\Support\Collection $cast_to_as_collection
  * @property \Illuminate\Support\Collection $cast_to_as_enum_collection
- * @property \ArrayObject $cast_to_as_array_object
+ * @property \ArrayObject<array-key, mixed> $cast_to_as_array_object
  * @property AdvancedCastCollection $cast_to_as_collection_using
  * @property \Illuminate\Support\Collection<int, AdvancedCastEnum> $cast_to_as_enum_collection_of
  * @method static \Illuminate\Database\Eloquent\Builder<static>|AdvancedCast newModelQuery()

--- a/tests/Console/ModelsCommand/SimpleCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/SimpleCasts/__snapshots__/Test__test__1.php
@@ -19,9 +19,9 @@ use Illuminate\Database\Eloquent\Model;
  * @property bool $cast_to_bool
  * @property bool $cast_to_boolean
  * @property object $cast_to_object
- * @property array $cast_to_array
- * @property array $cast_to_json
- * @property \Illuminate\Support\Collection $cast_to_collection
+ * @property array<array-key, mixed> $cast_to_array
+ * @property array<array-key, mixed> $cast_to_json
+ * @property \Illuminate\Support\Collection<array-key, mixed> $cast_to_collection
  * @property \Illuminate\Support\Carbon $cast_to_date
  * @property \Illuminate\Support\Carbon $cast_to_datetime
  * @property \Illuminate\Support\Carbon $cast_to_date_serialization
@@ -34,9 +34,9 @@ use Illuminate\Database\Eloquent\Model;
  * @property \Carbon\CarbonImmutable $cast_to_immutable_datetime_serialization
  * @property int $cast_to_timestamp
  * @property mixed $cast_to_encrypted
- * @property array $cast_to_encrypted_array
- * @property \Illuminate\Support\Collection $cast_to_encrypted_collection
- * @property array $cast_to_encrypted_json
+ * @property array<array-key, mixed> $cast_to_encrypted_array
+ * @property \Illuminate\Support\Collection<array-key, mixed> $cast_to_encrypted_collection
+ * @property array<array-key, mixed> $cast_to_encrypted_json
  * @property object $cast_to_encrypted_object
  * @method static \Illuminate\Database\Eloquent\Builder<static>|SimpleCast newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|SimpleCast newQuery()


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->
Add weak default generics of the kind <array-key, mixed> for default casts that returns those generics, i.e. json, array, arrayable and collection casts.

Solves #1614 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Update the README.md 
- [x] Code style has been fixed via `composer fix-style`
