### PR TITLE
Add magic `*_exists` properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,11 +212,11 @@ Eloquent allows calling `where<Attribute>` on your models, e.g. `Post::whereTitl
 
 If for some reason it's undesired to have them generated (one for each column), you can disable this via config `write_model_magic_where` and setting it to `false`.
 
-#### Magic `*_count` properties
+#### Magic `*_count` and `*_exists` properties
 
-You may use the [`::withCount`](https://laravel.com/docs/master/eloquent-relationships#counting-related-models) method to count the number results from a relationship without actually loading them. Those results are then placed in attributes following the `<columname>_count` convention.
+You may use the [`::withCount`](https://laravel.com/docs/master/eloquent-relationships#counting-related-models) and [`::withExists`](https://laravel.com/docs/master/eloquent-relationships#other-aggregate-functions) methodsto count the number results from a relationship without actually loading them. Those results are then placed in attributes following the `<columname>_count` and `<columname>_exists` convention.
 
-By default, these attributes are generated in the phpdoc. You can turn them off by setting the config `write_model_relation_count_properties` to `false`.
+By default, these attributes are generated in the phpdoc. You can turn them off by setting the config `write_model_relation_count_properties` and `write_model_relation_exists_properties` to `false`.
 
 #### Generics annotations
 

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -85,14 +85,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Write model relation count properties
+    | Write model relation count and exists properties
     |--------------------------------------------------------------------------
     |
-    | Set to false to disable writing of relation count properties to model DocBlocks.
+    | Set to false to disable writing of relation count and exists properties
+    | to model DocBlocks.
     |
     */
 
     'write_model_relation_count_properties' => true,
+    'write_model_relation_exists_properties' => true,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -114,6 +114,7 @@ class ModelsCommand extends Command
 
     protected $write_model_magic_where;
     protected $write_model_relation_count_properties;
+    protected $write_model_relation_exists_properties;
     protected $properties = [];
     protected $methods = [];
     protected $write = false;
@@ -173,6 +174,8 @@ class ModelsCommand extends Command
         $this->write_model_external_builder_methods = $this->laravel['config']->get('ide-helper.write_model_external_builder_methods', true);
         $this->write_model_relation_count_properties =
             $this->laravel['config']->get('ide-helper.write_model_relation_count_properties', true);
+        $this->write_model_relation_exists_properties =
+            $this->laravel['config']->get('ide-helper.write_model_relation_exists_properties', true);
 
         $this->write = $this->write_mixin ? true : $this->write;
         //If filename is default and Write is not specified, ask what to do
@@ -810,6 +813,15 @@ class ModelsCommand extends Command
                                     if ($this->write_model_relation_count_properties) {
                                         $this->setProperty(
                                             Str::snake($method) . '_count',
+                                            'int|null',
+                                            true,
+                                            false
+                                            // What kind of comments should be added to the relation count here?
+                                        );
+                                    }
+                                    if ($this->write_model_relation_exists_properties) {
+                                        $this->setProperty(
+                                            Str::snake($method) . '_exists',
                                             'int|null',
                                             true,
                                             false

--- a/tests/Console/ModelsCommand/Comment/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Comment/__snapshots__/Test__test__1.php
@@ -23,6 +23,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * @property-read string $not_comment
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationHasMany HasMany relations.
  * @property-read int|null $relation_has_many_count
+ * @property-read bool|null $relation_has_many_exists
  * @property-read Simple|null $relationHasOne Others relations.
  * @property-read Model|\Eloquent $relationMorphTo MorphTo relations.
  * @property-write mixed $first_name Set the user's first name.

--- a/tests/Console/ModelsCommand/CustomCollection/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/CustomCollection/__snapshots__/Test__test__1.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property int $id
  * @property-read SimpleCollection<int, Simple> $relationHasMany
  * @property-read int|null $relation_has_many_count
+ * @property-read bool|null $relation_has_many_exists
  * @method static SimpleCollection<int, static> all($columns = ['*'])
  * @method static SimpleCollection<int, static> get($columns = ['*'])
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple newModelQuery()

--- a/tests/Console/ModelsCommand/DynamicRelations/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/DynamicRelations/__snapshots__/Test__test__1.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  *
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Dynamic> $regularHasMany
  * @property-read int|null $regular_has_many_count
+ * @property-read bool|null $regular_has_many_exists
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Dynamic newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Dynamic newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Dynamic query()

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
@@ -84,6 +84,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post> $posts
  * @property-read int|null $posts_count
+ * @property-read bool|null $posts_exists
  * @method static \Illuminate\Database\Eloquent\Builder<static>|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post null(string $unusedParam)

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
@@ -90,6 +90,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property-read Collection<int, Post> $posts
  * @property-read int|null $posts_count
+ * @property-read bool|null $posts_exists
  * @method static EloquentBuilder<static>|Post newModelQuery()
  * @method static EloquentBuilder<static>|Post newQuery()
  * @method static EloquentBuilder<static>|Post null(string $unusedParam)

--- a/tests/Console/ModelsCommand/GenericsSyntaxDisabled/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GenericsSyntaxDisabled/__snapshots__/Test__test__1.php
@@ -14,8 +14,9 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property int $id
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $regularBelongsToMany
  * @property-read int|null $regular_belongs_to_many_count
+ * @property-read bool|null $regular_belongs_to_many_exists
  * @property-read \Illuminate\Database\Eloquent\Collection|Simple[] $regularHasMany
- * @property-read int|null $regular_has_many_count
+ * @property-read bool|null $regular_has_many_exists
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple query()

--- a/tests/Console/ModelsCommand/Pivot/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Pivot/__snapshots__/Test__test__1.php
@@ -14,16 +14,21 @@ use Illuminate\Database\Eloquent\Model;
  * @property-read DifferentCustomPivot|CustomPivot|null $pivot
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationCustomPivotUsingSameAccessor
  * @property-read int|null $relation_custom_pivot_using_same_accessor_count
+ * @property-read bool|null $relation_custom_pivot_using_same_accessor_exists
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationCustomPivotUsingSameAccessorAndClass
  * @property-read int|null $relation_custom_pivot_using_same_accessor_and_class_count
+ * @property-read bool|null $relation_custom_pivot_using_same_accessor_and_class_exists
  * @property-read CustomPivot|null $customAccessor
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithCustomPivot
  * @property-read int|null $relation_with_custom_pivot_count
+ * @property-read bool|null $relation_with_custom_pivot_exists
  * @property-read DifferentCustomPivot|null $differentCustomAccessor
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithDifferentCustomPivot
  * @property-read int|null $relation_with_different_custom_pivot_count
+ * @property-read bool|null $relation_with_different_custom_pivot_exists
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ModelWithPivot> $relationWithDifferentCustomPivotUsingSameAccessor
  * @property-read int|null $relation_with_different_custom_pivot_using_same_accessor_count
+ * @property-read bool|null $relation_with_different_custom_pivot_using_same_accessor_exists
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ModelWithPivot newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ModelWithPivot newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ModelWithPivot query()

--- a/tests/Console/ModelsCommand/RelationCountProperties/Test.php
+++ b/tests/Console/ModelsCommand/RelationCountProperties/Test.php
@@ -14,6 +14,7 @@ class Test extends AbstractModelsCommand
         parent::getEnvironmentSetUp($app);
 
         $app['config']->set('ide-helper.write_model_relation_count_properties', false);
+        $app['config']->set('ide-helper.write_model_relation_exists_properties', false);
     }
 
     public function test(): void

--- a/tests/Console/ModelsCommand/Relations/__snapshots__/Test__testRelationNotNullable__1.php
+++ b/tests/Console/ModelsCommand/Relations/__snapshots__/Test__testRelationNotNullable__1.php
@@ -139,26 +139,34 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  * @property-read AnotherModel $relationBelongsToInAnotherNamespace
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationBelongsToMany
  * @property-read int|null $relation_belongs_to_many_count
+ * @property-read bool|null $relation_belongs_to_many_exists
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationBelongsToManyWithSub
  * @property-read int|null $relation_belongs_to_many_with_sub_count
+ * @property-read bool|null $relation_belongs_to_many_with_sub_exists
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationBelongsToManyWithSubAnother
  * @property-read int|null $relation_belongs_to_many_with_sub_another_count
+ * @property-read bool|null $relation_belongs_to_many_with_sub_another_exists
  * @property-read AnotherModel $relationBelongsToSameNameAsColumn
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationHasMany
  * @property-read int|null $relation_has_many_count
+ * @property-read bool|null $relation_has_many_exists
  * @property-read Simple|null $relationHasOne
  * @property-read Simple $relationHasOneWithDefault
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationMorphMany
  * @property-read int|null $relation_morph_many_count
+ * @property-read bool|null $relation_morph_many_exists
  * @property-read Simple|null $relationMorphOne
  * @property-read Model|\Eloquent $relationMorphTo
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationMorphedByMany
  * @property-read int|null $relation_morphed_by_many_count
+ * @property-read bool|null $relation_morphed_by_many_exists
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationSampleRelationType
  * @property-read int|null $relation_sample_relation_type_count
+ * @property-read boo|null $relation_sample_relation_type_exists
  * @property-read Model|\Eloquent $relationSampleToAnyMorphedRelationType
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationSampleToAnyRelationType
  * @property-read int|null $relation_sample_to_any_relation_type_count
+ * @property-read bool|null $relation_sample_to_any_relation_type_exists
  * @property-read Simple $relationSampleToBadlyNamedNotManyRelation
  * @property-read Simple $relationSampleToManyRelationType
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple newModelQuery()

--- a/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Relations/__snapshots__/Test__test__1.php
@@ -139,26 +139,34 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  * @property-read AnotherModel|null $relationBelongsToInAnotherNamespace
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationBelongsToMany
  * @property-read int|null $relation_belongs_to_many_count
+ * @property-read bool|null $relation_belongs_to_many_exists
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationBelongsToManyWithSub
  * @property-read int|null $relation_belongs_to_many_with_sub_count
+ * @property-read bool|null $relation_belongs_to_many_with_sub_exists
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationBelongsToManyWithSubAnother
  * @property-read int|null $relation_belongs_to_many_with_sub_another_count
+ * @property-read bool|null $relation_belongs_to_many_with_sub_another_exists
  * @property-read AnotherModel|null $relationBelongsToSameNameAsColumn
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationHasMany
  * @property-read int|null $relation_has_many_count
+ * @property-read bool|null $relation_has_many_exists
  * @property-read Simple|null $relationHasOne
  * @property-read Simple $relationHasOneWithDefault
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationMorphMany
  * @property-read int|null $relation_morph_many_count
+ * @property-read bool|null $relation_morph_many_exists
  * @property-read Simple|null $relationMorphOne
  * @property-read Model|\Eloquent $relationMorphTo
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationMorphedByMany
  * @property-read int|null $relation_morphed_by_many_count
+ * @property-read bool|null $relation_morphed_by_many_exists
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationSampleRelationType
  * @property-read int|null $relation_sample_relation_type_count
+ * @property-read bool|null $relation_sample_relation_type_exists
  * @property-read Model|\Eloquent $relationSampleToAnyMorphedRelationType
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Simple> $relationSampleToAnyRelationType
  * @property-read int|null $relation_sample_to_any_relation_type_count
+ * @property-read bool|null $relation_sample_to_any_relation_type_exists
  * @property-read Simple $relationSampleToBadlyNamedNotManyRelation
  * @property-read Simple $relationSampleToManyRelationType
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple newModelQuery()

--- a/tests/Console/ModelsCommand/UnionTypes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/UnionTypes/__snapshots__/Test__test__1.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Query\Builder;
  * @property-read string|int|null $foo
  * @property-read \Illuminate\Database\Eloquent\Collection<int, UnionTypeModel> $withUnionTypeReturn
  * @property-read int|null $with_union_type_return_count
+ * @property-read bool|null $with_union_type_return_exists
  * @method static \Illuminate\Database\Eloquent\Builder<static>|UnionTypeModel newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|UnionTypeModel newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|UnionTypeModel query()


### PR DESCRIPTION
## Summary
This adds `*_exists` model properties, similar to the `*_count` properties.

I also added a `write_model_relation_exists_properties` config to disable it.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
