### PR TITLE
Configurable macro return type defaults

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -276,6 +276,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Default return types for macros
+    |--------------------------------------------------------------------------
+    |
+    | Define default return types for macros without explicit return types.
+    | e.g. `\Illuminate\Database\Query\Builder::class => 'static'`,
+    |      `\Illuminate\Support\Str::class => 'string'`
+    |
+    */
+    'macro_default_return_types' => [
+        \Illuminate\Http\Client\Factory::class => \Illuminate\Http\Client\PendingRequest::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Additional relation types
     |--------------------------------------------------------------------------
     |

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -57,9 +57,13 @@ class Generator
         // Find the drivers to add to the extra/interfaces
         $this->detectDrivers();
 
-        $this->extra = array_merge($this->extra, $this->config->get('ide-helper.extra'), []);
-        $this->magic = array_merge($this->magic, $this->config->get('ide-helper.magic'), []);
-        $this->interfaces = array_merge($this->interfaces, $this->config->get('ide-helper.interfaces'), []);
+        $this->extra = array_merge($this->extra, $this->config->get('ide-helper.extra', []));
+        $this->magic = array_merge($this->magic, $this->config->get('ide-helper.magic', []));
+        $this->interfaces = array_merge($this->interfaces, $this->config->get('ide-helper.interfaces', []));
+        Macro::setDefaultReturnTypes($this->config->get('ide-helper.macro_default_return_types', [
+            \Illuminate\Http\Client\Factory::class => \Illuminate\Http\Client\PendingRequest::class,
+        ]));
+        
         // Make all interface classes absolute
         foreach ($this->interfaces as &$interface) {
             $interface = '\\' . ltrim($interface, '\\');

--- a/src/Macro.php
+++ b/src/Macro.php
@@ -5,14 +5,11 @@ namespace Barryvdh\LaravelIdeHelper;
 use Barryvdh\Reflection\DocBlock;
 use Barryvdh\Reflection\DocBlock\Tag;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
-use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Collection;
 
 class Macro extends Method
 {
-    protected $macroDefaults = [
-        \Illuminate\Http\Client\Factory::class => PendingRequest::class,
-    ];
+    protected static $macroDefaults = [];
 
     /**
      * Macro constructor.
@@ -37,6 +34,10 @@ class Macro extends Method
         parent::__construct($method, $alias, $class, $methodName, $interfaces, $classAliases, $returnTypeNormalizers);
     }
 
+    public static function setDefaultReturnTypes(array $map = [])
+    {
+        static::$macroDefaults = array_merge(static::$macroDefaults, $map);
+    }
     /**
      * @param \ReflectionFunctionAbstract $method
      */
@@ -84,8 +85,8 @@ class Macro extends Method
         }
 
         $class = ltrim($this->declaringClassName, '\\');
-        if (!$this->phpdoc->hasTag('return') && isset($this->macroDefaults[$class])) {
-            $type = $this->macroDefaults[$class];
+        if (!$this->phpdoc->hasTag('return') && isset(static::$macroDefaults[$class])) {
+            $type = static::$macroDefaults[$class];
             $this->phpdoc->appendTag(Tag::createInstance("@return {$type}"));
         }
     }

--- a/tests/Console/GeneratorCommand/GenerateIdeHelper/Test.php
+++ b/tests/Console/GeneratorCommand/GenerateIdeHelper/Test.php
@@ -17,6 +17,7 @@ class Test extends AbstractGeneratorCommand
         });
         DB::macro('db_custom_macro', function () {
         });
+        $this->app['config']->set('ide-helper.macro_default_return_types', [Arr::class => 'Custom_Fake_Class']);
 
         $command = $this->app->make(GeneratorCommand::class);
 
@@ -26,6 +27,7 @@ class Test extends AbstractGeneratorCommand
 
         $this->assertStringContainsString('A new helper file was written to _ide_helper.php', $tester->getDisplay());
         $this->assertStringContainsString('public static function configure($basePath = null)', $this->mockFilesystemOutput);
+        $this->assertStringContainsString('* @return \Custom_Fake_Class', $this->mockFilesystemOutput);
         $this->assertStringContainsString('public static function arr_custom_macro()', $this->mockFilesystemOutput);
         $this->assertStringContainsString('public static function db_custom_macro()', $this->mockFilesystemOutput);
     }


### PR DESCRIPTION
## Summary
It would allow you to define custom defaults for macros, useful if you work in an environment where return types are not defined.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
