### PR TITLE
fix: Place PHPDoc before class attributes when writing to models

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1202,6 +1202,14 @@ class ModelsCommand extends Command
                 $replace = "{$modelDocComment}\n";
                 $pos = strpos($contents, "final class {$classname}") ?: strpos($contents, "class {$classname}");
                 if ($pos !== false) {
+                    // If PHP 8 attributes (e.g. #[ObservedBy(...)]) precede the class
+                    // declaration, insert the docblock before the first attribute so that
+                    // the resulting order is: docblock → attributes → class.
+                    $before = substr($contents, 0, $pos);
+                    if (preg_match('/(\s*(?:#\[.+?\]\s*)+)$/s', $before, $matches)) {
+                        $pos -= strlen($matches[1]);
+                        $replace = "{$modelDocComment}\n";
+                    }
                     $contents = substr_replace($contents, $replace, $pos, 0);
                 }
             }


### PR DESCRIPTION
## Problem

When running `php artisan ide-helper:models -RW` on models that have PHP 8 attributes (e.g. `#[ObservedBy(...)]`), the generated PHPDoc block is inserted **between** the attribute and the class declaration:

```php
#[ObservedBy([ImageObserver::class])]
/**
 * @property string $name
 * @property string $slug
 */
final class Image extends Model
```

This breaks PHPStan/Larastan, which expects the docblock to precede the attributes.

## Root Cause

When no existing docblock is found, the code locates `class {ClassName}` or `final class {ClassName}` via `strpos()` and inserts the docblock immediately before it. It doesn't account for PHP 8 attributes that may appear between the insertion point and the class keyword.

## Fix

Before inserting the docblock, scan the text preceding the class declaration for PHP 8 attribute blocks (`#[...]`). If found, shift the insertion point to before the first attribute, producing the correct order:

```php
/**
 * @property string $name
 * @property string $slug
 */
#[ObservedBy([ImageObserver::class])]
final class Image extends Model
```

Fixes #1734