### PR TITLE
fix: Fixed wrong doc for SoftDeletes `withTrashed` method

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1405,7 +1405,7 @@ class ModelsCommand extends Command
         if (in_array('Illuminate\\Database\\Eloquent\\SoftDeletes', $traits)) {
             $modelName = $this->getClassNameInDestinationFile($model, get_class($model));
             $builder = $this->getClassNameInDestinationFile($model, \Illuminate\Database\Eloquent\Builder::class);
-            $this->setMethod('withTrashed', $builder . '<static>|' . $modelName, []);
+            $this->setMethod('withTrashed', $builder . '<static>|' . $modelName, ['bool $withTrashed = true']);
             $this->setMethod('withoutTrashed', $builder . '<static>|' . $modelName, []);
             $this->setMethod('onlyTrashed', $builder . '<static>|' . $modelName, []);
         }

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithForcedFqn/__snapshots__/Test__test__1.php
@@ -160,7 +160,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @method static \Illuminate\Database\Eloquent\Builder<static>|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereUuidNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereYearNotNullable($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post whereYearNullable($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post withTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post withTrashed(bool $withTrashed = true)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|\Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\GeneratePhpdocWithForcedFqn\Models\Post withoutTrashed()
  * @mixin \Eloquent
  */

--- a/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/GeneratePhpdocWithFqn/__snapshots__/Test__test__1.php
@@ -166,7 +166,7 @@ use Illuminate\Support\Carbon;
  * @method static EloquentBuilder<static>|Post whereUuidNullable($value)
  * @method static EloquentBuilder<static>|Post whereYearNotNullable($value)
  * @method static EloquentBuilder<static>|Post whereYearNullable($value)
- * @method static EloquentBuilder<static>|Post withTrashed()
+ * @method static EloquentBuilder<static>|Post withTrashed(bool $withTrashed = true)
  * @method static EloquentBuilder<static>|Post withoutTrashed()
  * @mixin Eloquent
  */

--- a/tests/Console/ModelsCommand/SoftDeletes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/SoftDeletes/__snapshots__/Test__test__1.php
@@ -16,7 +16,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple onlyTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple query()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple whereId($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple withTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple withTrashed(bool $withTrashed = true)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple withoutTrashed()
  * @mixin \Eloquent
  */


### PR DESCRIPTION
## Summary
Fixed wrong php doc being generated for `withTrashed` method when SoftDeletes trait is used in a model.

Previously this doc looked like this (missing parameter):
` * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple withTrashed()`
When it should look like this (taken from the trait itself)
` * @method static \Illuminate\Database\Eloquent\Builder<static>|Simple withTrashed(bool $withTrashed = true)`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
