### PR TITLE
Fixed generating PHPDoc for methods with class templates

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -15,8 +15,8 @@ use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Context;
 use Barryvdh\Reflection\DocBlock\ContextFactory;
 use Barryvdh\Reflection\DocBlock\Serializer as DocBlockSerializer;
-use Barryvdh\Reflection\DocBlock\Tag\TemplateTag;
 use Barryvdh\Reflection\DocBlock\Tag\MethodTag;
+use Barryvdh\Reflection\DocBlock\Tag\TemplateTag;
 use Closure;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
@@ -523,7 +523,7 @@ class Alias
 
             $phpdoc = new DocBlock($reflection);
             $templates = $phpdoc->getTagsByName('template');
-            /** @var DocBlock\Tag\TemplateTag $template */
+            /** @var TemplateTag $template */
             foreach ($templates as $template) {
                 $templateNames[] = $template->getTemplateName();
             }
@@ -532,7 +532,7 @@ class Alias
                 $phpdoc = new DocBlock(new ReflectionClass($trait));
                 $templates = $phpdoc->getTagsByName('template');
 
-                /** @var DocBlock\Tag\TemplateTag $template */
+                /** @var TemplateTag $template */
                 foreach ($templates as $template) {
                     $templateNames[] = $template->getTemplateName();
                 }

--- a/src/Method.php
+++ b/src/Method.php
@@ -39,6 +39,9 @@ class Method
     protected $classAliases;
     protected $returnTypeNormalizers;
 
+    /** @var string[] */
+    protected $templateNames = [];
+
     /**
      * @param \ReflectionMethod|\ReflectionFunctionAbstract $method
      * @param string $alias
@@ -47,8 +50,9 @@ class Method
      * @param array $interfaces
      * @param array $classAliases
      * @param array $returnTypeNormalizers
+     * @param string[] $templateNames
      */
-    public function __construct($method, $alias, $class, $methodName = null, $interfaces = [], array $classAliases = [], array $returnTypeNormalizers = [])
+    public function __construct($method, $alias, $class, $methodName = null, $interfaces = [], array $classAliases = [], array $returnTypeNormalizers = [], array $templateNames = [])
     {
         $this->method = $method;
         $this->interfaces = $interfaces;
@@ -56,6 +60,7 @@ class Method
         $this->returnTypeNormalizers = $returnTypeNormalizers;
         $this->name = $methodName ?: $method->name;
         $this->real_name = $method->isClosure() ? $this->name : $method->name;
+        $this->templateNames = $templateNames;
         $this->initClassDefinedProperties($method, $class);
 
         //Reference the 'real' function in the declaring class
@@ -84,7 +89,7 @@ class Method
      */
     protected function initPhpDoc($method)
     {
-        $this->phpdoc = new DocBlock($method, new Context($this->namespace, $this->classAliases));
+        $this->phpdoc = new DocBlock($method, new Context($this->namespace, $this->classAliases, generics: $this->templateNames));
     }
 
     /**
@@ -386,7 +391,7 @@ class Method
         }
         if ($method) {
             $namespace = $method->getDeclaringClass()->getNamespaceName();
-            $phpdoc = new DocBlock($method, new Context($namespace, $this->classAliases));
+            $phpdoc = new DocBlock($method, new Context($namespace, $this->classAliases, generics: $this->templateNames));
 
             if (strpos($phpdoc->getText(), '{@inheritdoc}') !== false) {
                 //Not at the end yet, try another parent/interface..

--- a/tests/AliasTest.php
+++ b/tests/AliasTest.php
@@ -66,6 +66,21 @@ class AliasTest extends TestCase
         $this->assertNotNull($this->getAliasMacro($alias, EloquentBuilder::class, $macro));
     }
 
+    /**
+     * @covers ::detectTemplateNames
+     */
+    public function testTemplateNamesAreDetected(): void
+    {
+        // Mock
+        $alias = new AliasMock();
+
+        // Prepare
+        $alias->setClasses([EloquentBuilder::class]);
+
+        // Test
+        $this->assertSame(['TModel', 'TValue'], $alias->getTemplateNames());
+    }
+
     protected function getAliasMacro(Alias $alias, string $class, string $method): ?Macro
     {
         return Arr::first(
@@ -82,6 +97,7 @@ class AliasTest extends TestCase
 /**
  * @internal
  * @noinspection PhpMultipleClassesDeclarationsInOneFile
+ * @template TValue
  */
 class AliasMock extends Alias
 {

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -193,6 +193,29 @@ DOC;
         $this->assertSame([], $method->getParamsWithDefault(false));
         $this->assertTrue($method->shouldReturn());
     }
+
+    public function testEloquentBuilderWithTemplates()
+    {
+        $reflectionClass = new \ReflectionClass(EloquentBuilder::class);
+        $reflectionMethod = $reflectionClass->getMethod('firstOr');
+
+        $method = new Method($reflectionMethod, 'Builder', $reflectionClass, null, [], [], [], ['TModel']);
+
+        $output =  <<<'DOC'
+/**
+ * Execute the query and get the first result or call a callback.
+ *
+ * @template TValue
+ * @param (\Closure(): TValue)|list<string> $columns
+ * @param (\Closure(): TValue)|null $callback
+ * @return TModel|TValue 
+ * @static 
+ */
+DOC;
+        $this->assertSame($output, $method->getDocComment(''));
+        $this->assertSame('firstOr', $method->getName());
+        $this->assertSame('\\' . EloquentBuilder::class, $method->getDeclaringClass());
+    }
 }
 
 class ExampleClass


### PR DESCRIPTION
## Summary
This correctly generate PHPDoc for methods using class templates. https://github.com/barryvdh/laravel-ide-helper/issues/1572#issuecomment-2565571051

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
