### PR TITLE
fix: Add complete Request class methods to prevent Intelephense conflicts

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -49,6 +49,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Request stub generation
+    |--------------------------------------------------------------------------
+    |
+    | Set to true to generate complete Request class stubs including all methods.
+    | This helps prevent conflicts with PHP Intelephense extension.
+    |
+    */
+
+    'include_complete_request_stubs' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Factory builders
     |--------------------------------------------------------------------------
     |

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -76,6 +76,17 @@ class Generator
     public function generate()
     {
         $app = app();
+        $aliases = $this->getAliases();
+        
+        // Handle Request class specially if complete stubs are enabled
+        if ($this->config->get('ide-helper.include_complete_request_stubs', true)) {
+            foreach ($aliases as $alias) {
+                if ($alias->getExtends() === 'Illuminate\Http\Request') {
+                    $this->addCompleteRequestMethods($alias);
+                }
+            }
+        }
+
         return $this->view->make('ide-helper::helper')
             ->with('namespaces_by_extends_ns', $this->getAliasesByExtendsNamespace())
             ->with('namespaces_by_alias_ns', $this->getAliasesByAliasNamespace())
@@ -403,5 +414,60 @@ class Generator
                     return $alias->getExtends() === $class;
                 });
             });
+    }
+
+    /**
+     * Add complete Request class methods to the alias
+     *
+     * @param Alias $alias
+     * @return void
+     */
+    protected function addCompleteRequestMethods(Alias $alias)
+    {
+        $methods = [
+            'input' => 'mixed',
+            'route' => 'mixed',
+            'file' => 'mixed',
+            'hasFile' => 'bool',
+            'all' => 'array',
+            'only' => 'array',
+            'except' => 'array',
+            'query' => 'mixed',
+            'cookie' => 'mixed',
+            'header' => 'mixed',
+            'server' => 'mixed',
+            'session' => 'mixed',
+            'old' => 'mixed',
+            'flash' => 'void',
+            'flashOnly' => 'void',
+            'flashExcept' => 'void',
+            'flush' => 'void',
+            'merge' => 'void',
+            'replace' => 'void',
+            'json' => 'mixed',
+            'isJson' => 'bool',
+            'wantsJson' => 'bool',
+            'is' => 'bool',
+            'routeIs' => 'bool',
+            'fullUrl' => 'string',
+            'url' => 'string',
+            'path' => 'string',
+            'decodedPath' => 'string',
+            'root' => 'string',
+            'method' => 'string',
+            'isMethod' => 'bool',
+            'bearerToken' => 'string',
+            'ip' => 'string',
+            'ips' => 'array',
+            'userAgent' => 'string',
+            'secure' => 'bool',
+            'ajax' => 'bool',
+            'pjax' => 'bool',
+            'prefetch' => 'bool',
+        ];
+
+        foreach ($methods as $method => $returnType) {
+            $alias->addMethod($method, [], $returnType);
+        }
     }
 }


### PR DESCRIPTION
   This PR fixes the issue with Intelephense extension in VS Code by adding complete request class methods to the generated stubs.

   Changes:
   - Added new config option `include_complete_request_stubs` (default: true)
   - Added complete list of Request class methods with proper return types
   - Modified Generator class to handle Request class specially

   Fixes #1693