### PR TITLE
Allow adding custom Macroable classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Str::macro('concat', function(string $str1, string $str2) : string {
 });
 ```
 
+You can add any custom Macroable traits to detect in the `macroable_traits` config option.
+
 ### Automatic PHPDocs for models
 
 If you don't want to write your properties yourself, you can use the command `php artisan ide-helper:models` to generate

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -344,7 +344,8 @@ return [
     |
     */
     'macroable_traits' => [
-        Illuminate\Support\Traits\Macroable::class,
+        \Filament\Support\Concerns\Macroable::class,
+        \Spatie\Macroable\Macroable::class,
     ],
 
 ];

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -334,4 +334,17 @@ return [
         // 'ide-helper:models --nowrite',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Macroable Traits
+    |--------------------------------------------------------------------------
+    |
+    | Define which traits should be considered capable of adding Macro.
+    | You can add any custom trait that behaves like the original Laravel one.
+    |
+    */
+    'macroable_traits' => [
+        Illuminate\Support\Traits\Macroable::class,
+    ],
+
 ];

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -46,6 +46,8 @@ class Alias
     protected $phpdoc = null;
     protected $classAliases = [];
 
+    protected $isMacroable = false;
+
     /** @var ConfigRepository  */
     protected $config;
 
@@ -60,12 +62,13 @@ class Alias
      * @param array            $magicMethods
      * @param array            $interfaces
      */
-    public function __construct($config, $alias, $facade, $magicMethods = [], $interfaces = [])
+    public function __construct($config, $alias, $facade, $magicMethods = [], $interfaces = [], $isMacroable = false)
     {
         $this->alias = $alias;
         $this->magicMethods = $magicMethods;
         $this->interfaces = $interfaces;
         $this->config = $config;
+        $this->isMacroable = $isMacroable;
 
         // Make the class absolute
         $facade = '\\' . ltrim($facade, '\\');
@@ -395,8 +398,7 @@ class Alias
 
             // Check if the class is macroable
             // (Eloquent\Builder is also macroable but doesn't use Macroable trait)
-            $traits = collect($reflection->getTraitNames());
-            if ($traits->contains('Illuminate\Support\Traits\Macroable') || $class === EloquentBuilder::class) {
+            if ($this->isMacroable || $class === EloquentBuilder::class) {
                 $properties = $reflection->getStaticProperties();
                 $macros = isset($properties['macros']) ? $properties['macros'] : [];
                 foreach ($macros as $macro_name => $macro_func) {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -61,7 +61,6 @@ class Generator
         $this->extra = array_merge($this->extra, $this->config->get('ide-helper.extra'), []);
         $this->magic = array_merge($this->magic, $this->config->get('ide-helper.magic'), []);
         $this->interfaces = array_merge($this->interfaces, $this->config->get('ide-helper.interfaces'), []);
-        $this->macroableTraits = array_merge($this->macroableTraits, $this->config->get('ide-helper.macroable_traits'), []);
         // Make all interface classes absolute
         foreach ($this->interfaces as &$interface) {
             $interface = '\\' . ltrim($interface, '\\');
@@ -343,7 +342,7 @@ class Generator
                 continue;
             }
 
-            $aliases[] = new Alias($this->config, $class, $class, [], $this->interfaces);
+            $aliases[] = new Alias($this->config, $class, $class, [], $this->interfaces, true);
         }
     }
 
@@ -365,8 +364,12 @@ class Generator
             ->filter(function ($class) {
                 $traits = class_uses_recursive($class);
 
+                if (isset($traits[Macroable::class])) {
+                    return true;
+                }
+
                 // Filter only classes with a macroable trait
-                foreach ($this->macroableTraits as $trait) {
+                foreach ($this->config->get('ide-helper.macroable_traits', []) as $trait) {
                     if (isset($traits[$trait])) {
                         return true;
                     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -35,6 +35,7 @@ class Generator
     protected $magic = [];
     protected $interfaces = [];
     protected $helpers;
+    protected array $macroableTraits = [];
 
     /**
      * @param \Illuminate\Config\Repository $config
@@ -60,6 +61,7 @@ class Generator
         $this->extra = array_merge($this->extra, $this->config->get('ide-helper.extra'), []);
         $this->magic = array_merge($this->magic, $this->config->get('ide-helper.magic'), []);
         $this->interfaces = array_merge($this->interfaces, $this->config->get('ide-helper.interfaces'), []);
+        $this->macroableTraits = array_merge($this->macroableTraits, $this->config->get('ide-helper.macroable_traits'), []);
         // Make all interface classes absolute
         foreach ($this->interfaces as &$interface) {
             $interface = '\\' . ltrim($interface, '\\');
@@ -363,8 +365,14 @@ class Generator
             ->filter(function ($class) {
                 $traits = class_uses_recursive($class);
 
-                // Filter only classes with the macroable trait
-                return isset($traits[Macroable::class]);
+                // Filter only classes with a macroable trait
+                foreach ($this->macroableTraits as $trait) {
+                    if (isset($traits[$trait])) {
+                        return true;
+                    }
+                }
+
+                return false;
             })
             ->filter(function ($class) use ($aliases) {
                 $class = Str::start($class, '\\');

--- a/tests/AliasTest.php
+++ b/tests/AliasTest.php
@@ -19,38 +19,13 @@ class AliasTest extends TestCase
     /**
      * @covers ::detectMethods
      */
-    public function testDetectMethodsMacroableMacros(): void
-    {
-        // Mock
-        $macro = __FUNCTION__;
-        $alias = new AliasMock();
-
-        // Macros
-        Builder::macro(
-            $macro,
-            function () {
-                // empty
-            }
-        );
-
-        // Prepare
-        $alias->setClasses([Builder::class]);
-        $alias->detectMethods();
-
-        // Test
-        $this->assertNotNull($this->getAliasMacro($alias, Builder::class, $macro));
-    }
-
-    /**
-     * @covers ::detectMethods
-     */
     public function testDetectMethodsEloquentBuilderMacros(): void
     {
         // Mock
         $macro = __FUNCTION__;
         $alias = new AliasMock();
 
-        // Macros
+        // Macrosx
         EloquentBuilder::macro(
             $macro,
             function () {


### PR DESCRIPTION
## Summary
Some packages, like [Filament](https://filamentphp.com), implements their own version of the Macroable trait.
Spatie even made [their own version](https://github.com/spatie/macroable).

This PR allow adding any macro class we want to detect in the config file.

Thanks,
Mathieu.
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
