### PR TITLE
Fix unsetMethod handling for camelCase methods

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1038,7 +1038,7 @@ class ModelsCommand extends Command
         }
     }
 
-    public function unsetMethod($name)
+public function unsetMethod($name)
 {
     foreach (array_keys($this->methods) as $method) {
         if (strtolower($method) === strtolower($name)) {
@@ -1048,7 +1048,6 @@ class ModelsCommand extends Command
         }
     }
 }
-
     public function getMethodType(Model $model, string $classType)
     {
         $modelName = $this->getClassNameInDestinationFile($model, get_class($model));

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1039,14 +1039,15 @@ class ModelsCommand extends Command
     }
 
     public function unsetMethod($name)
-    {
-        foreach ($this->methods as $k => $v) {
-            if (strtolower($k) === strtolower($name)) {
-                unset($this->methods[$k]);
-                return;
-            }
+{
+    foreach (array_keys($this->methods) as $method) {
+        if (strtolower($method) === strtolower($name)) {
+            unset($this->methods[$method]);
+
+            return;
         }
     }
+}
 
     public function getMethodType(Model $model, string $classType)
     {

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1038,16 +1038,17 @@ class ModelsCommand extends Command
         }
     }
 
-public function unsetMethod($name)
-{
-    foreach (array_keys($this->methods) as $method) {
-        if (strtolower($method) === strtolower($name)) {
-            unset($this->methods[$method]);
+    public function unsetMethod($name)
+    {
+        foreach (array_keys($this->methods) as $method) {
+            if (strtolower($method) === strtolower($name)) {
+                unset($this->methods[$method]);
 
-            return;
+                return;
+            }
         }
     }
-}
+    
     public function getMethodType(Model $model, string $classType)
     {
         $modelName = $this->getClassNameInDestinationFile($model, get_class($model));

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1048,7 +1048,7 @@ class ModelsCommand extends Command
             }
         }
     }
-    
+
     public function getMethodType(Model $model, string $classType)
     {
         $modelName = $this->getClassNameInDestinationFile($model, get_class($model));

--- a/tests/Console/ModelsCommand/ModelHooks/Hooks/UnsetMethod.php
+++ b/tests/Console/ModelsCommand/ModelHooks/Hooks/UnsetMethod.php
@@ -12,6 +12,6 @@ class UnsetMethod implements ModelHookInterface
 {
     public function run(ModelsCommand $command, Model $model): void
     {
-        $command->unsetMethod('newmodelquery');
+        $command->unsetMethod('newModelQuery');;
     }
 }

--- a/tests/Console/ModelsCommand/ModelHooks/Hooks/UnsetMethod.php
+++ b/tests/Console/ModelsCommand/ModelHooks/Hooks/UnsetMethod.php
@@ -12,6 +12,6 @@ class UnsetMethod implements ModelHookInterface
 {
     public function run(ModelsCommand $command, Model $model): void
     {
-        $command->unsetMethod('newModelQuery');;
+        $command->unsetMethod('newModelQuery');
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes `unsetMethod()` so it can correctly remove generated methods regardless of the casing used when calling it.

Currently, `setMethod()` stores method names using their original casing, while `unsetMethod()` tries to remove the lowercase version of the method name. Because of this, calling `unsetMethod('newModelQuery')` does not remove the generated `newModelQuery` method.

This update makes `unsetMethod()` compare method names case-insensitively while still unsetting the actual stored key.

Fixes #1381.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`