### PR TITLE
Prevent generation of incorrect property annotation

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -628,6 +628,10 @@ class ModelsCommand extends Command
                     )
                 );
             });
+            // https://github.com/barryvdh/laravel-ide-helper/issues/1664
+            $reflections = array_filter($reflections, function (\ReflectionMethod $methodReflection) {
+                return !($methodReflection->getName() === 'getUseFactoryAttribute');
+            });
             sort($reflections);
             foreach ($reflections as $reflection) {
                 $type = $this->getReturnTypeFromReflection($reflection);


### PR DESCRIPTION
## Summary
When generating Eloquent annotations on a model that uses a factory, the tool generates an incorrect `$use_factory` property with the following annotation:
`@property-read \App\Models\TFactory|null $use_factory`

Then, when running a static analysis tool (like Larastan), it fails:
PHPDoc tag `@property-read for property App\Models\User::$use_factory contains unknown class App\Models\User\TFactory`.

This pull request introduces a workaround for that problem by filtering out the `getUseFactoryAttribute` method from the reflected methods in `src/Console/ModelsCommand::getPropertiesFromMethods()`.

With the changes from this PR, running `artisan ide-helper:models -n -W -R` in our project root removes the faulty `@property-read` annotations.

Credit for this idea goes to [LauJosefsen](https://github.com/barryvdh/laravel-ide-helper/issues/1664#issuecomment-2612027802).

See [issue 1664](https://github.com/barryvdh/laravel-ide-helper/issues/1664) for more details.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [X] Code style has been fixed via `composer fix-style`
