### PR TITLE
feat: use generics of return type to determine resulting models

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -819,10 +819,14 @@ class ModelsCommand extends Command
                                         $relation === 'morphTo'
                                     )
                                 ) {
+                                    $matches = [];
+                                    $returnType = $this->getReturnTypeFromDocBlock($reflection);
+                                    preg_match('/MorphTo<(.+?)(?:,|>)/i', $returnType, $matches);
+
                                     // Model isn't specified because relation is polymorphic
                                     $this->setProperty(
                                         $method,
-                                        $this->getClassNameInDestinationFile($model, Model::class) . '|\Eloquent',
+                                        $matches[1] ?? $this->getClassNameInDestinationFile($model, Model::class) . '|\Eloquent',
                                         true,
                                         null,
                                         $comment,


### PR DESCRIPTION
## Summary

PHPStan requires you to specify the generics in a docblock when using MorphTo (and other relations) like this:

```php
/**
 * @return MorphTo<LocationComplex|LocationAccommodation|LocationRoom, $this>
 */
public function location(): MorphTo
{
    return $this->morphTo();
}
```

Since this is already in the same model, we can use these generics (if specified) to determine the type of MorphTo. This would save (at least me) the trouble of having to write a custom hook for each polymorphic relation that I use. :)

This will return the following docblock:
```php
/**
 * @property-read LocationComplex|LocationAccommodation|LocationRoom $location
 */
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
