### PR TITLE
docs(readme): add Laravel 12 support information

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 This package generates helper files that enable your IDE to provide accurate autocompletion.
 Generation is done based on the files in your project, so they are always up-to-date.
 
-The 3.x branch supports Laravel 10 and 11. For older version, use the 2.x releases.
+The 3.x branch supports Laravel 10 and 11, and (since version 3.5.5) Laravel 12. For older version, use the 2.x releases.
 
 - [Installation](#installation)
 - [Usage](#usage)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 This package generates helper files that enable your IDE to provide accurate autocompletion.
 Generation is done based on the files in your project, so they are always up-to-date.
 
-The 3.x branch supports Laravel 10 and 11, and (since version 3.5.5) Laravel 12. For older version, use the 2.x releases.
+The 3.x branch supports Laravel 10 and later. For older version, use the 2.x releases.
 
 - [Installation](#installation)
 - [Usage](#usage)


### PR DESCRIPTION
## Summary
This pull request updates the project's readme to explicitly clarify that Laravel 12 is supported by the 3.x branch, specifically since version [3.5.5](https://github.com/barryvdh/laravel-ide-helper/pull/1672). Previously, the documentation only mentioned support for Laravel 10 and 11, which could lead to confusion or uncertainty for users working with Laravel 12. This change provides accurate and up-to-date information, helping users quickly understand compatibility.

## Type of change
- This change requires a documentation update.

### Checklist
- Update the README.md.
