### PR TITLE
Fix MorphTo Model Doc Generation

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -826,7 +826,7 @@ class ModelsCommand extends Command
                                     $matches = [];
                                     $returnType = $this->getReturnTypeFromDocBlock($reflection);
                                     if ($returnType !== null) {
-                                        preg_match('/MorphTo<(.+?)(?:,|>)/i', $returnType, $matches);
+                                        preg_match('/MorphTo<(?:contravariant\s+)?(.+?)(?:,|>)/i', $returnType, $matches);
                                     }
 
                                     // Model isn't specified because relation is polymorphic


### PR DESCRIPTION
fix:
```php
    /**
     * @return MorphTo<contravariant ModelA|ModelB, $this>
     */
    public function reminderable(): MorphTo {
        return $this->morphTo(__FUNCTION__, 'entity', 'entity_id');
    }
```
From:
```php
* @property-read contravariant ModelA|ModelB $reminderable
 ```
To:
```php
* @property-read ModelA|ModelB $reminderable ``` Fixes: #1667

## Summary
<!-- Please provide an exhaustive description. -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
