### PR TITLE
Mark optional parameters with [optional] in PHPDoc

### DIFF
--- a/src/Method.php
+++ b/src/Method.php
@@ -264,9 +264,22 @@ class Method
                 $content = $this->convertKeywords($tag->getContent());
                 $tag->setContent($content);
 
-                // Get the expanded type and re-set the content
-                $content = $tag->getType() . ' ' . $tag->getVariableName() . ' ' . $tag->getDescription();
-                $tag->setContent(trim($content));
+                        // Get the expanded type and re-set the content
+                $description = $tag->getDescription();
+                $content = $tag->getType() . ' ' . $tag->getVariableName();
+                if ($description) {
+                    $content .= ' ' . $description;
+                }
+
+                $paramName = ltrim($tag->getVariableName(), '$');
+                foreach ($this->method->getParameters() as $reflectionParam) {
+                    if ($reflectionParam->getName() === $paramName && $reflectionParam->isOptional()) {
+                        $content .= ' [optional]';
+                        break;
+                    }
+                }
+
+                $tag->setContent($content);
             }
         }
     }

--- a/tests/Console/ModelsCommand/UniqueColumn/Models/User.php
+++ b/tests/Console/ModelsCommand/UniqueColumn/Models/User.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\UniqueColumn\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $table = 'users_unique';
+}

--- a/tests/Console/ModelsCommand/UniqueColumn/Test.php
+++ b/tests/Console/ModelsCommand/UniqueColumn/Test.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\UniqueColumn;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\AbstractModelsCommand;
+
+class Test extends AbstractModelsCommand
+{
+    public function test(): void
+    {
+        $command = $this->app->make(ModelsCommand::class);
+
+        $tester = $this->runCommand($command, [
+            '--write' => true,
+        ]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Written new phpDocBlock to', $tester->getDisplay());
+
+        $this->assertMatchesMockedSnapshot();
+    }
+}

--- a/tests/Console/ModelsCommand/UniqueColumn/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/UniqueColumn/__snapshots__/Test__test__1.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\UniqueColumn\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property string $password
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User whereEmail($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User wherePassword($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|User whereUpdatedAt($value)
+ * @mixin \Eloquent
+ */
+class User extends Model
+{
+    protected $table = 'users_unique';
+}

--- a/tests/Console/ModelsCommand/migrations/____users_unique_table.php
+++ b/tests/Console/ModelsCommand/migrations/____users_unique_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UsersUniqueTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users_unique', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->timestamps();
+        });
+    }
+}

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -63,7 +63,7 @@ class MacroTest extends TestCase
 
         $this->assertNotNull($phpdoc);
         $this->assertEmpty($phpdoc->getText());
-        $this->assertEquals('@param int|null $a', $this->tagsToString($phpdoc, 'param'));
+        $this->assertEquals('@param int|null $a [optional]', $this->tagsToString($phpdoc, 'param'));
         $this->assertEquals('@return int', $this->tagsToString($phpdoc, 'return'));
         $this->assertTrue($phpdoc->hasTag('see'));
     }
@@ -87,7 +87,7 @@ class MacroTest extends TestCase
 
         $this->assertNotNull($phpdoc);
         $this->assertStringContainsString('Test docblock', $phpdoc->getText());
-        $this->assertEquals('@param int|null $a', $this->tagsToString($phpdoc, 'param'));
+        $this->assertEquals('@param int|null $a [optional]', $this->tagsToString($phpdoc, 'param'));
         $this->assertEquals('@return int', $this->tagsToString($phpdoc, 'return'));
         $this->assertTrue($phpdoc->hasTag('see'));
     }
@@ -111,7 +111,7 @@ class MacroTest extends TestCase
 
         $this->assertNotNull($phpdoc);
         $this->assertStringContainsString('Test docblock', $phpdoc->getText());
-        $this->assertEquals('@param int|null $a', $this->tagsToString($phpdoc, 'param'));
+        $this->assertEquals('@param int|null $a [optional]', $this->tagsToString($phpdoc, 'param'));
         $this->assertFalse($phpdoc->hasTag('return'));
         $this->assertTrue($phpdoc->hasTag('see'));
     }
