### PR TITLE
Check if returnType from docblock is not null

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -821,7 +821,9 @@ class ModelsCommand extends Command
                                 ) {
                                     $matches = [];
                                     $returnType = $this->getReturnTypeFromDocBlock($reflection);
-                                    preg_match('/MorphTo<(.+?)(?:,|>)/i', $returnType, $matches);
+                                    if ($returnType !== null) {
+                                        preg_match('/MorphTo<(.+?)(?:,|>)/i', $returnType, $matches);
+                                    }
 
                                     // Model isn't specified because relation is polymorphic
                                     $this->setProperty(


### PR DESCRIPTION
## Summary
Fixes #1657 which was introduced in #1653

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
