### PR TITLE
Add extends declaration for Macroable classes to fix missing inherited methods

### DIFF
--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -29,7 +29,7 @@ $s3 = $s1 . $s2;
 <?php foreach ($namespaces_by_extends_ns as $namespace => $aliases) : ?>
 namespace <?= $namespace === '__root' ? '' : trim($namespace, '\\') ?> {
     <?php foreach ($aliases as $alias) : ?>
-<?php echo trim($alias->getDocComment($s1)) . "\n{$s1}" . $alias->getClassType() ?> <?= $alias->getExtendsClass() ?> {
+<?php echo trim($alias->getDocComment($s1)) . "\n{$s1}" . $alias->getClassType() ?> <?= $alias->getExtendsClass() ?><?php if($alias->shouldExtendParentClass()): ?> extends <?= $alias->getParentClass() ?><?php endif; ?> {
         <?php foreach ($alias->getMethods() as $method) : ?>
 <?= trim($method->getDocComment($s2)) . "\n{$s2}" ?>public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
         {<?php if ($method->getDeclaringClass() !== $method->getRoot()) : ?>

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -36,6 +36,7 @@ class Alias
     protected $classType = 'class';
     protected $short;
     protected $namespace = '__root';
+    protected $parentClass;
     protected $root = null;
     protected $classes = [];
     protected $methods = [];
@@ -87,6 +88,7 @@ class Alias
         $this->detectNamespace();
         $this->detectClassType();
         $this->detectExtendsNamespace();
+        $this->detectParentClass();
 
         if (!empty($this->namespace)) {
             try {
@@ -169,6 +171,25 @@ class Alias
     public function getExtendsNamespace()
     {
         return $this->extendsNamespace;
+    }
+
+    /**
+     * Get the parent class of the class which this alias extends
+     *
+     * @return null|string
+     */
+    public function getParentClass()
+    {
+        return $this->parentClass;
+    }
+
+    /**
+     * Check if this class should extend the parent class
+     */
+    public function shouldExtendParentClass()
+    {
+        return $this->parentClass
+            && $this->getExtendsNamespace() !== '\\Illuminate\\Support\\Facades';
     }
 
     /**
@@ -266,6 +287,18 @@ class Alias
             $this->extendsClass = array_pop($nsParts);
             $this->extendsNamespace = implode('\\', $nsParts);
         }
+    }
+
+    /**
+     * Detect the parent class
+     */
+    protected function detectParentClass()
+    {
+        $reflection = new ReflectionClass($this->root);
+
+        $parentClass = $reflection->getParentClass();
+
+        $this->parentClass = $parentClass ? '\\' . $parentClass->getName() : null;
     }
 
     /**


### PR DESCRIPTION
## Summary

### Overview

Currently, Laravel IDE Helper does not generate `extends` declarations for Macroable classes in their DocBlock. For example, `Illuminate\Http\Request` extends `Symfony\Component\HttpFoundation\Request`, but this inheritance is missing in the generated helper file.

As a result, tools like [PHPStan](https://phpstan.org/) or [PHP Intelephense](https://github.com/bmewburn/vscode-intelephense) sonetimes fail to detect the inherited methods and constants, triggering errors or warnings such as:

```php
use Illuminate\Http\Request;

function foo(Request $request)
{
    $request->isMethod(Request::METHOD_GET);
}
```

```
Access to undefined constant Illuminate\Http\Request::METHOD_GET
Call to an undefined method Illuminate\Http\Request::isMethod()
```

### What this PR Does

- **Adds an `extends` declaration** to the DocBlock for Macroable classes so that PHPStan, Intelephense, and other tools can properly recognize inherited methods and constants.
- **Facades are always omitted**, since they do not truly extend the underlying class but rather proxy calls to an actual instance.

### Additional Notes

- In a default Laravel configuration, `Illuminate\Http\Request` is effectively the only Macroable class that relies on a parent class. Without an `extends` declaration, any inherited methods or constants remain hidden from static analysis.
- After applying this PR, the generated DocBlock for `Illuminate\Http\Request` gains the `extends` line:

```diff
22382c22382
<     class Request {
---
>     class Request extends \Symfony\Component\HttpFoundation\Request {
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Code style has been fixed via `composer fix-style`
