### PR TITLE
Skip incrementEach and decrementEach for Eloquent helper

### DIFF
--- a/src/Alias.php
+++ b/src/Alias.php
@@ -101,7 +101,12 @@ class Alias
         }
 
         if ($facade === '\Illuminate\Database\Eloquent\Model') {
-            $this->usedMethods = ['decrement' => true, 'increment' => true];
+            $this->usedMethods = [
+                'decrement' => true,
+                'decrementEach' => true,
+                'increment' => true,
+                'incrementEach' => true,
+            ];
         }
     }
 


### PR DESCRIPTION
## Summary

This PR prevents the generated Eloquent helper from adding `incrementEach` and `decrementEach` methods.

These methods exist as protected methods on Laravel's Eloquent model, but the generated helper currently outputs them as public static methods. This can cause IDE/static analysis errors because the generated method visibility is incompatible with the original model methods.

The generator already skips `increment` and `decrement`, so this update also skips `incrementEach` and `decrementEach`.

Fixes #1778.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [ ] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [ ] Code style has been fixed via `composer fix-style`