### PR TITLE
Feat guess macro types

### DIFF
--- a/src/Macro.php
+++ b/src/Macro.php
@@ -5,10 +5,15 @@ namespace Barryvdh\LaravelIdeHelper;
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Tag;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Collection;
 
 class Macro extends Method
 {
+    protected $macroDefaults = [
+        \Illuminate\Http\Client\Factory::class => PendingRequest::class,
+    ];
+
     /**
      * Macro constructor.
      *
@@ -75,6 +80,12 @@ class Macro extends Method
                 $type .= $return->allowsNull() ? '|null' : '';
             }
 
+            $this->phpdoc->appendTag(Tag::createInstance("@return {$type}"));
+        }
+
+        $class = ltrim($this->declaringClassName, "\\");
+        if (!$this->phpdoc->hasTag('return') && isset($this->macroDefaults[$class])) {
+            $type = $this->macroDefaults[$class];
             $this->phpdoc->appendTag(Tag::createInstance("@return {$type}"));
         }
     }

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -83,7 +83,7 @@ class Macro extends Method
             $this->phpdoc->appendTag(Tag::createInstance("@return {$type}"));
         }
 
-        $class = ltrim($this->declaringClassName, "\\");
+        $class = ltrim($this->declaringClassName, '\\');
         if (!$this->phpdoc->hasTag('return') && isset($this->macroDefaults[$class])) {
             $type = $this->macroDefaults[$class];
             $this->phpdoc->appendTag(Tag::createInstance("@return {$type}"));


### PR DESCRIPTION
## Summary
When a Macro is set for eg. the Client class, we cannot always know the return type. For ClientFactory, we assume the macro is a PendingRequest, even without typehints.

Fixes https://github.com/barryvdh/laravel-ide-helper/issues/1565

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
