### PR TITLE
fix: Add complete class methods to prevent Intelephense conflicts

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -49,6 +49,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Complete stub generation
+    |--------------------------------------------------------------------------
+    |
+    | Set to true to generate complete class stubs including all methods,
+    | can also detail the classes with an array; e.g.
+    | `[\Illuminate\Http\Request::class]`
+    |
+    */
+
+    'include_complete_stubs' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Factory builders
     |--------------------------------------------------------------------------
     |

--- a/src/Alias.php
+++ b/src/Alias.php
@@ -31,6 +31,7 @@ class Alias
     protected $alias;
     /** @psalm-var class-string $facade */
     protected $facade;
+    protected $completeStub = false;
     protected $extends = null;
     protected $extendsClass = null;
     protected $extendsNamespace = null;
@@ -80,6 +81,10 @@ class Alias
         }
 
         $this->valid = true;
+        $this->completeStub = $config->get('ide-helper.include_complete_stubs', false);
+        if(is_array($this->completeStub)) {
+            $this->completeStub = in_array(ltrim($this->root, '\\'), $this->completeStub);
+        }
 
         $this->addClass($this->root);
         $this->detectFake();
@@ -410,7 +415,7 @@ class Alias
                     if (!in_array($method->name, $this->usedMethods)) {
                         // Only add the methods to the output when the root is not the same as the class.
                         // And don't add the __*() methods
-                        if ($this->extends !== $class && substr($method->name, 0, 2) !== '__') {
+                        if (($this->extends !== $class || $this->completeStub) && substr($method->name, 0, 2) !== '__') {
                             $this->methods[] = new Method(
                                 $method,
                                 $this->alias,

--- a/tests/Console/GeneratorCommand/GenerateIdeHelper/Test.php
+++ b/tests/Console/GeneratorCommand/GenerateIdeHelper/Test.php
@@ -30,6 +30,7 @@ class Test extends AbstractGeneratorCommand
         $this->assertStringContainsString('public static function arr_custom_macro()', $this->mockFilesystemOutput);
         $this->assertStringContainsString('public static function db_custom_macro()', $this->mockFilesystemOutput);
         $this->assertStringContainsString('return \Illuminate\Support\Arr::add', $this->mockFilesystemOutput);
+        $this->assertStringNotContainsString('return \Illuminate\Support\Str::of', $this->mockFilesystemOutput);
     }
 
     public function testFilename(): void

--- a/tests/Console/GeneratorCommand/GenerateIdeHelper/Test.php
+++ b/tests/Console/GeneratorCommand/GenerateIdeHelper/Test.php
@@ -17,6 +17,7 @@ class Test extends AbstractGeneratorCommand
         });
         DB::macro('db_custom_macro', function () {
         });
+        $this->app['config']->set('ide-helper.include_complete_stubs', [Arr::class]);
 
         $command = $this->app->make(GeneratorCommand::class);
 
@@ -28,6 +29,7 @@ class Test extends AbstractGeneratorCommand
         $this->assertStringContainsString('public static function configure($basePath = null)', $this->mockFilesystemOutput);
         $this->assertStringContainsString('public static function arr_custom_macro()', $this->mockFilesystemOutput);
         $this->assertStringContainsString('public static function db_custom_macro()', $this->mockFilesystemOutput);
+        $this->assertStringContainsString('return \Illuminate\Support\Arr::add', $this->mockFilesystemOutput);
     }
 
     public function testFilename(): void


### PR DESCRIPTION
## Summary
Alternartive to #1695, #1696, Closes #1693

This PR fixes Intelephense issues by adding complete classes methods to the generated stubs.
It also works for other simpler IDEs, I tested it in NetBeans

Now could be 
- `include_complete_stubs => true //(default: false)`, would force map all the methods of the aliases
- `include_complete_stubs => [Request::class, Arr::class]` would force map only the listed aliases

Changes:

- Added new config option `include_complete_stubs`(**OPT-IN, false as default**)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
