### PR TITLE
fix: wrap bare intersection types in parentheses when adding nullable

### DIFF
--- a/tests/Console/ModelsCommand/MorphToIntersection/Models/BaseModel.php
+++ b/tests/Console/ModelsCommand/MorphToIntersection/Models/BaseModel.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\MorphToIntersection\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class BaseModel extends Model
+{
+}

--- a/tests/Console/ModelsCommand/MorphToIntersection/Models/CanBeAssigned.php
+++ b/tests/Console/ModelsCommand/MorphToIntersection/Models/CanBeAssigned.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\MorphToIntersection\Models;
+
+interface CanBeAssigned
+{
+}

--- a/tests/Console/ModelsCommand/MorphToIntersection/Models/MorphToIntersection.php
+++ b/tests/Console/ModelsCommand/MorphToIntersection/Models/MorphToIntersection.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\MorphToIntersection\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class MorphToIntersection extends Model
+{
+    protected $table = 'morphs';
+
+    /** @return MorphTo<(BaseModel&CanBeAssigned), $this> */
+    public function assigneeWithParens(): MorphTo
+    {
+        return $this->morphTo(type: 'nullable_relation_morph_to_type', id: 'nullable_relation_morph_to_id');
+    }
+
+    /** @return MorphTo<BaseModel&CanBeAssigned, $this> */
+    public function assigneeWithoutParens(): MorphTo
+    {
+        return $this->morphTo(type: 'nullable_relation_morph_to_type', id: 'nullable_relation_morph_to_id');
+    }
+
+    /** @return MorphTo<(BaseModel&CanBeAssigned), $this> */
+    public function nonNullableAssignee(): MorphTo
+    {
+        return $this->morphTo(type: 'relation_morph_to_type', id: 'relation_morph_to_id');
+    }
+}

--- a/tests/Console/ModelsCommand/MorphToIntersection/Test.php
+++ b/tests/Console/ModelsCommand/MorphToIntersection/Test.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\MorphToIntersection;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+
+class Test extends AbstractModelsCommand
+{
+    public function test(): void
+    {
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--write' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
+        $this->assertMatchesMockedSnapshot();
+    }
+}

--- a/tests/Console/ModelsCommand/MorphToIntersection/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/MorphToIntersection/__snapshots__/Test__test__1.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\MorphToIntersection\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * @property string $relation_morph_to_type
+ * @property int $relation_morph_to_id
+ * @property string|null $nullable_relation_morph_to_type
+ * @property int|null $nullable_relation_morph_to_id
+ * @property-read (BaseModel&CanBeAssigned)|null $assigneeWithParens
+ * @property-read (BaseModel&CanBeAssigned)|null $assigneeWithoutParens
+ * @property-read (BaseModel&CanBeAssigned) $nonNullableAssignee
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|MorphToIntersection newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|MorphToIntersection newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|MorphToIntersection query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|MorphToIntersection whereNullableRelationMorphToId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|MorphToIntersection whereNullableRelationMorphToType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|MorphToIntersection whereRelationMorphToId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|MorphToIntersection whereRelationMorphToType($value)
+ * @mixin \Eloquent
+ */
+class MorphToIntersection extends Model
+{
+    protected $table = 'morphs';
+
+    /** @return MorphTo<(BaseModel&CanBeAssigned), $this> */
+    public function assigneeWithParens(): MorphTo
+    {
+        return $this->morphTo(type: 'nullable_relation_morph_to_type', id: 'nullable_relation_morph_to_id');
+    }
+
+    /** @return MorphTo<BaseModel&CanBeAssigned, $this> */
+    public function assigneeWithoutParens(): MorphTo
+    {
+        return $this->morphTo(type: 'nullable_relation_morph_to_type', id: 'nullable_relation_morph_to_id');
+    }
+
+    /** @return MorphTo<(BaseModel&CanBeAssigned), $this> */
+    public function nonNullableAssignee(): MorphTo
+    {
+        return $this->morphTo(type: 'relation_morph_to_type', id: 'relation_morph_to_id');
+    }
+}


### PR DESCRIPTION
## Summary

When a MorphTo relation's docblock uses a bare intersection type in the generic parameter (e.g. `MorphTo<BaseModel&CanBeAssigned, $this>`), the generated property type incorrectly becomes `BaseModel&CanBeAssigned|null` instead of the correct `(BaseModel&CanBeAssigned)|null`.

This adds `wrapIntersectionType()` which ensures bare intersection types are wrapped in parentheses before `|null` is appended, producing valid DNF type syntax. Applied in both `setProperty()` and `applyNullability()`.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Code style has been fixed via `composer fix-style`
