### PR TITLE
Add special `dev` to composer keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "netbeans",
         "sublime",
         "codeintel",
-        "phpdoc"
+        "phpdoc",
+        "dev"
     ],
     "authors": [
         {


### PR DESCRIPTION
## Summary
The special `dev` keyword will warn users who run `composer require barryvdh/laravel-ide-helper` with the following prompt:
```
> composer require barryvdh/laravel-ide-helper
The package you required is recommended to be placed in require-dev (because it is tagged as "dev") but you did not use --dev.
Do you want to re-run the command with --dev? [yes]?
```

See also https://getcomposer.org/doc/04-schema.md#keywords.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
