### PR TITLE
Include camel case attribute version

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -349,4 +349,19 @@ return [
         Spatie\Macroable\Macroable::class,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Include camel case attribute version
+    |--------------------------------------------------------------------------
+    |
+    | Generate camel camel case version for attributes
+    | When model attribute is defined as either one of these
+    | - getSomeValueAttribute()
+    | - someValue(): Attribute
+    | include both of these in the DocBlock:
+    | - $some_value
+    | - $someValue
+    |
+    */
+    'model_include_camel_case_attribute_version' => false,
 ];

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -637,6 +637,7 @@ class ModelsCommand extends Command
                 $type = $this->getReturnTypeFromReflection($reflection);
                 $isAttribute = is_a($type, '\Illuminate\Database\Eloquent\Casts\Attribute', true);
                 $method = $reflection->getName();
+                $includeCamelCaseAttributeVersion = $this->laravel['config']->get('ide-helper.model_include_camel_case_attribute_version', false);
                 if (
                     Str::startsWith($method, 'get') && Str::endsWith($method, 'Attribute') && $method !== 'getAttribute'
                 ) {
@@ -647,6 +648,9 @@ class ModelsCommand extends Command
                         $type = $this->getTypeInModel($model, $type);
                         $comment = $this->getCommentFromDocBlock($reflection);
                         $this->setProperty($name, $type, true, null, $comment);
+                        if ($includeCamelCaseAttributeVersion) {
+                            $this->setProperty(Str::camel($name), $type, true, null, $comment);
+                        }
                     }
                 } elseif ($isAttribute) {
                     $types = $this->getAttributeTypes($model, $reflection);
@@ -658,6 +662,15 @@ class ModelsCommand extends Command
                         $types->has('set') ?: null,
                         $this->getCommentFromDocBlock($reflection)
                     );
+                    if ($includeCamelCaseAttributeVersion && $types->has('get')) {
+                        $this->setProperty(
+                            Str::camel($method),
+                            $type,
+                            true,
+                            null,
+                            $this->getCommentFromDocBlock($reflection)
+                        );
+                    }
                 } elseif (
                     Str::startsWith($method, 'set') &&
                     Str::endsWith($method, 'Attribute') &&

--- a/tests/Console/ModelsCommand/GeneratePhpdocModelIncludeCamelCaseAttributeVersion/Models/Simple.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocModelIncludeCamelCaseAttributeVersion/Models/Simple.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocModelIncludeCamelCaseAttributeVersion\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use stdClass;
+
+class Simple extends Model
+{
+    public function getIntValueAttribute(): int
+    {
+        return rand();
+    }
+
+    public function setIntValueAttribute(int $value): int
+    {
+        return $value;
+    }
+
+    public function stringValue(): Attribute
+    {
+        return new Attribute(
+            get: fn (): string => Str::random(),
+            set: fn (string $value): string => $value,
+        );
+    }
+    public function getBoolValueAttribute(): bool
+    {
+        return (bool) rand(0,1);
+    }
+
+    public function arrayValue(): Attribute
+    {
+        return new Attribute(
+            get: fn (): array => [],
+        );
+    }
+
+    public function setStdClassValueAttribute(stdClass $stdClass): stdClass
+    {
+        return $stdClass;
+    }
+
+    public function voidValue(): Attribute
+    {
+        return new Attribute(
+            set: function (): void {}
+        );
+    }
+}

--- a/tests/Console/ModelsCommand/GeneratePhpdocModelIncludeCamelCaseAttributeVersion/Models/Simple.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocModelIncludeCamelCaseAttributeVersion/Models/Simple.php
@@ -30,7 +30,7 @@ class Simple extends Model
     }
     public function getBoolValueAttribute(): bool
     {
-        return (bool) rand(0,1);
+        return (bool) rand(0, 1);
     }
 
     public function arrayValue(): Attribute
@@ -48,7 +48,8 @@ class Simple extends Model
     public function voidValue(): Attribute
     {
         return new Attribute(
-            set: function (): void {}
+            set: function (): void {
+            }
         );
     }
 }

--- a/tests/Console/ModelsCommand/GeneratePhpdocModelIncludeCamelCaseAttributeVersion/Test.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocModelIncludeCamelCaseAttributeVersion/Test.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocModelIncludeCamelCaseAttributeVersion;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+
+class Test extends AbstractModelsCommand
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('ide-helper.model_include_camel_case_attribute_version', true);
+    }
+
+    public function test(): void
+    {
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--write' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
+        $this->assertMatchesMockedSnapshot();
+    }
+}

--- a/tests/Console/ModelsCommand/GeneratePhpdocModelIncludeCamelCaseAttributeVersion/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocModelIncludeCamelCaseAttributeVersion/__snapshots__/Test__test__1.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocModelIncludeCamelCaseAttributeVersion\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use stdClass;
+
+/**
+ * 
+ *
+ * @property int $id
+ * @property-read array $array_value
+ * @property-read array $arrayValue
+ * @property-read bool $bool_value
+ * @property-read bool $boolValue
+ * @property int $int_value
+ * @property-read int $intValue
+ * @property-write mixed $std_class_value
+ * @property string $string_value
+ * @property-read string $stringValue
+ * @property-write mixed $void_value
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple whereId($value)
+ * @mixin \Eloquent
+ */
+class Simple extends Model
+{
+    public function getIntValueAttribute(): int
+    {
+        return rand();
+    }
+
+    public function setIntValueAttribute(int $value): int
+    {
+        return $value;
+    }
+
+    public function stringValue(): Attribute
+    {
+        return new Attribute(
+            get: fn (): string => Str::random(),
+            set: fn (string $value): string => $value,
+        );
+    }
+    public function getBoolValueAttribute(): bool
+    {
+        return (bool) rand(0,1);
+    }
+
+    public function arrayValue(): Attribute
+    {
+        return new Attribute(
+            get: fn (): array => [],
+        );
+    }
+
+    public function setStdClassValueAttribute(stdClass $stdClass): stdClass
+    {
+        return $stdClass;
+    }
+
+    public function voidValue(): Attribute
+    {
+        return new Attribute(
+            set: function (): void {}
+        );
+    }
+}


### PR DESCRIPTION
## Summary

When model attribute is defined as either one of these
``` php
public function getSomeValueAttribute() 
{
    return 'some value';
}
````
```php
public function someValue(): Attribute 
{
    return Attribute::get(fn () => 'some value');
}
```

it is also possible to access the attribute via its camel case form, a.k.a

```php
$post = Post::first();
// both output the same value based on the attribute configuration
// in the case of the above example: "some value"
$post->some_value;
$post->someValue;
```
I am aware of `model_camel_case_properties` config option, but I don't want to have all attributes camel cased, just attributes.

Having this option improved the navigation to attributes, at least in my code base (don't have a publicaly facing repo to showcase, sorry).

Decided to add a configuration option for this and it's off by default, so existing projects would not have their models' DocBlocks populated with the camelCase version of attributes, but if this is deemed as too much, I am happy to remove it.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
