### PR TITLE
fix: Skip autoload exception when class existence is being checked

### DIFF
--- a/src/Console/MetaCommand.php
+++ b/src/Console/MetaCommand.php
@@ -195,6 +195,18 @@ class MetaCommand extends Command
                 return;
             }
 
+            // Don't throw when class existence is being checked via class_exists(),
+            // interface_exists(), trait_exists(), or enum_exists(). These functions
+            // expect the autoloader to return gracefully when the class doesn't exist.
+            // Throwing here would break libraries that use class_exists() to check for
+            // optional dependencies (e.g. Doctrine ORM checking for removed classes).
+            $existsFunctions = ['class_exists', 'interface_exists', 'trait_exists', 'enum_exists'];
+            foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3) as $frame) {
+                if (isset($frame['function']) && in_array($frame['function'], $existsFunctions, true)) {
+                    return;
+                }
+            }
+
             throw new \ReflectionException("Class '$class' not found.");
         };
 


### PR DESCRIPTION
## Problem

The `MetaCommand`'s custom autoloader (registered via `registerClassAutoloadExceptions()`) throws a `ReflectionException` for any class not in the aliases list. This causes a fatal error when libraries use `class_exists()` to check for optional dependencies during autoloading.

**Example:** Doctrine ORM v3 checks `class_exists('Doctrine\Persistence\Mapping\StaticReflectionService')` in [`GetReflectionClassImplementation.php`](https://github.com/doctrine/orm/blob/2148940290e4c44b9101095707e71fb590832fa5/src/Mapping/GetReflectionClassImplementation.php#L12) to maintain backward compatibility with doctrine/persistence v3.x. When the class doesn't exist (removed in v4), the autoloader throws instead of returning false.

## Root Cause

The autoloader unconditionally throws `ReflectionException` for any class not in the aliases list. But `class_exists()`, `interface_exists()`, `trait_exists()`, and `enum_exists()` expect autoloaders to return gracefully when a class doesn't exist — they rely on the return value to determine existence.

## Fix

Before throwing, check the call stack (up to 3 frames) for `class_exists()`, `interface_exists()`, `trait_exists()`, or `enum_exists()` calls. If one is found, return without throwing so the existence check correctly returns `false`.

## Steps to Reproduce

1. Install `doctrine/orm:^3` alongside `laravel-ide-helper`
2. Register a deferred service provider for `EntityManager`
3. Run `php artisan ide-helper:meta`
4. Observe fatal: `ReflectionException: Class 'Doctrine\Persistence\Mapping\StaticReflectionService' not found`

Fixes #1750