### PR TITLE
Fix `methodsto` typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ If for some reason it's undesired to have them generated (one for each column), 
 
 #### Magic `*_count` and `*_exists` properties
 
-You may use the [`::withCount`](https://laravel.com/docs/master/eloquent-relationships#counting-related-models) and [`::withExists`](https://laravel.com/docs/master/eloquent-relationships#other-aggregate-functions) methodsto count the number results from a relationship without actually loading them. Those results are then placed in attributes following the `<columname>_count` and `<columname>_exists` convention.
+You may use the [`::withCount`](https://laravel.com/docs/master/eloquent-relationships#counting-related-models) and [`::withExists`](https://laravel.com/docs/master/eloquent-relationships#other-aggregate-functions) methods to count the number results from a relationship without actually loading them. Those results are then placed in attributes following the `<columname>_count` and `<columname>_exists` convention.
 
 By default, these attributes are generated in the phpdoc. You can turn them off by setting the config `write_model_relation_count_properties` and `write_model_relation_exists_properties` to `false`.
 


### PR DESCRIPTION
## Summary

Fixes typo introduced in #1712

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist

- [x] Existing tests have been adapted and/or new tests have been added
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
