### PR TITLE
Fix typos in documentation and code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ php artisan ide-helper:models -RW
 
 If you don't want the full _ide_helper.php file, you can run add `--write-eloquent-helper` to the model command to generate small version, which is required for the `@mixin \Eloquent` to be able to add the QueryBuilder methods.
 
-If you don't want to add all the phpdocs to your Models directly, you can use `--nowrite` to create a seperate file. The  `--write-mixin` option can be used to only add a `@mixin` to your models, but add the generated phpdocs in a seperate file. This avoids having the results marked as duplicate.
+If you don't want to add all the phpdocs to your Models directly, you can use `--nowrite` to create a separate file. The  `--write-mixin` option can be used to only add a `@mixin` to your models, but add the generated phpdocs in a separate file. This avoids having the results marked as duplicate.
 
 
 _Check out [this Laracasts video](https://laracasts.com/series/how-to-be-awesome-in-phpstorm/episodes/15) for a quick introduction/explanation!_
@@ -212,7 +212,7 @@ If for some reason it's undesired to have them generated (one for each column), 
 
 #### Magic `*_count` and `*_exists` properties
 
-You may use the [`::withCount`](https://laravel.com/docs/master/eloquent-relationships#counting-related-models) and [`::withExists`](https://laravel.com/docs/master/eloquent-relationships#other-aggregate-functions) methods to count the number results from a relationship without actually loading them. Those results are then placed in attributes following the `<columname>_count` and `<columname>_exists` convention.
+You may use the [`::withCount`](https://laravel.com/docs/master/eloquent-relationships#counting-related-models) and [`::withExists`](https://laravel.com/docs/master/eloquent-relationships#other-aggregate-functions) methods to count the number results from a relationship without actually loading them. Those results are then placed in attributes following the `<columnname>_count` and `<columnname>_exists` convention.
 
 By default, these attributes are generated in the phpdoc. You can turn them off by setting the config `write_model_relation_count_properties` and `write_model_relation_exists_properties` to `false`.
 

--- a/src/Method.php
+++ b/src/Method.php
@@ -178,7 +178,7 @@ class Method
     /**
      * Get the parameters for this method
      *
-     * @param bool $implode Wether to implode the array or not
+     * @param bool $implode Whether to implode the array or not
      * @return string
      */
     public function getParams($implode = true)
@@ -208,7 +208,7 @@ class Method
     /**
      * Get the parameters for this method including default values
      *
-     * @param bool $implode Wether to implode the array or not
+     * @param bool $implode Whether to implode the array or not
      * @return string
      */
     public function getParamsWithDefault($implode = true)


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->
- Fixed 'seperate' to 'separate' in README.md (2 occurrences)
- Fixed 'columname' to 'columnname' in README.md (2 occurrences)
- Fixed 'Wether' to 'Whether' in src/Method.php PHPDoc comments (2 occurrences)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
