### PR TITLE
Remove duplicate config, fix ->can()

### DIFF
--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -232,18 +232,14 @@ class MetaCommand extends Command
                 'argumentSet' => 'auth',
             ],
             [
-                'class' => ['\Illuminate\Support\Facades\Route', '\Illuminate\Support\Facades\Auth'],
+                'class' => ['\Illuminate\Support\Facades\Route', '\Illuminate\Support\Facades\Auth', 'Illuminate\Foundation\Auth\Access\Authorizable'],
                 'method' => ['can', 'cannot'],
                 'argumentSet' => 'auth',
             ],
             [
-                'method' => 'config',
-                'argumentSet' => 'configs',
-            ],
-            [
                 'class' => ['\Illuminate\Config\Repository', '\Illuminate\Support\Facades\Config'],
                 'method' => [
-                    'get',
+//                    'get',    // config() and Config::Get() are added with return type hints already
                     'getMany',
                     'set',
                     'string',


### PR DESCRIPTION
## Summary
- Config already added with return types for the get() calls
- Authorizable can() was missing for users.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
