### PR TITLE
fix(ModelsCommand): use 'string' as realType for 'encrypted' casts

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -410,9 +410,6 @@ class ModelsCommand extends Command
             $params = [];
 
             switch ($type) {
-                case 'encrypted':
-                    $realType = 'mixed';
-                    break;
                 case 'boolean':
                 case 'bool':
                     $realType = 'bool';
@@ -420,6 +417,7 @@ class ModelsCommand extends Command
                 case 'decimal':
                     $realType = 'numeric';
                     break;
+                case 'encrypted':
                 case 'string':
                 case 'hashed':
                     $realType = 'string';

--- a/tests/Console/ModelsCommand/AdvancedCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/AdvancedCasts/__snapshots__/Test__test__1.php
@@ -21,7 +21,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property \Carbon\CarbonImmutable $cast_to_immutable_custom_datetime
  * @property \Carbon\CarbonImmutable $cast_to_immutable_datetime
  * @property int $cast_to_timestamp
- * @property mixed $cast_to_encrypted
+ * @property string $cast_to_encrypted
  * @property array<array-key, mixed> $cast_to_encrypted_array
  * @property \Illuminate\Support\Collection<array-key, mixed> $cast_to_encrypted_collection
  * @property array<array-key, mixed> $cast_to_encrypted_json

--- a/tests/Console/ModelsCommand/SimpleCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/SimpleCasts/__snapshots__/Test__test__1.php
@@ -33,7 +33,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property \Carbon\CarbonImmutable $cast_to_immutable_datetime
  * @property \Carbon\CarbonImmutable $cast_to_immutable_datetime_serialization
  * @property int $cast_to_timestamp
- * @property mixed $cast_to_encrypted
+ * @property string $cast_to_encrypted
  * @property array<array-key, mixed> $cast_to_encrypted_array
  * @property \Illuminate\Support\Collection<array-key, mixed> $cast_to_encrypted_collection
  * @property array<array-key, mixed> $cast_to_encrypted_json


### PR DESCRIPTION
## Summary
Laravel casts using `'encrypted'` always result in a string. This is because Laravel encrypts the value directly without serialization. As a result, the output will never be anything other than a string.

Ref in HasAttributes.php:
![image](https://github.com/user-attachments/assets/0a9e33a4-6e23-415f-a17e-e9d6b4d21345)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
