### PR TITLE
fix: Correct indentation in camel case config comment block

### DIFF
--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -201,29 +201,29 @@ return [
     ],
 
     /*
-     |--------------------------------------------------------------------------
-     | Support for camel cased models
-     |--------------------------------------------------------------------------
-     |
-     | There are some Laravel packages (such as Eloquence) that allow for accessing
-     | Eloquent model properties via camel case, instead of snake case.
-     |
-     | Enabling this option will support these packages by saving all model
-     | properties as camel case, instead of snake case.
-     |
-     | For example, normally you would see this:
-     |
-     |  * @property \Illuminate\Support\Carbon $created_at
-     |  * @property \Illuminate\Support\Carbon $updated_at
-     |
-     | With this enabled, the properties will be this:
-     |
-     |  * @property \Illuminate\Support\Carbon $createdAt
-     |  * @property \Illuminate\Support\Carbon $updatedAt
-     |
-     | Note, it is currently an all-or-nothing option.
-     |
-     */
+    |--------------------------------------------------------------------------
+    | Support for camel cased models
+    |--------------------------------------------------------------------------
+    |
+    | There are some Laravel packages (such as Eloquence) that allow for accessing
+    | Eloquent model properties via camel case, instead of snake case.
+    |
+    | Enabling this option will support these packages by saving all model
+    | properties as camel case, instead of snake case.
+    |
+    | For example, normally you would see this:
+    |
+    |  * @property \Illuminate\Support\Carbon $created_at
+    |  * @property \Illuminate\Support\Carbon $updated_at
+    |
+    | With this enabled, the properties will be this:
+    |
+    |  * @property \Illuminate\Support\Carbon $createdAt
+    |  * @property \Illuminate\Support\Carbon $updatedAt
+    |
+    | Note, it is currently an all-or-nothing option.
+    |
+    */
     'model_camel_case_properties' => false,
 
     /*


### PR DESCRIPTION
## Problem

The 'Support for camel cased models' comment block (lines 204–226) in `config/ide-helper.php` uses 5-space indentation for the pipe characters and the closing `*/`, while all other comment blocks in the file use the standard 4-space indentation. This causes misalignment when viewing the config file.

## Fix

Reduced the indentation from 5 spaces to 4 spaces for the affected comment block to match the rest of the file.

Fixes #1761