### PR TITLE
Convert auth() helper to use Auth facade

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -123,6 +123,7 @@ return [
 
     'helper_files' => [
         base_path() . '/vendor/laravel/framework/src/Illuminate/Support/helpers.php',
+        base_path() . '/vendor/laravel/framework/src/Illuminate/Foundation/helpers.php',
     ],
 
     /*

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -117,11 +117,13 @@ class Generator
         $helpers = $this->helpers;
 
         $replacements = [
-            '($guard is null ? \Illuminate\Contracts\Auth\Factory : \Illuminate\Contracts\Auth\StatefulGuard)' => '\\Auth'
+            '($guard is null ? \Illuminate\Contracts\Auth\Factory : \Illuminate\Contracts\Auth\StatefulGuard)' => '\\Auth',
         ];
         foreach ($replacements as $search => $replace) {
-            $helpers= Str::replace(
-                "@return {$search}", "@return $replace|$search", $helpers
+            $helpers = Str::replace(
+                "@return {$search}",
+                "@return $replace|$search",
+                $helpers
             );
         }
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -80,7 +80,7 @@ class Generator
             ->with('namespaces_by_extends_ns', $this->getAliasesByExtendsNamespace())
             ->with('namespaces_by_alias_ns', $this->getAliasesByAliasNamespace())
             ->with('real_time_facades', $this->getRealTimeFacades())
-            ->with('helpers', $this->helpers)
+            ->with('helpers', $this->detectHelpers())
             ->with('include_fluent', $this->config->get('ide-helper.include_fluent', true))
             ->with('factories', $this->config->get('ide-helper.include_factory_builders') ? Factories::all() : [])
             ->render();
@@ -110,6 +110,22 @@ class Generator
             ->with('include_fluent', false)
             ->with('factories', [])
             ->render();
+    }
+
+    protected function detectHelpers()
+    {
+        $helpers = $this->helpers;
+
+        $replacements = [
+            '($guard is null ? \Illuminate\Contracts\Auth\Factory : \Illuminate\Contracts\Auth\StatefulGuard)' => '\\Auth'
+        ];
+        foreach ($replacements as $search => $replace) {
+            $helpers= Str::replace(
+                "@return {$search}", "@return $replace|$search", $helpers
+            );
+        }
+
+        return $helpers;
     }
 
     protected function detectDrivers()


### PR DESCRIPTION
## Summary
When the auth() helper is included, fix the return type to match \Auth

```php
if (! function_exists('auth')) {
    /**
     * Get the available auth instance.
     *
     * @param  string|null  $guard
     * @return \Auth|($guard is null ? \Illuminate\Contracts\Auth\Factory : \Illuminate\Contracts\Auth\StatefulGuard)
     */
    function auth($guard = null)
    {
        if (is_null($guard)) {
            return app(AuthFactory::class);
        }

        return app(AuthFactory::class)->guard($guard);
    }
}
```

This will make auth()->user() behave the same as \Auth::user() which is returning the default User model already.

This might be useful to do for only the helpers that are actually required to change, like auth() and perhaps request()

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
