### PR TITLE
Skip incrementEach and decrementEach for Eloquent helper

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -101,7 +101,12 @@ class Alias
         }
 
         if ($facade === '\Illuminate\Database\Eloquent\Model') {
-            $this->usedMethods = ['decrement' => true, 'increment' => true];
+    $this->usedMethods = [
+        'decrement' => true,
+        'decrementEach' => true,
+        'increment' => true,
+        'incrementEach' => true,
+    ];
         }
     }
 

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1038,7 +1038,7 @@ class ModelsCommand extends Command
         }
     }
 
-    public function unsetMethod($name)
+public function unsetMethod($name)
 {
     foreach (array_keys($this->methods) as $method) {
         if (strtolower($method) === strtolower($name)) {
@@ -1048,7 +1048,6 @@ class ModelsCommand extends Command
         }
     }
 }
-
     public function getMethodType(Model $model, string $classType)
     {
         $modelName = $this->getClassNameInDestinationFile($model, get_class($model));

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1039,14 +1039,15 @@ class ModelsCommand extends Command
     }
 
     public function unsetMethod($name)
-    {
-        foreach ($this->methods as $k => $v) {
-            if (strtolower($k) === strtolower($name)) {
-                unset($this->methods[$k]);
-                return;
-            }
+{
+    foreach (array_keys($this->methods) as $method) {
+        if (strtolower($method) === strtolower($name)) {
+            unset($this->methods[$method]);
+
+            return;
         }
     }
+}
 
     public function getMethodType(Model $model, string $classType)
     {

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1038,16 +1038,17 @@ class ModelsCommand extends Command
         }
     }
 
-public function unsetMethod($name)
-{
-    foreach (array_keys($this->methods) as $method) {
-        if (strtolower($method) === strtolower($name)) {
-            unset($this->methods[$method]);
+    public function unsetMethod($name)
+    {
+        foreach (array_keys($this->methods) as $method) {
+            if (strtolower($method) === strtolower($name)) {
+                unset($this->methods[$method]);
 
-            return;
+                return;
+            }
         }
     }
-}
+    
     public function getMethodType(Model $model, string $classType)
     {
         $modelName = $this->getClassNameInDestinationFile($model, get_class($model));

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1048,7 +1048,7 @@ class ModelsCommand extends Command
             }
         }
     }
-    
+
     public function getMethodType(Model $model, string $classType)
     {
         $modelName = $this->getClassNameInDestinationFile($model, get_class($model));

--- a/tests/Console/ModelsCommand/ModelHooks/Hooks/UnsetMethod.php
+++ b/tests/Console/ModelsCommand/ModelHooks/Hooks/UnsetMethod.php
@@ -12,6 +12,6 @@ class UnsetMethod implements ModelHookInterface
 {
     public function run(ModelsCommand $command, Model $model): void
     {
-        $command->unsetMethod('newmodelquery');
+        $command->unsetMethod('newModelQuery');;
     }
 }

--- a/tests/Console/ModelsCommand/ModelHooks/Hooks/UnsetMethod.php
+++ b/tests/Console/ModelsCommand/ModelHooks/Hooks/UnsetMethod.php
@@ -12,6 +12,6 @@ class UnsetMethod implements ModelHookInterface
 {
     public function run(ModelsCommand $command, Model $model): void
     {
-        $command->unsetMethod('newModelQuery');;
+        $command->unsetMethod('newModelQuery');
     }
 }


### PR DESCRIPTION
## Summary

This PR prevents the generated Eloquent helper from adding `incrementEach` and `decrementEach` methods.

These methods exist as protected methods on Laravel's Eloquent model, but the generated helper currently outputs them as public static methods. This can cause IDE/static analysis errors because the generated method visibility is incompatible with the original model methods.

The generator already skips `increment` and `decrement`, so this update also skips `incrementEach` and `decrementEach`.

Fixes #1778.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`