### PR TITLE
Respect `CastAttributes::castUsing` generic types

### DIFF
--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CastableWithGenericObjectType.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CastableWithGenericObjectType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class CastableWithGenericObjectType implements Castable
+{
+    /**
+     * @return CastsAttributes<SpecializedCastedProperty, SpecializedCastedProperty>
+     */
+    public static function castUsing(array $arguments): CastsAttributes
+    {
+        return new CustomCasterWithDocblockReturn();
+    }
+}

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CastableWithGenericSelfType.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/CastableWithGenericSelfType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class CastableWithGenericSelfType implements Castable
+{
+    /**
+     * @return CastsAttributes<self, self>
+     */
+    public static function castUsing(array $arguments): CastsAttributes
+    {
+        return new CustomCasterWithDocblockReturn();
+    }
+}

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/SpecializedCastedProperty.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/SpecializedCastedProperty.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
+
+class SpecializedCastedProperty extends CastedProperty
+{
+}

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Models/CustomCast.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Models/CustomCast.php
@@ -6,6 +6,8 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCas
 
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableReturnsAnonymousCaster;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableReturnsCustomCaster;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableWithGenericObjectType;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableWithGenericSelfType;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableWithoutReturnType;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithDocblockReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithDocblockReturnFqn;
@@ -39,6 +41,8 @@ class CustomCast extends Model
         'casted_property_with_static_return_docblock' => SelfCastingCasterWithStaticDocblockReturn::class,
         'casted_property_with_this_return_docblock' => SelfCastingCasterWithThisDocblockReturn::class,
         'casted_property_with_castable' => CastableReturnsCustomCaster::class,
+        'casted_property_with_generic_object_type' => CastableWithGenericObjectType::class,
+        'casted_property_with_generic_self_type' => CastableWithGenericSelfType::class,
         'casted_property_with_anonymous_cast' => CastableReturnsAnonymousCaster::class,
         'casted_property_without_return_type' => CastableWithoutReturnType::class,
         'extended_casted_property_with_static_return_docblock' => ExtendedSelfCastingCasterWithStaticDocblockReturn::class,

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/__snapshots__/Test__test__1.php
@@ -6,6 +6,9 @@ namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCas
 
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableReturnsAnonymousCaster;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableReturnsCustomCaster;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableWithGenericObjectType;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableWithGenericSelfType;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableWithGenericTypes;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastableWithoutReturnType;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithDocblockReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CustomCasterWithDocblockReturnFqn;
@@ -42,6 +45,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property SelfCastingCasterWithStaticDocblockReturn $casted_property_with_static_return_docblock_and_param
  * @property CustomCasterWithStaticReturnType $casted_property_with_static_return_type
  * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $casted_property_with_castable
+ * @property SpecializedCastedProperty $casted_property_with_generic_object_type
+ * @property CastableWithGenericSelfType $casted_property_with_generic_self_type
  * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $casted_property_with_anonymous_cast
  * @property CastableWithoutReturnType $casted_property_without_return_type
  * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $cast_without_property
@@ -81,6 +86,8 @@ class CustomCast extends Model
         'casted_property_with_static_return_docblock' => SelfCastingCasterWithStaticDocblockReturn::class,
         'casted_property_with_this_return_docblock' => SelfCastingCasterWithThisDocblockReturn::class,
         'casted_property_with_castable' => CastableReturnsCustomCaster::class,
+        'casted_property_with_generic_object_type' => CastableWithGenericObjectType::class,
+        'casted_property_with_generic_self_type' => CastableWithGenericSelfType::class,
         'casted_property_with_anonymous_cast' => CastableReturnsAnonymousCaster::class,
         'casted_property_without_return_type' => CastableWithoutReturnType::class,
         'extended_casted_property_with_static_return_docblock' => ExtendedSelfCastingCasterWithStaticDocblockReturn::class,


### PR DESCRIPTION
## Summary

See https://github.com/barryvdh/laravel-ide-helper/issues/1700

This PR adds some logic for parsing generic types from `CastAttributes::castUsing` doc-blocks to allow for specializing `castUsing` while casting Laravel model columns.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
