### PR TITLE
Add meta override for user return types

### DIFF
--- a/resources/views/meta.php
+++ b/resources/views/meta.php
@@ -21,6 +21,12 @@ namespace PHPSTORM_META {
     ]));
 <?php endforeach; ?>
 
+<?php foreach ($userMethods as $method) : ?>
+    override(<?= $method ?>, map([
+        '' => \<?= $userModel ?>::class,
+    ]));
+<?php endforeach; ?>
+
 <?php foreach ($configMethods as $method) : ?>
     override(<?= $method ?>, map([
     <?php foreach ($configValues as $name => $value) : ?>

--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -73,6 +73,15 @@ class MetaCommand extends Command
         '\Illuminate\Support\Facades\Config::set()',
     ];
 
+    protected $userMethods = [
+        '\auth()->user()',
+        '\Illuminate\Contracts\Auth\Guard::user()',
+        '\Illuminate\Support\Facades\Auth::user()',
+        '\request()->user()',
+        '\Illuminate\Http\Request::user()',
+        '\Illuminate\Support\Facades\Request::user()'
+    ];
+
     protected $templateCache = [];
 
     /**
@@ -135,6 +144,8 @@ class MetaCommand extends Command
             return gettype($value);
         });
 
+        $defaultUserModel = $this->config->get('auth.providers.users.model', $this->config->get('auth.model', 'App\User'));
+
         $content = $this->view->make('ide-helper::meta', [
             'bindings' => $bindings,
             'methods' => $this->methods,
@@ -143,6 +154,8 @@ class MetaCommand extends Command
             'configValues' => $configValues,
             'expectedArgumentSets' => $this->getExpectedArgumentSets(),
             'expectedArguments' => $this->getExpectedArguments(),
+            'userModel' => $defaultUserModel,
+            'userMethods' => $this->userMethods,
         ])->render();
 
         $filename = $this->option('filename');

--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -79,7 +79,7 @@ class MetaCommand extends Command
         '\Illuminate\Support\Facades\Auth::user()',
         '\request()->user()',
         '\Illuminate\Http\Request::user()',
-        '\Illuminate\Support\Facades\Request::user()'
+        '\Illuminate\Support\Facades\Request::user()',
     ];
 
     protected $templateCache = [];


### PR DESCRIPTION
## Summary
When using the PHpstorm Metadata, this sets the user model correctly on thing like `$request->user()`

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
