### PR TITLE
fix: Don't extend root's parent class for facade stubs in helper file

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -187,7 +187,7 @@ class Alias
     public function shouldExtendParentClass()
     {
         return $this->parentClass
-            && $this->getExtendsNamespace() !== '\\Illuminate\\Support\\Facades';
+            && !is_subclass_of($this->extends, \Illuminate\Support\Facades\Facade::class);
     }
 
     /**


### PR DESCRIPTION
## Problem

Since #1674, the generated `_ide_helper.php` file adds `extends` declarations for Macroable classes to expose inherited methods. However, the condition to skip facades only checked if the extends namespace was `\Illuminate\Support\Facades`, so **third-party facades** (e.g. `Spatie\Menu\Laravel\Facades\Menu`) would incorrectly extend the facade root's parent class:

```php
// Generated (broken):
namespace Spatie\Menu\Laravel\Facades {
    class Menu extends \Spatie\Menu\Menu {
        // ...
    }
}
```

The real `Spatie\Menu\Laravel\Facades\Menu` extends `Illuminate\Support\Facades\Facade`, not `\Spatie\Menu\Menu`. This conflicting class definition causes PHP errors and IDE confusion.

## Root Cause

`shouldExtendParentClass()` used a namespace string comparison:
```php
return $this->parentClass
    && $this->getExtendsNamespace() !== '\\Illuminate\\Support\\Facades';
```

This only excluded Laravel's own facades but not third-party facades in other namespaces.

## Fix

Replace the namespace string comparison with `is_subclass_of()` to check if the extends class is actually a Facade subclass:
```php
return $this->parentClass
    && !is_subclass_of($this->extends, Facade::class);
```

This correctly excludes **all** facade classes (both Laravel and third-party) while still allowing non-facade Macroable classes to extend their parent and expose inherited methods as intended by #1674.

Fixes #1724