### PR TITLE
Prefer the original Castable class over a generic Cast's widened get() type

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -1646,9 +1646,40 @@ class ModelsCommand extends Command
 
         $methodReflection = $castReflection->getMethod('get');
 
-        return $this->getReturnTypeFromReflection($methodReflection) ??
+        $resolvedType = $this->getReturnTypeFromReflection($methodReflection) ??
             $this->getReturnTypeFromDocBlock($methodReflection, $reflection) ??
             $type;
+
+        return $this->preferMoreSpecificCastableType($type, $resolvedType);
+    }
+
+    /**
+     * A resolved Cast's `get()` method may only be able to declare the upper
+     * bound of a generic template (e.g. spatie/laravel-data's
+     * `DataEloquentCast<TData>` must declare `get(): BaseData|
+     * TransformableData|null`, because PHP has no runtime generics to
+     * express the concrete `TData` for a given `Castable`). When the
+     * original Castable class is already at least as specific as one of the
+     * resolved type's members, it is the more accurate answer — use it
+     * instead. Nullability is intentionally left for the caller to
+     * re-derive, since it is normalised from the model's own nullability
+     * (e.g. the backing column) further down the pipeline regardless of
+     * what the resolved type says.
+     */
+    protected function preferMoreSpecificCastableType(string $type, string $resolvedType): string
+    {
+        $classMembers = array_filter(
+            explode('|', $resolvedType),
+            static fn (string $member) => strtolower(ltrim($member, '?\\')) !== 'null'
+        );
+
+        foreach ($classMembers as $member) {
+            if (is_a($type, ltrim($member, '\\'), true)) {
+                return $type;
+            }
+        }
+
+        return $resolvedType;
     }
 
     /**

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/GenericCast.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/GenericCast.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+/**
+ * @template TData of GenericCastableData
+ *
+ * @implements CastsAttributes<TData|null, TData|null>
+ */
+class GenericCast implements CastsAttributes
+{
+    public function __construct(
+        protected string $dataClass,
+        protected array $arguments
+    ) {
+    }
+
+    public function get($model, string $key, $value, array $attributes): GenericCastableData|null
+    {
+        return $value === null ? null : new ($this->dataClass)();
+    }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        return $value;
+    }
+}

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/GenericCastableData.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/GenericCastableData.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+
+/**
+ * Mirrors packages such as spatie/laravel-data, where a Castable base class's
+ * castUsing() resolves to a Cast that is generic over the calling subclass.
+ * PHP has no runtime generics, so the Cast's get() method can only declare
+ * the template's upper bound, not the concrete subclass actually being cast.
+ */
+abstract class GenericCastableData implements Castable
+{
+    public static function castUsing(array $arguments)
+    {
+        return new GenericCast(static::class, $arguments);
+    }
+}

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/SpecificCastableData.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Casts/SpecificCastableData.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts;
+
+class SpecificCastableData extends GenericCastableData
+{
+}

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/Models/CustomCast.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/Models/CustomCast.php
@@ -21,6 +21,7 @@ use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Cas
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\InboundAttributeCaster;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\SelfCastingCasterWithStaticDocblockReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\SelfCastingCasterWithThisDocblockReturn;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\SpecificCastableData;
 use Illuminate\Database\Eloquent\Model;
 
 class CustomCast extends Model
@@ -46,5 +47,6 @@ class CustomCast extends Model
         'casted_property_with_static_return_docblock_and_param' => SelfCastingCasterWithStaticDocblockReturn::class . ':param',
         'cast_without_property' => CustomCasterWithReturnType::class,
         'cast_inbound_attribute' => InboundAttributeCaster::class,
+        'casted_property_with_generic_castable' => SpecificCastableData::class,
     ];
 }

--- a/tests/Console/ModelsCommand/LaravelCustomCasts/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/LaravelCustomCasts/__snapshots__/Test__test__1.php
@@ -21,6 +21,7 @@ use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Cas
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\InboundAttributeCaster;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\SelfCastingCasterWithStaticDocblockReturn;
 use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\SelfCastingCasterWithThisDocblockReturn;
+use Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\SpecificCastableData;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -38,6 +39,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property ExtendedSelfCastingCasterWithStaticDocblockReturn $extended_casted_property_with_static_return_docblock
  * @property ExtendedSelfCastingCasterWithThisDocblockReturn $extended_casted_property_with_this_return_docblock
  * @property SelfCastingCasterWithStaticDocblockReturn $casted_property_with_static_return_docblock_and_param
