### PR TITLE
fix: preserve non-empty array default values in generated params

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1259,7 +1259,17 @@ class ModelsCommand extends Command
                 if (is_bool($default)) {
                     $default = $default ? 'true' : 'false';
                 } elseif (is_array($default)) {
-                    $default = '[]';
+                    if (empty($default)) {
+                        $default = '[]';
+                    } else {
+                        $items = [];
+                        foreach ($default as $k => $v) {
+                            $items[] = is_string($k)
+                                ? var_export($k, true) . ' => ' . var_export($v, true)
+                                : var_export($v, true);
+                        }
+                        $default = '[' . implode(', ', $items) . ']';
+                    }
                 } elseif (is_null($default)) {
                     $default = 'null';
                 } elseif (is_int($default) || is_float($default)) {

--- a/src/Method.php
+++ b/src/Method.php
@@ -355,7 +355,17 @@ class Method
                 if (is_bool($default)) {
                     $default = $default ? 'true' : 'false';
                 } elseif (is_array($default)) {
-                    $default = '[]';
+                    if (empty($default)) {
+                        $default = '[]';
+                    } else {
+                        $items = [];
+                        foreach ($default as $k => $v) {
+                            $items[] = is_string($k)
+                                ? var_export($k, true) . ' => ' . var_export($v, true)
+                                : var_export($v, true);
+                        }
+                        $default = '[' . implode(', ', $items) . ']';
+                    }
                 } elseif (is_null($default)) {
                     $default = 'null';
                 } elseif (is_int($default)) {


### PR DESCRIPTION
## Root Cause

When `_ide_helper.php` generates method stubs (via `Method::getParameters()`), and `_ide_helper_models.php` generates `@method` annotations (via `ModelsCommand::getParameters()`), any non-empty array default value was converted to `[]`.

This affected methods like `Builder::find($id, $columns = ['*'])` where the generated output showed `$columns = []` instead of `$columns = ['*']`. While the parameter remained optional with an empty array default, the incorrect default value could confuse downstream consumers.

## Reproduction

1. Run `php artisan ide-helper:generate` or `php artisan ide-helper:models`
2. Check any method whose signature has a non-empty array default param (e.g. `find()`, `all()`, `get()`)
3. Observe the generated default value shows `[]` instead of the actual array content

## Fix

Both `src/Method.php` and `src/Console/ModelsCommand.php` now check whether the array default is empty. Non-empty arrays are formatted with proper short array syntax, preserving key/value pairs:

```php
// Before: all arrays -> []
$default = '[]';

// After: non-empty arrays preserved
// ['*'] -> "['*']"
// ['key' => 'val'] -> "['key' => 'val']"
```

Empty arrays (`[]`) continue to render as `[]`.

## Testing

- Existing tests should continue to pass (empty arrays unaffected)
- Methods with non-empty array defaults (e.g. `find($id, $columns = ['*'])`) will now show the correct default
- Scope methods and relation methods with array defaults will be correct in generated models `@method` annotations
