### PR TITLE
test: add regression test for unique() column type resolution

### DIFF
--- a/tests/Console/ModelsCommand/UniqueColumn/Models/User.php
+++ b/tests/Console/ModelsCommand/UniqueColumn/Models/User.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\UniqueColumn\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $table = 'users_unique';
+}

--- a/tests/Console/ModelsCommand/UniqueColumn/Test.php
+++ b/tests/Console/ModelsCommand/UniqueColumn/Test.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\UniqueColumn;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+
+class Test extends AbstractModelsCommand
+{
+    public function test(): void
+    {
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--write' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
+
+        $this->assertMatchesMockedSnapshot();
+    }
+}

--- a/tests/Console/ModelsCommand/UniqueColumn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/UniqueColumn/__snapshots__/Test__test__1.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\UniqueColumn\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property string $password
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User whereEmail($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User wherePassword($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User whereUpdatedAt($value)
+ * @mixin \Eloquent
+ */
+class User extends Model
+{
+    protected $table = 'users_unique';
+}

--- a/tests/Console/ModelsCommand/migrations/____users_unique_table.php
+++ b/tests/Console/ModelsCommand/migrations/____users_unique_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UsersUniqueTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users_unique', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->timestamps();
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Adds a regression test to verify that columns created with `->unique()` (e.g. `$table->string("email")->unique()`) correctly resolve to `string` type in generated model PHPDoc.

## Background

Issue #1747 reported that `string()->unique()` columns show as `mixed|null` in generated model PHPDoc. This test confirms the type resolves correctly to `string` (at least on SQLite). Adds coverage for this edge case.

## Changes

- `tests/Console/ModelsCommand/migrations/____users_unique_table.php` - Migration with a `->unique()` column
- `tests/Console/ModelsCommand/UniqueColumn/Test.php` - Test that verifies the generated PHPDoc
- `tests/Console/ModelsCommand/UniqueColumn/Models/User.php` - Test model
- `__snapshots__/Test__test__1.php` - Snapshot showing expected output

Related: #1747