### PR TITLE
fix: drop redundant @param tags for optional scalar defaults on query builders

### DIFF
--- a/src/Method.php
+++ b/src/Method.php
@@ -76,6 +76,8 @@ class Method
         } catch (\Exception $e) {
         }
 
+        $this->removePhpDocParamTagsForOptionalParameters();
+
         //Get the parameters, including formatted default values
         $this->getParameters($method);
 
@@ -243,6 +245,50 @@ class Method
                 foreach ($inheritTags as $tag) {
                     $tag->setDocBlock();
                     $phpdoc->appendTag($tag);
+                }
+            }
+        }
+    }
+
+    /**
+     * Remove @param tags for optional reflection parameters so generated stubs match arity
+     * checks in static analysis (optional params still appear in the PHP signature).
+     */
+    protected function removePhpDocParamTagsForOptionalParameters(): void
+    {
+        if (!$this->method instanceof \ReflectionMethod) {
+            return;
+        }
+
+        $declaring = $this->method->getDeclaringClass()->getName();
+        if (
+            $declaring !== \Illuminate\Database\Query\Builder::class
+            && $declaring !== \Illuminate\Database\Eloquent\Builder::class
+        ) {
+            return;
+        }
+
+        foreach ($this->method->getParameters() as $param) {
+            if (!$param->isOptional() || $param->isVariadic()) {
+                continue;
+            }
+            if (!$param->isDefaultValueAvailable()) {
+                continue;
+            }
+
+            $default = $param->getDefaultValue();
+            // Keep @param for null/array defaults (nullable and list defaults stay documented).
+            // Strip only non-null scalars (e.g. $boolean = 'and', $not = false) so tools that
+            // count @param tags do not report false "missing argument" errors on shortened calls.
+            if ($default === null || is_array($default) || !is_scalar($default)) {
+                continue;
+            }
+
+            $varName = '$' . $param->getName();
+            $paramTags = $this->phpdoc->getTagsByName('param');
+            foreach (array_values($paramTags) as $tag) {
+                if ($tag instanceof ParamTag && $tag->getVariableName() === $varName) {
+                    $this->phpdoc->deleteTag($tag);
                 }
             }
         }

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -101,7 +101,6 @@ DOC;
  * @param (\Closure(static): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression $column
  * @param mixed $operator
  * @param mixed $value
- * @param string $boolean
  * @return \Illuminate\Database\Eloquent\Builder<static>
  * @static
  */
@@ -130,8 +129,6 @@ DOC;
  * Add a "where null" clause to the query.
  *
  * @param string|array|\Illuminate\Contracts\Database\Query\Expression $columns
- * @param string $boolean
- * @param bool $not
  * @return \Illuminate\Database\Eloquent\Builder<static>
  * @static
  */


### PR DESCRIPTION
## Summary

`ide-helper:generate` emits the global Eloquent helper from Illuminate\Database\Query\Builder / Eloquent\Builder methods. Laravel’s PHPDoc often lists `@param` for every parameter, including optional tail args like `$boolean = 'and'` and `$not = false`. The generated PHP signature already includes defaults, but some language servers (e.g. Intelephense) treat each `@param` line as a required argument and report false positives such as “expected 4 arguments, found 2” on calls like `whereIn('id', $ids)`.

## Type of change

For methods declared on Illuminate\Database\Query\Builder and Illuminate\Database\Eloquent\Builder only, remove `@param` docblock entries when the reflection parameter is optional and its default is a non-null scalar (so we keep documentation for null and array defaults).
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`

Closes: #1784