### PR TITLE
fix: Change AsArrayObject cast to be Laravel's ArrayObject

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -453,7 +453,7 @@ class ModelsCommand extends Command
                     $realType = '\Illuminate\Support\Collection<array-key, mixed>';
                     break;
                 case AsArrayObject::class:
-                    $realType = '\ArrayObject<array-key, mixed>';
+                    $realType = '\Illuminate\Database\Eloquent\Casts\ArrayObject<array-key, mixed>';
                     break;
                 default:
                     // In case of an optional custom cast parameter , only evaluate

--- a/tests/Console/ModelsCommand/AdvancedCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/AdvancedCasts/__snapshots__/Test__test__1.php
@@ -28,7 +28,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property object $cast_to_encrypted_object
  * @property \Illuminate\Support\Collection $cast_to_as_collection
  * @property \Illuminate\Support\Collection $cast_to_as_enum_collection
- * @property \ArrayObject<array-key, mixed> $cast_to_as_array_object
+ * @property \Illuminate\Database\Eloquent\Casts\ArrayObject<array-key, mixed> $cast_to_as_array_object
  * @property AdvancedCastCollection $cast_to_as_collection_using
  * @property \Illuminate\Support\Collection<int, AdvancedCastEnum> $cast_to_as_enum_collection_of
  * @method static \Illuminate\Database\Eloquent\Builder<static>|AdvancedCast newModelQuery()


### PR DESCRIPTION
## Summary
Support for Laravel's model `AsArrayObject` cast was added in https://github.com/barryvdh/laravel-ide-helper/pull/1393. It, however, was added using PHP's `\ArrayObject` object when it should be Laravel's `Illuminate\Database\Eloquent\Casts\ArrayObject`.

As it is now, using Laravel's methods like `toArray` throw an error in the editor (like VS Code) saying the method is invalid.

### Reference
 - Laravel's model [`Illuminate\Database\Eloquent\Casts\AsArrayObject`](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Eloquent/Casts/AsArrayObject.php#L28) cast
 - [`Illuminate\Database\Eloquent\Casts\ArrayObject`](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Database/Eloquent/Casts/ArrayObject.php#L16)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] ~Update the README.md~
- [x] Code style has been fixed via `composer fix-style`
