### PR TITLE
Bump branch alias to 3.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.5-dev"
+            "dev-master": "3.6-dev"
         },
         "laravel": {
             "providers": [


### PR DESCRIPTION
## Summary
<!-- Please provide an exhaustive description. -->
When trying to test my application for Laravel 13 compatibility, it would not pick up the `dev-master` version of this package due to the `^3.6.1` constraint I currently have in place and the `3.5` alias in `composer.json` here.

This PR ensures that `dev-master` is a valid upgrade from the `^3.6` range. 

Alternatively, `3.7-dev` or `3.x-dev` would also seem to reasonable alternatives to me here,
so if wanted I'd be happy to change to either of these.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`
