### PR TITLE
feat(ModelsCommand): add support for the new Scope attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,16 +25,16 @@
         "ext-json": "*",
         "barryvdh/reflection-docblock": "^2.3",
         "composer/class-map-generator": "^1.0",
-        "illuminate/console": "^11.15 || ^12.4.1",
-        "illuminate/database": "^11.15 || ^12.4.1",
-        "illuminate/filesystem": "^11.15 || ^12.4.1",
-        "illuminate/support": "^11.15 || ^12.4.1"
+        "illuminate/console": "^11.15 || ^12",
+        "illuminate/database": "^11.15 || ^12",
+        "illuminate/filesystem": "^11.15 || ^12",
+        "illuminate/support": "^11.15 || ^12"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "friendsofphp/php-cs-fixer": "^3",
-        "illuminate/config": "^11.15 || ^12.4.1",
-        "illuminate/view": "^11.15 || ^12.4.1",
+        "illuminate/config": "^11.15 || ^12",
+        "illuminate/view": "^11.15 || ^12",
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^9.2 || ^10",
         "phpunit/phpunit": "^10.5 || ^11.5.3",

--- a/composer.json
+++ b/composer.json
@@ -25,16 +25,16 @@
         "ext-json": "*",
         "barryvdh/reflection-docblock": "^2.3",
         "composer/class-map-generator": "^1.0",
