### PR TITLE
Remove calls to PHP 8.5-deprecated `setAccessible`

### DIFF
--- a/php-templates/translations.php
+++ b/php-templates/translations.php
@@ -124,7 +124,6 @@ $reflection = new ReflectionClass($loader);
 $property = $reflection->hasProperty('paths')
     ? $reflection->getProperty('paths')
     : $reflection->getProperty('path');
-$property->setAccessible(true);
 
 $paths = Illuminate\Support\Arr::wrap($property->getValue($loader));
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -887,7 +887,6 @@ class ModelsCommand extends Command
 
         if (in_array($relation, ['hasOne', 'hasOneThrough', 'morphOne'], true)) {
             $defaultProp = $reflectionObj->getProperty('withDefault');
-            $defaultProp->setAccessible(true);
 
             return !$defaultProp->getValue($relationObj);
         }
@@ -897,7 +896,6 @@ class ModelsCommand extends Command
         }
 
         $fkProp = $reflectionObj->getProperty('foreignKey');
-        $fkProp->setAccessible(true);
 
         $enforceNullableRelation = $this->laravel['config']->get('ide-helper.enforce_nullable_relationships', true);
 
@@ -930,7 +928,6 @@ class ModelsCommand extends Command
         }
 
         $fkProp = $reflectionObj->getProperty('foreignKey');
-        $fkProp->setAccessible(true);
 
         foreach (Arr::wrap($fkProp->getValue($relationObj)) as $foreignKey) {
             if (isset($this->nullableColumns[$foreignKey])) {
@@ -1283,9 +1280,6 @@ class ModelsCommand extends Command
      */
     protected function getAttributeTypes(Model $model, \ReflectionMethod $reflectionMethod): Collection
     {
-        // Private/protected ReflectionMethods require setAccessible prior to PHP 8.1
-        $reflectionMethod->setAccessible(true);
-
         /** @var Attribute $attribute */
         $attribute = $reflectionMethod->invoke($model);
 

--- a/src/Factories.php
+++ b/src/Factories.php
@@ -16,7 +16,6 @@ class Factories
             $factory = app(Factory::class);
 
             $definitions = (new ReflectionClass(Factory::class))->getProperty('definitions');
-            $definitions->setAccessible(true);
 
             foreach ($definitions->getValue($factory) as $factory_target => $config) {
                 try {


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->

These are no-op as of PHP 8.1 and thus no longer needed:
https://github.com/barryvdh/laravel-ide-helper/blob/9ef25f60e70ced86f687ef6b9ffd9ac74a7c388a/composer.json#L24

See also https://wiki.php.net/rfc/make-reflection-setaccessible-no-op

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
