### PR TITLE
Fix no facade aliased classes with macroable

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -30,6 +30,7 @@ class Alias
     protected $alias;
     /** @psalm-var class-string $facade */
     protected $facade;
+    protected $isLaravelFacade = false;
     protected $extends = null;
     protected $extendsClass = null;
     protected $extendsNamespace = null;
@@ -82,6 +83,7 @@ class Alias
         }
 
         $this->valid = true;
+        $this->isLaravelFacade = is_subclass_of($facade, Facade::class);
 
         $this->addClass($this->root);
         $this->detectFake();
@@ -242,11 +244,7 @@ class Alias
     {
         $facade = $this->facade;
 
-        if (!is_subclass_of($facade, Facade::class)) {
-            return;
-        }
-
-        if (!method_exists($facade, 'fake')) {
+        if (!$this->isLaravelFacade || !method_exists($facade, 'fake')) {
             return;
         }
 
@@ -412,7 +410,7 @@ class Alias
                     if (!in_array($method->name, $this->usedMethods)) {
                         // Only add the methods to the output when the root is not the same as the class.
                         // And don't add the __*() methods
-                        if ($this->extends !== $class && substr($method->name, 0, 2) !== '__') {
+                        if (!$this->isLaravelFacade && substr($method->name, 0, 2) !== '__') {
                             $this->methods[] = new Method(
                                 $method,
                                 $this->alias,

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -266,9 +266,7 @@ class Generator
      */
     protected function getAliasesByExtendsNamespace()
     {
-        $aliases = $this->getValidAliases()->filter(static function (Alias $alias) {
-            return is_subclass_of($alias->getExtends(), Facade::class);
-        });
+        $aliases = $this->getValidAliases();
 
         $this->addMacroableClasses($aliases);
 


### PR DESCRIPTION
## Summary

Aliases can be used with classes that are not `Illuminate\Support\Facades\Facade` and they can be `Macroable`.
This PR allows classes alias that do not extend Facade to be added to the list of macroables.

To explain myself better, an example:
[`'Arr' => \Illuminate\Support\Arr::class` Facades/Facade.php#L276@_defaultAliases()_](https://github.com/laravel/framework/blob/df12a087731b37708cfbba72172a4c381363fed2/src/Illuminate/Support/Facades/Facade.php#L276)
`Arr` alias for `\Illuminate\Support\Arr::class` is not a Facade but uses `Macroable`: [Illuminate/Collections/Arr.php#L16-L18](https://github.com/laravel/framework/blob/7f20c6184f5a39797a8ae50dc5182dd22ad37fc5/src/Illuminate/Collections/Arr.php#L16-L18)

If you look at the code below, before adding the list of macroables it is filtered by `Facade`, which is why aliases like `Arr` would not work
https://github.com/barryvdh/laravel-ide-helper/blob/0fa96e572d3ac8f280ad1be89e9c3747c481cdda/src/Generator.php#L269-L273

- Are those aliases being removed for some reason?
- With this change and #1707, all my macros work correctly.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