+ * @property SpecificCastableData|null $casted_property_with_generic_castable
  * @property CustomCasterWithStaticReturnType $casted_property_with_static_return_type
  * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $casted_property_with_castable
  * @property \Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\LaravelCustomCasts\Casts\CastedProperty $casted_property_with_anonymous_cast
@@ -47,6 +49,7 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCast newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCast newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCast query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCast whereCastedPropertyWithGenericCastable($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCast whereCastedPropertyWithParam($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCast whereCastedPropertyWithReturnDocblock($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|CustomCast whereCastedPropertyWithReturnDocblockFqn($value)
@@ -86,5 +89,6 @@ class CustomCast extends Model
         'casted_property_with_static_return_docblock_and_param' => SelfCastingCasterWithStaticDocblockReturn::class . ':param',
         'cast_without_property' => CustomCasterWithReturnType::class,
         'cast_inbound_attribute' => InboundAttributeCaster::class,
+        'casted_property_with_generic_castable' => SpecificCastableData::class,
     ];
 }

--- a/tests/Console/ModelsCommand/migrations/____custom_casts_table.php
+++ b/tests/Console/ModelsCommand/migrations/____custom_casts_table.php
@@ -25,6 +25,7 @@ class CustomCastsTable extends Migration
             $table->string('extended_casted_property_with_static_return_docblock');
             $table->string('extended_casted_property_with_this_return_docblock');
             $table->string('casted_property_with_static_return_docblock_and_param');
+            $table->string('casted_property_with_generic_castable')->nullable();
         });
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1437 and #1700.

When `castUsing()` resolves to a `Cast` that is generic over the calling subclass — e.g. spatie/laravel-data's `DataEloquentCast<TData>` — the `Cast`'s `get()` method can only declare the template's *upper bound* in real PHP, since there are no runtime generics to express the concrete `TData` for a given `Castable`:

```php
/**
 * @template TData of (BaseData&TransformableData)
 * @implements CastsAttributes<TData|null,TData|array|null>
 */
class DataEloquentCast implements CastsAttributes
{
    public function get($model, string $key, $value, array $attributes): BaseData|TransformableData|null { ... }
}
```

`checkForCastableCasts()` reflects that declared return type verbatim, so the generated docblock ends up typed `BaseData|TransformableData|null` instead of the actual Data subclass being cast — even though the Castable class passed to `casts()` (and already known to `checkForCastableCasts()` as `$type`) is exactly that concrete subclass.

## Fix

Since `$type` — the original `Castable` class — is already known at this point, prefer it whenever it is at least as specific as (a subtype of) one of the resolved type's members. No generic-parameter resolution is required: if a value of `$type` would always satisfy the resolved type anyway, `$type` is strictly more informative and can never be wrong. Nullability is left untouched by this change — it continues to be normalised from the model's own nullability (e.g. the backing column) further down the existing pipeline, as before.

## Why not #1701

#1701 took a different approach: parsing an `@return CastsAttributes<TGet, TSet>` annotation off `castUsing()`'s *own* docblock. That works when the `Castable` class itself declares the generic binding on `castUsing()`, but doesn't cover spatie/laravel-data's shape, where `castUsing()` has no return annotation at all and the `@template` lives on the resolved `DataEloquentCast` class instead — the author flagged this gap themselves in the PR discussion, and it's also why #1437 (specifically about spatie/laravel-data) was never actually fixed by it. This PR sidesteps generic-annotation parsing entirely by comparing the already-known `Castable` class against the resolved type structurally, so it isn't tied to where the generic annotation happens to live.

## Test plan

- [x] Added `GenericCastableData` / `GenericCast` / `SpecificCastableData` fixtures under `tests/Console/ModelsCommand/LaravelCustomCasts/Casts/` reproducing the generic-template shape (a `Castable` base class whose `castUsing()` returns a `Cast` generic over the calling subclass, with a native `get()` return type pinned to the template's bound) — this is deliberately spatie/laravel-data-shaped without depending on that package.
- [x] `casted_property_with_generic_castable` added to the `CustomCast` fixture model (backed by a nullable column, to exercise nullability end-to-end) and to the snapshot.
- [x] Full existing suite passes unchanged (`vendor/bin/phpunit`, 84 tests) — no regressions to the other `Castable`/`CastsAttributes` fixtures.
- [x] `composer analyze` (phpstan) and `composer check-style` (php-cs-fixer) both clean.