### PR TITLE
Fixed PHP 8.4 deprecation warning

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1301,10 +1301,11 @@ class ModelsCommand extends Command
      * Get method return type based on it DocBlock comment
      *
      * @param \ReflectionMethod $reflection
+     * @param ?\Reflector $reflectorForContext
      *
      * @return null|string
      */
-    protected function getReturnTypeFromDocBlock(\ReflectionMethod $reflection, \Reflector $reflectorForContext = null)
+    protected function getReturnTypeFromDocBlock(\ReflectionMethod $reflection, ?\Reflector $reflectorForContext = null)
     {
         $phpDocContext = (new ContextFactory())->createFromReflector($reflectorForContext ?? $reflection);
         $context = new Context(

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -42,7 +42,7 @@ class Generator
     /**
      * @param \Illuminate\Config\Repository $config
      * @param \Illuminate\View\Factory $view
-     * @param OutputInterface $output
+     * @param ?OutputInterface $output
      * @param string $helpers
      */
     public function __construct(
@@ -50,7 +50,7 @@ class Generator
         $config,
         /* Illuminate\View\Factory */
         $view,
-        OutputInterface $output = null,
+        ?OutputInterface $output = null,
         $helpers = ''
     ) {
         $this->config = $config;


### PR DESCRIPTION
After upgrade from PHP 8.3 to 8.4 I get this deprecation error on laravel deprecated log.

```
WARNING: ErrorException: Barryvdh\LaravelIdeHelper\Console\ModelsCommand::getReturnTypeFromDocBlock(): Implicitly marking parameter $reflectorForContext as nullable is deprecated, the explicit nullable type must be used instead in vendor/barryvdh/laravel-ide-helper/src/Console/ModelsCommand.php:1305
```