### PR TITLE
Fix for incorrect config item types in meta file

### DIFF
--- a/php-templates/configs.php
+++ b/php-templates/configs.php
@@ -72,7 +72,7 @@ function vsCodeGetConfigValue($value, $key, $configPaths)
                 $key = collect(explode('.', $key));
                 $key->pop();
                 $key = $key->implode('.');
-                $value = 'array(...)';
+                $value = [];
             }
 
             $nextKey = $keysToFind->shift();


### PR DESCRIPTION
Fixes config items incorectlly set as `string` due to `'array(...)'` value passed to `gettype` instead of real array

## Summary
<!-- Please provide an exhaustive description. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
