### PR TITLE
fix: Remove trailing spaces from empty docblock lines

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1164,7 +1164,7 @@ class ModelsCommand extends Command
         }
 
         $serializer = new DocBlockSerializer();
-        $docComment = $serializer->getDocComment($phpdoc);
+        $docComment = $this->stripTrailingSpaces($serializer->getDocComment($phpdoc));
         $mixinClassName = null;
 
         if ($this->write_mixin) {
@@ -1178,7 +1178,7 @@ class ModelsCommand extends Command
 
             $mixinClassName = "IdeHelper{$classname}";
             $phpdocMixin->appendTag(Tag::createInstance("@mixin {$mixinClassName}", $phpdocMixin));
-            $mixinDocComment = $serializer->getDocComment($phpdocMixin);
+            $mixinDocComment = $this->stripTrailingSpaces($serializer->getDocComment($phpdocMixin));
             // remove blank lines if there's no text
             if (!$phpdocMixin->getText()) {
                 $mixinDocComment = preg_replace("/\s\*\s*\n/", '', $mixinDocComment);
@@ -1189,7 +1189,7 @@ class ModelsCommand extends Command
                     $phpdoc->deleteTag($tag);
                 }
             }
-            $docComment = $serializer->getDocComment($phpdoc);
+            $docComment = $this->stripTrailingSpaces($serializer->getDocComment($phpdoc));
         }
 
         if ($this->write) {
@@ -1881,5 +1881,16 @@ class ModelsCommand extends Command
                 $this->foreignKeyConstraintsColumns[] = $columnName;
             }
         }
+    }
+
+    /**
+     * Remove trailing whitespace from docblock lines.
+     *
+     * The serializer may produce lines like " * " (with a trailing space)
+     * for empty docblock lines. This trims them to " *".
+     */
+    protected function stripTrailingSpaces(string $docComment): string
+    {
+        return preg_replace('/^(\s*\*)\s+$/m', '$1', $docComment);
     }
 }


### PR DESCRIPTION
## Problem

When running `ide-helper:models`, the generated PHPDoc blocks contain trailing spaces on empty comment lines:

```php
/**
 * This model does something interesting.
 * <-- trailing space here
 * It is an example of a model with lots of documentation
 *
 * @mixin IdeHelperMyModel
 */
```

This triggers trailing-whitespace linters and requires a second pass (manual or automated) to clean up.

## Root Cause

The `DocBlockSerializer` from `barryvdh/reflection-docblock` produces ` * ` (with trailing space) for empty docblock lines instead of ` *`.

## Fix

Added a `stripTrailingSpaces()` method that post-processes the serialized docblock output using a regex to trim trailing whitespace from lines that only contain ` *` followed by spaces. Applied to all `getDocComment()` calls in the `createPhpDocs()` method.

The regex `/^(\s*\*)\s+$/m` matches lines where `*` is followed only by whitespace and strips the trailing spaces while preserving the indentation and asterisk.

Fixes #1669