### PR TITLE
Update vimeo/psalm version constraint to support 6.0 for development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "orchestra/testbench": "^9.2 || ^10",
         "phpunit/phpunit": "^10.5 || ^11.5.3",
         "spatie/phpunit-snapshot-assertions": "^4 || ^5",
-        "vimeo/psalm": "^5.4",
+        "vimeo/psalm": "^5.4|^6.0",
         "vlucas/phpdotenv": "^5"
     },
     "suggest": {


### PR DESCRIPTION
## Summary
Can't run `composer install` without it.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