@@ -160,7 +160,7 @@ class MacroTest extends TestCase
 
         $this->assertNotNull($phpdoc);
         $this->assertStringContainsString('Test docblock', $phpdoc->getText());
-        $this->assertEquals('@param \stdClass|null $a aaaaa', $this->tagsToString($phpdoc, 'param'));
+        $this->assertEquals('@param \stdClass|null $a aaaaa [optional]', $this->tagsToString($phpdoc, 'param'));
         $this->assertEquals('@return int', $this->tagsToString($phpdoc, 'return'));
     }
 
@@ -184,7 +184,7 @@ class MacroTest extends TestCase
 
         $this->assertNotNull($phpdoc);
         $this->assertStringContainsString('Test docblock', $phpdoc->getText());
-        $this->assertEquals('@param mixed $a', $this->tagsToString($phpdoc, 'param'));
+        $this->assertEquals('@param mixed $a [optional]', $this->tagsToString($phpdoc, 'param'));
         $this->assertEquals('@return \stdClass|null rrrrrrr', $this->tagsToString($phpdoc, 'return'));
     }
 
@@ -203,7 +203,7 @@ class MacroTest extends TestCase
 
         $this->assertNotNull($phpdoc);
         $this->assertStringContainsString('Test docblock', $phpdoc->getText());
-        $this->assertEquals('@param \Stringable|string|null $a', $this->tagsToString($phpdoc, 'param'));
+        $this->assertEquals('@param \Stringable|string|null $a [optional]', $this->tagsToString($phpdoc, 'param'));
         $this->assertEquals('@return \Stringable|string|null', $this->tagsToString($phpdoc, 'return'));
     }
 
@@ -300,7 +300,7 @@ class MacroTest extends TestCase
         $output = <<<'DOC'
 /**
  * @param string $foo
- * @param int $bar
+ * @param int $bar [optional]
  * @return string
  * @see \Barryvdh\LaravelIdeHelper\Tests\UrlGeneratorMacroClass::__invoke()
  * @static

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -37,8 +37,8 @@ class MethodTest extends TestCase
         $output = <<<'DOC'
 /**
  * @param string $last
- * @param string $first
- * @param string $middle
+ * @param string $first [optional]
+ * @param string $middle [optional]
  * @static
  */
 DOC;
@@ -68,7 +68,7 @@ DOC;
  *
  * @param array $values
  * @param array|string $uniqueBy
- * @param array|null $update
+ * @param array|null $update [optional]
  * @return int
  * @static
  */
@@ -99,9 +99,9 @@ DOC;
  * Add a basic where clause to the query.
  *
  * @param (\Closure(static): mixed)|string|array|\Illuminate\Contracts\Database\Query\Expression $column
- * @param mixed $operator
- * @param mixed $value
- * @param string $boolean
+ * @param mixed $operator [optional]
+ * @param mixed $value [optional]
+ * @param string $boolean [optional]
  * @return \Illuminate\Database\Eloquent\Builder<static>
  * @static
  */
@@ -130,8 +130,8 @@ DOC;
  * Add a "where null" clause to the query.
  *
  * @param string|array|\Illuminate\Contracts\Database\Query\Expression $columns
- * @param string $boolean
- * @param bool $not
+ * @param string $boolean [optional]
+ * @param bool $not [optional]
  * @return \Illuminate\Database\Eloquent\Builder<static>
  * @static
  */
@@ -202,8 +202,8 @@ DOC;
  * Execute the query and get the first result or call a callback.
  *
  * @template TValue
- * @param (\Closure(): TValue)|list<string> $columns
- * @param (\Closure(): TValue)|null $callback
+ * @param (\Closure(): TValue)|list<string> $columns [optional]
+ * @param (\Closure(): TValue)|null $callback [optional]
  * @return TModel|TValue
  * @static
  */


### PR DESCRIPTION
When PHPDoc `@param` tags are generated for methods with optional parameters (those with default values), the `[optional]` annotation was missing. This caused static analyzers like Intelephense to report all parameters as required, flagging valid calls as having "not enough arguments".

**Before:**
```
 * @param string $boolean
 * @param bool $not
```

**After:**
```
 * @param string $boolean [optional]
 * @param bool $not [optional]
```

Fixes #1784