### PR TITLE
avoid adding duplicate tags

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1048,6 +1048,11 @@ class ModelsCommand extends Command
 
             $tagLine = trim("@{$attr} {$property['type']} {$name} {$property['comment']}");
             $tag = Tag::createInstance($tagLine, $phpdoc);
+
+            if ($this->tagExists($phpdoc, $tag)) {
+                continue;
+            }
+
             $phpdoc->appendTag($tag);
         }
 
@@ -1761,5 +1766,20 @@ class ModelsCommand extends Command
                 $this->foreignKeyConstraintsColumns[] = $columnName;
             }
         }
+    }
+
+    /**
+     * @param DocBlock $phpdoc
+     * @param Tag $tag
+     */
+    public function tagExists($phpdoc, $tag): bool
+    {
+        foreach ($phpdoc->getTags() as $originalTag) {
+            if ($originalTag->getContent() == $tag->getContent()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

When running `php artisan ide-helper:models --write` command, it sometimes will add duplicate phpdoc comment for the same property.

I added a check before adding a new tag for `ModelsCommand`. It will not create a new tag if it's a duplicate tag.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