-        "illuminate/console": "^11.15 || ^12",
-        "illuminate/database": "^11.15 || ^12",
-        "illuminate/filesystem": "^11.15 || ^12",
-        "illuminate/support": "^11.15 || ^12"
+        "illuminate/console": "^11.15 || ^12.4.1",
+        "illuminate/database": "^11.15 || ^12.4.1",
+        "illuminate/filesystem": "^11.15 || ^12.4.1",
+        "illuminate/support": "^11.15 || ^12.4.1"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "friendsofphp/php-cs-fixer": "^3",
-        "illuminate/config": "^11.15 || ^12",
-        "illuminate/view": "^11.15 || ^12",
+        "illuminate/config": "^11.15 || ^12.4.1",
+        "illuminate/view": "^11.15 || ^12.4.1",
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^9.2 || ^10",
         "phpunit/phpunit": "^10.5 || ^11.5.3",

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -29,7 +29,7 @@ $s3 = $s1 . $s2;
 <?php foreach ($namespaces_by_extends_ns as $namespace => $aliases) : ?>
 namespace <?= $namespace === '__root' ? '' : trim($namespace, '\\') ?> {
     <?php foreach ($aliases as $alias) : ?>
-<?php echo trim($alias->getDocComment($s1)) . "\n{$s1}" . $alias->getClassType() ?> <?= $alias->getExtendsClass() ?><?php if ($alias->shouldExtendParentClass()): ?> extends <?= $alias->getParentClass() ?><?php endif; ?> {
+<?php echo trim($alias->getDocComment($s1)) . "\n{$s1}" . $alias->getClassType() ?> <?= $alias->getExtendsClass() ?><?php if($alias->shouldExtendParentClass()): ?> extends <?= $alias->getParentClass() ?><?php endif; ?> {
         <?php foreach ($alias->getMethods() as $method) : ?>
 <?= trim($method->getDocComment($s2)) . "\n{$s2}" ?>public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
         {<?php if ($method->getDeclaringClass() !== $method->getRoot()) : ?>
@@ -76,7 +76,7 @@ namespace <?= $namespace === '__root' ? '' : trim($namespace, '\\') ?> {
 
 <?php endforeach; ?>
 
-<?php foreach ($real_time_facades as $name): ?>
+<?php foreach($real_time_facades as $name): ?>
 <?php $nested = explode('\\', str_replace('\\' . class_basename($name), '', $name)); ?>
 namespace <?php echo implode('\\', $nested); ?> {
     /**

--- a/resources/views/helper.php
+++ b/resources/views/helper.php
@@ -29,7 +29,7 @@ $s3 = $s1 . $s2;
 <?php foreach ($namespaces_by_extends_ns as $namespace => $aliases) : ?>
 namespace <?= $namespace === '__root' ? '' : trim($namespace, '\\') ?> {
     <?php foreach ($aliases as $alias) : ?>
-<?php echo trim($alias->getDocComment($s1)) . "\n{$s1}" . $alias->getClassType() ?> <?= $alias->getExtendsClass() ?><?php if($alias->shouldExtendParentClass()): ?> extends <?= $alias->getParentClass() ?><?php endif; ?> {
+<?php echo trim($alias->getDocComment($s1)) . "\n{$s1}" . $alias->getClassType() ?> <?= $alias->getExtendsClass() ?><?php if ($alias->shouldExtendParentClass()): ?> extends <?= $alias->getParentClass() ?><?php endif; ?> {
         <?php foreach ($alias->getMethods() as $method) : ?>
 <?= trim($method->getDocComment($s2)) . "\n{$s2}" ?>public static function <?= $method->getName() ?>(<?= $method->getParamsWithDefault() ?>)
         {<?php if ($method->getDeclaringClass() !== $method->getRoot()) : ?>
@@ -76,7 +76,7 @@ namespace <?= $namespace === '__root' ? '' : trim($namespace, '\\') ?> {
 
 <?php endforeach; ?>
 
-<?php foreach($real_time_facades as $name): ?>
+<?php foreach ($real_time_facades as $name): ?>
 <?php $nested = explode('\\', str_replace('\\' . class_basename($name), '', $name)); ?>
 namespace <?php echo implode('\\', $nested); ?> {
     /**

--- a/resources/views/meta.php
+++ b/resources/views/meta.php
@@ -81,7 +81,7 @@ namespace PHPSTORM_META {
 
     <?php if (isset($expectedArgumentSets)): ?>
     <?php foreach ($expectedArgumentSets as $name => $argumentsList) : ?>
-    registerArgumentsSet('<?= $name ?>', <?php foreach ($argumentsList as $i => $arg) : ?><?php if($i % 5 == 0) {
+    registerArgumentsSet('<?= $name ?>', <?php foreach ($argumentsList as $i => $arg) : ?><?php if ($i % 5 == 0) {
         echo "\n";
     } ?><?= var_export($arg, true); ?>,<?php endforeach; ?>);
     <?php endforeach; ?>

--- a/resources/views/meta.php
+++ b/resources/views/meta.php
@@ -81,7 +81,7 @@ namespace PHPSTORM_META {
 
     <?php if (isset($expectedArgumentSets)): ?>
     <?php foreach ($expectedArgumentSets as $name => $argumentsList) : ?>
-    registerArgumentsSet('<?= $name ?>', <?php foreach ($argumentsList as $i => $arg) : ?><?php if ($i % 5 == 0) {
+    registerArgumentsSet('<?= $name ?>', <?php foreach ($argumentsList as $i => $arg) : ?><?php if($i % 5 == 0) {
         echo "\n";
     } ?><?= var_export($arg, true); ?>,<?php endforeach; ?>);
     <?php endforeach; ?>

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -25,6 +25,7 @@ use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
+use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
@@ -669,9 +670,11 @@ class ModelsCommand extends Command
                         $comment = $this->getCommentFromDocBlock($reflection);
                         $this->setProperty($name, null, null, true, $comment);
                     }
-                } elseif (Str::startsWith($method, 'scope') && $method !== 'scopeQuery' && $method !== 'scope' && $method !== 'scopes') {
+                } elseif (!empty($reflection->getAttributes(Scope::class)) || (Str::startsWith($method, 'scope') && $method !== 'scopeQuery' && $method !== 'scope' && $method !== 'scopes')) {
+                    $scopeUsingAttribute = !empty($reflection->getAttributes(Scope::class));
+
                     //Magic scope<name>Attribute
-                    $name = Str::camel(substr($method, 5));
+                    $name = $scopeUsingAttribute ? $method : Str::camel(substr($method, 5));
                     if (!empty($name)) {
                         $comment = $this->getCommentFromDocBlock($reflection);
                         $args = $this->getParameters($reflection);

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -25,7 +25,6 @@ use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
-use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Casts\AsEnumCollection;
@@ -670,8 +669,8 @@ class ModelsCommand extends Command
                         $comment = $this->getCommentFromDocBlock($reflection);
                         $this->setProperty($name, null, null, true, $comment);
                     }
-                } elseif (class_exists(Scope::class) && !empty($reflection->getAttributes(Scope::class)) || (Str::startsWith($method, 'scope') && $method !== 'scopeQuery' && $method !== 'scope' && $method !== 'scopes')) {
-                    $scopeUsingAttribute = class_exists(Scope::class) && !empty($reflection->getAttributes(Scope::class));
+                } elseif (!empty($reflection->getAttributes('\Illuminate\Database\Eloquent\Attributes\Scope')) || (Str::startsWith($method, 'scope') && $method !== 'scopeQuery' && $method !== 'scope' && $method !== 'scopes')) {
+                    $scopeUsingAttribute = !empty($reflection->getAttributes('\Illuminate\Database\Eloquent\Attributes\Scope'));
 
                     //Magic scope<name>Attribute
                     $name = $scopeUsingAttribute ? $method : Str::camel(substr($method, 5));

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -669,8 +669,8 @@ class ModelsCommand extends Command
                         $comment = $this->getCommentFromDocBlock($reflection);
                         $this->setProperty($name, null, null, true, $comment);
                     }
-                } elseif (!empty($reflection->getAttributes('\Illuminate\Database\Eloquent\Attributes\Scope')) || (Str::startsWith($method, 'scope') && $method !== 'scopeQuery' && $method !== 'scope' && $method !== 'scopes')) {
-                    $scopeUsingAttribute = !empty($reflection->getAttributes('\Illuminate\Database\Eloquent\Attributes\Scope'));
+                } elseif (!empty($reflection->getAttributes('Illuminate\Database\Eloquent\Attributes\Scope')) || (Str::startsWith($method, 'scope') && $method !== 'scopeQuery' && $method !== 'scope' && $method !== 'scopes')) {
+                    $scopeUsingAttribute = !empty($reflection->getAttributes('Illuminate\Database\Eloquent\Attributes\Scope'));
 
                     //Magic scope<name>Attribute
                     $name = $scopeUsingAttribute ? $method : Str::camel(substr($method, 5));

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -670,8 +670,8 @@ class ModelsCommand extends Command
                         $comment = $this->getCommentFromDocBlock($reflection);
                         $this->setProperty($name, null, null, true, $comment);
                     }
-                } elseif (class_exists(Scope::class && !empty($reflection->getAttributes(Scope::class))) || (Str::startsWith($method, 'scope') && $method !== 'scopeQuery' && $method !== 'scope' && $method !== 'scopes')) {
-                    $scopeUsingAttribute = class_exists(Scope::class && !empty($reflection->getAttributes(Scope::class);
+                } elseif (class_exists(Scope::class) && !empty($reflection->getAttributes(Scope::class)) || (Str::startsWith($method, 'scope') && $method !== 'scopeQuery' && $method !== 'scope' && $method !== 'scopes')) {
+                    $scopeUsingAttribute = class_exists(Scope::class) && !empty($reflection->getAttributes(Scope::class));
 
                     //Magic scope<name>Attribute
                     $name = $scopeUsingAttribute ? $method : Str::camel(substr($method, 5));

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -670,8 +670,8 @@ class ModelsCommand extends Command
                         $comment = $this->getCommentFromDocBlock($reflection);
                         $this->setProperty($name, null, null, true, $comment);
                     }
-                } elseif (!empty($reflection->getAttributes(Scope::class)) || (Str::startsWith($method, 'scope') && $method !== 'scopeQuery' && $method !== 'scope' && $method !== 'scopes')) {
-                    $scopeUsingAttribute = !empty($reflection->getAttributes(Scope::class));
+                } elseif (class_exists(Scope::class && !empty($reflection->getAttributes(Scope::class))) || (Str::startsWith($method, 'scope') && $method !== 'scopeQuery' && $method !== 'scope' && $method !== 'scopes')) {
+                    $scopeUsingAttribute = class_exists(Scope::class && !empty($reflection->getAttributes(Scope::class);
 
                     //Magic scope<name>Attribute
                     $name = $scopeUsingAttribute ? $method : Str::camel(substr($method, 5));

--- a/tests/Console/ModelsCommand/QueryScopes/Models/Comment.php
+++ b/tests/Console/ModelsCommand/QueryScopes/Models/Comment.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\QueryScopes\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    /**
+     * @comment Scope using the 'Scope' attribute
+     * @param Builder $query
+     * @return void
+     */
+    #[Scope]
+    protected function local(Builder $query): void {
+        $query->where('ip_address', '127.0.0.1');
+    }
+
+    /**
+     * @comment Scope using the 'scope' prefix
+     * @param Builder $query
+     * @return void
+     */
+    protected function scopeSystem(Builder $query): void {
+        $query->where('system', true);
+    }
+}

--- a/tests/Console/ModelsCommand/QueryScopes/Models/Comment.php
+++ b/tests/Console/ModelsCommand/QueryScopes/Models/Comment.php
@@ -16,7 +16,8 @@ class Comment extends Model
      * @return void
      */
     #[Scope]
-    protected function local(Builder $query): void {
+    protected function local(Builder $query): void
+    {
         $query->where('ip_address', '127.0.0.1');
     }
 
@@ -25,7 +26,8 @@ class Comment extends Model
      * @param Builder $query
      * @return void
      */
-    protected function scopeSystem(Builder $query): void {
+    protected function scopeSystem(Builder $query): void
+    {
         $query->where('system', true);
     }
 }

--- a/tests/Console/ModelsCommand/QueryScopes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/QueryScopes/__snapshots__/Test__test__1.php
@@ -4,6 +4,47 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\QueryScopes\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * 
+ *
+ * @method static Builder<static>|Comment local() Scope using the 'Scope' attribute
+ * @method static Builder<static>|Comment newModelQuery()
+ * @method static Builder<static>|Comment newQuery()
+ * @method static Builder<static>|Comment query()
+ * @method static Builder<static>|Comment system() Scope using the 'scope' prefix
+ * @mixin \Eloquent
+ */
+class Comment extends Model
+{
+    /**
+     * @comment Scope using the 'Scope' attribute
+     * @param Builder $query
+     * @return void
+     */
+    #[Scope]
+    protected function local(Builder $query): void {
+        $query->where('ip_address', '127.0.0.1');
+    }
+
+    /**
+     * @comment Scope using the 'scope' prefix
+     * @param Builder $query
+     * @return void
+     */
+    protected function scopeSystem(Builder $query): void {
+        $query->where('system', true);
+    }
+}
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\QueryScopes\Models;
+
 /**
  * 
  *

--- a/tests/Console/ModelsCommand/QueryScopes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/QueryScopes/__snapshots__/Test__test__1.php
@@ -26,7 +26,8 @@ class Comment extends Model
      * @return void
      */
     #[Scope]
-    protected function local(Builder $query): void {
+    protected function local(Builder $query): void
+    {
         $query->where('ip_address', '127.0.0.1');
     }
 
@@ -35,7 +36,8 @@ class Comment extends Model
      * @param Builder $query
      * @return void
      */
-    protected function scopeSystem(Builder $query): void {
+    protected function scopeSystem(Builder $query): void
+    {
         $query->where('system', true);
     }
 }


### PR DESCRIPTION
## Summary

(https://laravel-news.com/local-model-scopes-in-laravel-with-the-scope-attribute)

This adds support for the new Scope syntax:
```php
use Illuminate\Database\Eloquent\Attributes\Scope;
 
#[Scope]
protected function popular(Builder $query): void
{
    $query->where('votes', '>', 100);
}
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
