### PR TITLE
fix: resolve scope builder class against the model being documented

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -712,7 +712,7 @@ class ModelsCommand extends Command
                         //Remove the first ($query) argument
                         array_shift($args);
                         $builder = $this->getClassNameInDestinationFile(
-                            $reflection->getDeclaringClass(),
+                            new ReflectionClass($model),
                             get_class($model->newModelQuery())
                         );
                         $modelName = $this->getClassNameInDestinationFile(

--- a/tests/Console/ModelsCommand/QueryScopes/Models/Article.php
+++ b/tests/Console/ModelsCommand/QueryScopes/Models/Article.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\QueryScopes\Models;
+
+class Article extends ArticleParent
+{
+}

--- a/tests/Console/ModelsCommand/QueryScopes/Models/ArticleParent.php
+++ b/tests/Console/ModelsCommand/QueryScopes/Models/ArticleParent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\QueryScopes\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class ArticleParent extends Model
+{
+    public function scopeDraft(Builder $query): Builder
+    {
+        return $query;
+    }
+}

--- a/tests/Console/ModelsCommand/QueryScopes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/QueryScopes/__snapshots__/Test__test__1.php
@@ -4,6 +4,45 @@ declare(strict_types=1);
 
 namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\QueryScopes\Models;
 
+/**
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Article draft()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Article newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Article newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Article query()
+ * @mixin \Eloquent
+ */
+class Article extends ArticleParent
+{
+}
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\QueryScopes\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @method static Builder<static>|ArticleParent draft()
+ * @method static Builder<static>|ArticleParent newModelQuery()
+ * @method static Builder<static>|ArticleParent newQuery()
+ * @method static Builder<static>|ArticleParent query()
+ * @mixin \Eloquent
+ */
+class ArticleParent extends Model
+{
+    public function scopeDraft(Builder $query): Builder
+    {
+        return $query;
+    }
+}
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\QueryScopes\Models;
+
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;


### PR DESCRIPTION
## Summary

Scopes inherited from a parent model were annotated with whatever name the parent file uses for the builder. If the parent imports `Illuminate\Database\Eloquent\Builder` but the child does not, the child model gets `@method static Builder<static>|Child scope()` and the IDE reports an unknown class.

The builder class is now resolved against the model the docblock is written to, the same way the model name already is since #1366.

Fixes #1795

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Update the README.md
- [x] Code style has been fixed via `composer fix-style`