### PR TITLE
feat(ModelsCommand): add `model_connection_resolver` hook for dynamic connection/schema setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ The 3.x branch supports Laravel 10 and later. For older version, use the 2.x rel
 
 - [Installation](#installation)
 - [Usage](#usage)
-  - [Automatic PHPDoc generation for Laravel Facades](#automatic-phpdoc-generation-for-laravel-facades)
-  - [Automatic PHPDocs for models](#automatic-phpdocs-for-models)
-    - [Model Directories](#model-directories)
-    - [Ignore Models](#ignore-models)
-    - [Model Hooks](#model-hooks)
-  - [Automatic PHPDocs generation for Laravel Fluent methods](#automatic-phpdocs-generation-for-laravel-fluent-methods)
-  - [Auto-completion for factory builders](#auto-completion-for-factory-builders)
-  - [PhpStorm Meta for Container instances](#phpstorm-meta-for-container-instances)
+    - [Automatic PHPDoc generation for Laravel Facades](#automatic-phpdoc-generation-for-laravel-facades)
+    - [Automatic PHPDocs for models](#automatic-phpdocs-for-models)
+        - [Model Directories](#model-directories)
+        - [Ignore Models](#ignore-models)
+        - [Model Hooks](#model-hooks)
+    - [Automatic PHPDocs generation for Laravel Fluent methods](#automatic-phpdocs-generation-for-laravel-fluent-methods)
+    - [Auto-completion for factory builders](#auto-completion-for-factory-builders)
+    - [PhpStorm Meta for Container instances](#phpstorm-meta-for-container-instances)
 - [License](#license)
 
 ## Installation
@@ -33,33 +33,31 @@ Require this package with composer using the following command:
 composer require --dev barryvdh/laravel-ide-helper
 ```
 
-
 ## Usage
 
 ### TL;DR
 
-Run this to generate autocompletion for Facades. This creates _ide_helper.php
+Run this to generate autocompletion for Facades. This creates \_ide_helper.php
 
 ```
 php artisan ide-helper:generate
 ```
 
 Run this to add phpdocs for your models. Add -RW to Reset existing phpdocs and Write to the models directly.
+
 ```
 php artisan ide-helper:models -RW
 ```
 
-If you don't want the full _ide_helper.php file, you can run add `--write-eloquent-helper` to the model command to generate small version, which is required for the `@mixin \Eloquent` to be able to add the QueryBuilder methods.
+If you don't want the full \_ide_helper.php file, you can run add `--write-eloquent-helper` to the model command to generate small version, which is required for the `@mixin \Eloquent` to be able to add the QueryBuilder methods.
 
-If you don't want to add all the phpdocs to your Models directly, you can use `--nowrite` to create a separate file. The  `--write-mixin` option can be used to only add a `@mixin` to your models, but add the generated phpdocs in a separate file. This avoids having the results marked as duplicate.
-
+If you don't want to add all the phpdocs to your Models directly, you can use `--nowrite` to create a separate file. The `--write-mixin` option can be used to only add a `@mixin` to your models, but add the generated phpdocs in a separate file. This avoids having the results marked as duplicate.
 
 _Check out [this Laracasts video](https://laracasts.com/series/how-to-be-awesome-in-phpstorm/episodes/15) for a quick introduction/explanation!_
 
 - `php artisan ide-helper:generate` - [PHPDoc generation for Laravel Facades ](#automatic-phpdoc-generation-for-laravel-facades)
 - `php artisan ide-helper:models` - [PHPDocs for models](#automatic-phpdocs-for-models)
 - `php artisan ide-helper:meta` - [PhpStorm Meta file](#phpstorm-meta-for-container-instances)
-
 
 > Note: You do need CodeComplice for Sublime Text: https://github.com/spectacles/CodeComplice
 
@@ -96,7 +94,7 @@ The generator tries to identify the real class, but if it cannot be found, you c
 Some classes need a working database connection. If you do not have a default working connection, some facades will not be included.
 You can use an in-memory SQLite driver by adding the `-M` option.
 
-If you use [real-time facades](https://laravel.com/docs/master/facades#real-time-facades) in your app, those will also be included in the generated file using a `@mixin` annotation and extending the original class underneath the facade. 
+If you use [real-time facades](https://laravel.com/docs/master/facades#real-time-facades) in your app, those will also be included in the generated file using a `@mixin` annotation and extending the original class underneath the facade.
 
 > **Note**: this feature uses the generated real-time facades files in the `storage/framework/cache` folder. Those files are generated on-demand as you use the real-time facade, so if the framework has not generated that first, it will not be included in the helper file. Run the route/command/code first and then regenerate the helper file and this time the real-time facade will be included in it.
 
@@ -132,7 +130,7 @@ The class name will be different from the model, avoiding the IDE duplicate anno
 
 > Please make sure to back up your models, before writing the info.
 
-> You need the _ide_helper.php file to add the QueryBuilder methods. You can add --write-eloquent-helper/-E to generate a minimal version. If this file does not exist, you will be prompted for it.
+> You need the \_ide_helper.php file to add the QueryBuilder methods. You can add --write-eloquent-helper/-E to generate a minimal version. If this file does not exist, you will be prompted for it.
 
 Writing to the models should keep the existing comments and only append new properties/methods. It will not update changed properties/methods.
 
@@ -164,6 +162,7 @@ php artisan ide-helper:models "App\Models\Post"
 ```
 
 With the `--write-mixin (-M)` option
+
 ```php
 /**
  * …
@@ -225,6 +224,7 @@ These can be disabled by setting the config `use_generics_annotations` to `false
 #### Support `@comment` based on DocBlock
 
 In order to better support IDEs, relations and getters/setters can also add a comment to a property like table columns. Therefore a custom docblock `@comment` is used:
+
 ```php
 class Users extends Model
 {
@@ -243,7 +243,7 @@ class Users extends Model
 
 /**
  * App\Models\Users
- * 
+ *
  * @property-read string $full_name Get User's full name
  * …
  */
@@ -251,7 +251,7 @@ class Users extends Model
 
 #### Dedicated Eloquent Builder methods
 
-A new method to the eloquent models was added called `newEloquentBuilder` [Reference](https://timacdonald.me/dedicated-eloquent-model-query-builders/) where we can 
+A new method to the eloquent models was added called `newEloquentBuilder` [Reference](https://timacdonald.me/dedicated-eloquent-model-query-builders/) where we can
 add support for creating a new dedicated class instead of using local scopes in the model itself.
 
 If for some reason it's undesired to have them generated (one for each column), you can disable this via config `write_model_external_builder_methods` and setting it to `false`.
@@ -279,12 +279,12 @@ If your custom relationships don't follow this traditional naming scheme you can
 #### Model Hooks
 
 If you need additional information on your model from sources that are not handled by default, you can hook in to the
- generation process with model hooks to add extra information on the fly.
- Simply create a class that implements `ModelHookInterface` and add it to the `model_hooks` array in the config:
- 
- ```php
+generation process with model hooks to add extra information on the fly.
+Simply create a class that implements `ModelHookInterface` and add it to the `model_hooks` array in the config:
+
+```php
 'model_hooks' => [
-    MyCustomHook::class,
+   MyCustomHook::class,
 ],
 ```
 
@@ -313,6 +313,40 @@ class MyCustomHook implements ModelHookInterface
  * @property integer $id
  * @property-read string $custom
 ```
+
+#### Model Connection Resolver
+
+If your application uses dynamic database connections or schemas, for example a multi-tenant setup where each tenant has its own PostgreSQL schema, you can configure a resolver that fires before each model's table columns are introspected, giving you a chance to point the connection at the right place.
+
+Set `model_connection_resolver` in the config to a class implementing `ModelConnectionResolverInterface`:
+
+```php
+'model_connection_resolver' => App\Support\IdeHelper\MyConnectionResolver::class,
+```
+
+The class must implement two methods:
+
+```php
+use Barryvdh\LaravelIdeHelper\Contracts\ModelConnectionResolverInterface;
+use Illuminate\Database\Eloquent\Model;
+
+class MyConnectionResolver implements ModelConnectionResolverInterface
+{
+    public function resolve(Model $model): void
+    {
+        // Called before getPropertiesFromTable().
+        // Set your connection, search_path, or any other context here.
+    }
+
+    public function after(Model $model): void
+    {
+        // Called after getPropertiesFromTable().
+        // Revert whatever you changed in resolve().
+    }
+}
+```
+
+The resolver is instantiated once per command run and is a no-op when model_connection_resolver is null (the default), so existing behaviour is completely unchanged.
 
 ### Automatic PHPDocs generation for Laravel Fluent methods
 
@@ -376,4 +410,3 @@ You can change the generated filename via the config `meta_filename`. This can b
 ## License
 
 The Laravel IDE Helper Generator is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT)
-

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -172,6 +172,28 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Model connection resolver
+    |--------------------------------------------------------------------------
+    |
+    | A class that resolves/configures the database connection before
+    | ide-helper introspects each model's table columns. This is called
+    | before getPropertiesFromTable() so you can set the correct schema,
+    | search_path, or tenant context.
+    |
+    | The class must implement:
+    | Barryvdh\LaravelIdeHelper\Contracts\ModelConnectionResolverInterface
+    |
+    | Example use case: Stancl Tenancy with PostgreSQL schemas-per-tenant.
+    | Set this to a class that initialises a tenant context before column
+    | introspection, then reverts it after.
+    |
+    */
+
+    'model_connection_resolver' => null,
+    // 'model_connection_resolver' => App\Support\IdeHelper\TenantConnectionResolver::class,
+
+    /*
+    |--------------------------------------------------------------------------
     | Extra classes
     |--------------------------------------------------------------------------
     |

--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -11,6 +11,7 @@
 
 namespace Barryvdh\LaravelIdeHelper\Console;
 
+use Barryvdh\LaravelIdeHelper\Contracts\ModelConnectionResolverInterface;
 use Barryvdh\LaravelIdeHelper\Contracts\ModelHookInterface;
 use Barryvdh\LaravelIdeHelper\Generator;
 use Barryvdh\LaravelIdeHelper\Parsers\PhpDocReturnTypeParser;
@@ -123,6 +124,7 @@ class ModelsCommand extends Command
     protected $reset;
     protected $phpstorm_noinspections;
     protected $write_model_external_builder_methods;
+    protected ?ModelConnectionResolverInterface $connectionResolver = null;
     /**
      * @var array<string, \SplFileObject>
      */
@@ -200,6 +202,18 @@ class ModelsCommand extends Command
         $this->dateClass = class_exists(\Illuminate\Support\Facades\Date::class)
             ? '\\' . get_class(\Illuminate\Support\Facades\Date::now())
             : '\Illuminate\Support\Carbon';
+
+        $resolverClass = $this->laravel['config']->get('ide-helper.model_connection_resolver');
+        if ($resolverClass !== null) {
+            $resolver = $this->laravel->make($resolverClass);
+            if (!$resolver instanceof ModelConnectionResolverInterface) {
+                throw new \RuntimeException(
+                    'Your IDE helper model connection resolver must implement ' .
+                    ModelConnectionResolverInterface::class
+                );
+            }
+            $this->connectionResolver = $resolver;
+        }
 
         $content = $this->generateDocs($model, $ignore);
 
@@ -333,7 +347,15 @@ class ModelsCommand extends Command
 
                     $model = $this->laravel->make($name);
 
+                    if ($this->connectionResolver !== null) {
+                        $this->connectionResolver->resolve($model);
+                    }
+
                     $this->getPropertiesFromTable($model);
+
+                    if ($this->connectionResolver !== null) {
+                        $this->connectionResolver->after($model);
+                    }
 
                     if (method_exists($model, 'getCasts')) {
                         $this->castPropertiesType($model);

--- a/src/Contracts/ModelConnectionResolverInterface.php
+++ b/src/Contracts/ModelConnectionResolverInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Barryvdh\LaravelIdeHelper\Contracts;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Implement this interface to resolve/configure the database connection
+ * before ide-helper introspects a model's table columns.
+ *
+ * This is useful for multi-tenant setups where the connection or schema
+ * must be configured per-model before the SchemaBuilder runs.
+ */
+interface ModelConnectionResolverInterface
+{
+    /**
+     * Called before getPropertiesFromTable() for each model.
+     * Use this to set the correct connection, search_path, or tenant context.
+     *
+     * @param  Model  $model  The model instance about to be introspected
+     * @return void
+     */
+    public function resolve(Model $model): void;
+
+    /**
+     * Called after getPropertiesFromTable() finishes for the model.
+     * Use this to revert any connection changes made in resolve().
+     *
+     * @param  Model  $model
+     * @return void
+     */
+    public function after(Model $model): void;
+}

--- a/tests/Console/ModelsCommand/ModelConnectionResolver/Models/Simple.php
+++ b/tests/Console/ModelsCommand/ModelConnectionResolver/Models/Simple.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelConnectionResolver\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Simple extends Model
+{
+}

--- a/tests/Console/ModelsCommand/ModelConnectionResolver/Resolvers/SpyResolver.php
+++ b/tests/Console/ModelsCommand/ModelConnectionResolver/Resolvers/SpyResolver.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelConnectionResolver\Resolvers;
+
+use Barryvdh\LaravelIdeHelper\Contracts\ModelConnectionResolverInterface;
+use Illuminate\Database\Eloquent\Model;
+
+class SpyResolver implements ModelConnectionResolverInterface
+{
+    public array $calls = [];
+
+    public function resolve(Model $model): void
+    {
+        $this->calls[] = 'resolve:' . class_basename($model);
+    }
+
+    public function after(Model $model): void
+    {
+        $this->calls[] = 'after:' . class_basename($model);
+    }
+}

--- a/tests/Console/ModelsCommand/ModelConnectionResolver/Test.php
+++ b/tests/Console/ModelsCommand/ModelConnectionResolver/Test.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelConnectionResolver;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\ModelConnectionResolver\Resolvers\SpyResolver;
+
+class Test extends AbstractModelsCommand
+{
+    public function testResolveAndAfterAreCalledInOrder(): void
+    {
+        $spy = new SpyResolver();
+
+        $this->app['config']->set('ide-helper.model_connection_resolver', SpyResolver::class);
+        $this->app->instance(SpyResolver::class, $spy);
+
+        $command = $this->app->make(ModelsCommand::class);
+        $tester = $this->runCommand($command, ['--write' => true]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertContains('resolve:Simple', $spy->calls);
+        $this->assertContains('after:Simple', $spy->calls);
+
+        $resolveIndex = array_search('resolve:Simple', $spy->calls);
+        $afterIndex = array_search('after:Simple', $spy->calls);
+        $this->assertLessThan($afterIndex, $resolveIndex);
+    }
+
+    public function testSkipsResolverWhenConfigIsNull(): void
+    {
+        $this->app['config']->set('ide-helper.model_connection_resolver', null);
+
+        $command = $this->app->make(ModelsCommand::class);
+        $tester = $this->runCommand($command, ['--write' => true]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+    }
+
+    public function testThrowsRuntimeExceptionForInvalidResolver(): void
+    {
+        $this->app['config']->set('ide-helper.model_connection_resolver', \stdClass::class);
+
+        $this->expectException(\RuntimeException::class);
+
+        $command = $this->app->make(ModelsCommand::class);
+        $this->runCommand($command, ['--write' => true]);
+    }
+}


### PR DESCRIPTION
## Summary


The `ide-helper:models` command has no way to configure the database connection *before* it introspects a model's table. This is a problem for any setup where the active connection or schema depends on runtime context , the most common case being multi-tenant apps using PostgreSQL schemas-per-tenant (e.g. via `stancl/tenancy` with `PostgreSQLSchemaManager`).

At artisan CLI time, no tenant is bootstrapped. The PostgreSQL connection's `search_path` stays on `public`, so `getPropertiesFromTable()` finds no columns and silently produces empty docblocks for every tenant model.

The existing `model_hooks` / `ModelHookInterface` doesn't solve this. It was designed to *add* information to the docblock after introspection has already run. By the time `run()` is called, the schema lookup has already failed.

---

This PR adds a `model_connection_resolver` config option that accepts a class implementing the new `ModelConnectionResolverInterface`. The interface has two methods:

- `resolve(Model $model)` called **before** `getPropertiesFromTable()`, so you can set the right connection, `search_path`, or any other context
- `after(Model $model)` called **after** `getPropertiesFromTable()`, so you can revert whatever you changed

```php
// config/ide-helper.php
'model_connection_resolver' => App\Support\IdeHelper\TenantConnectionResolver::class,
```

```php
<?php

namespace App\Support\IdeHelper;

use Barryvdh\LaravelIdeHelper\Contracts\ModelConnectionResolverInterface;
use Illuminate\Database\Eloquent\Model;
use Illuminate\Support\Facades\DB;

class TenantConnectionResolver implements ModelConnectionResolverInterface
{
    private ?string $tenantSchema = null;

    public function resolve(Model $model): void
    {
        // Only act on tenant models
        if (! str_starts_with(get_class($model), 'App\\Models\\Tenant\\')) {
            return;
        }

        $schema = DB::connection($model->getConnectionName() ?? config('database.default'))
            ->selectOne(
                "SELECT schema_name FROM information_schema.schemata
                 WHERE schema_name NOT IN ('public','information_schema','pg_catalog','pg_toast')
                   AND schema_name NOT LIKE 'pg_%'
                 ORDER BY schema_name LIMIT 1"
            )?->schema_name;

        if ($schema !== null) {
            $this->tenantSchema = $schema;
            DB::connection($model->getConnectionName() ?? config('database.default'))
                ->statement("SET search_path TO \"{$schema}\"");
        }
    }

    public function after(Model $model): void
    {
        if ($this->tenantSchema === null) {
            return;
        }

        DB::connection($model->getConnectionName() ?? config('database.default'))
            ->statement('SET search_path TO public');

        $this->tenantSchema = null;
    }
}
```

The feature is opt-in ; the config key defaults to `null` and the command behaviour is unchanged for anyone who doesn't set it.

The resolver is instantiated once per command run (not once per model), so the implementor can cache expensive lookups (like fetching a schema name) internally.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`


Closes #1141
Related: #1552